### PR TITLE
Query and store supported Vulkan Device Extensions in NvapiAdapter

### DIFF
--- a/src/sysinfo/nvapi_adapter.cpp
+++ b/src/sysinfo/nvapi_adapter.cpp
@@ -118,18 +118,18 @@ namespace dxvk {
         return std::string(m_deviceProperties.deviceName);
     }
 
-    u_int NvapiAdapter::GetDriverVersion() const {
+    uint32_t NvapiAdapter::GetDriverVersion() const {
         // Windows releases can only ever have a two digit minor version
         // and does not have a patch number
         return VK_VERSION_MAJOR(m_vkDriverVersion) * 100 +
-            std::min(VK_VERSION_MINOR(m_vkDriverVersion), (u_int) 99);
+            std::min(VK_VERSION_MINOR(m_vkDriverVersion), (uint32_t) 99);
     }
 
-    u_int NvapiAdapter::GetDeviceId() const {
+    uint32_t NvapiAdapter::GetDeviceId() const {
         return (m_deviceProperties.deviceID << 16) + m_deviceProperties.vendorID;
     }
 
-    u_int NvapiAdapter::GetGpuType() const {
+    uint32_t NvapiAdapter::GetGpuType() const {
         // The enum values for discrete, integrated and unknown GPU are the same for Vulkan and NvAPI
         auto vkDeviceType = m_deviceProperties.deviceType;
         return vkDeviceType == VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU || vkDeviceType == VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU
@@ -137,11 +137,11 @@ namespace dxvk {
             : VK_PHYSICAL_DEVICE_TYPE_OTHER;
     }
 
-    u_int NvapiAdapter::GetBusId() const {
+    uint32_t NvapiAdapter::GetBusId() const {
         return m_devicePciBusProperties.pciBus;
     }
 
-    u_int NvapiAdapter::GetVRamSize() const {
+    uint32_t NvapiAdapter::GetVRamSize() const {
         // Not sure if it is completely correct to just look at the first DEVICE_LOCAL heap,
         // but it seems to give the correct result.
         for (auto i = 0U; i < m_memoryProperties.memoryHeapCount; i++) {

--- a/src/sysinfo/nvapi_adapter.h
+++ b/src/sysinfo/nvapi_adapter.h
@@ -15,11 +15,11 @@ namespace dxvk {
 
         bool Initialize(Com<IDXGIAdapter>& dxgiAdapter, std::vector<NvapiOutput*>& outputs);
         [[nodiscard]] std::string GetDeviceName() const;
-        [[nodiscard]] u_int GetDriverVersion() const;
-        [[nodiscard]] u_int GetDeviceId() const;
-        [[nodiscard]] u_int GetGpuType() const;
-        [[nodiscard]] u_int GetBusId() const;
-        [[nodiscard]] u_int GetVRamSize() const;
+        [[nodiscard]] uint32_t GetDriverVersion() const;
+        [[nodiscard]] uint32_t GetDeviceId() const;
+        [[nodiscard]] uint32_t GetGpuType() const;
+        [[nodiscard]] uint32_t GetBusId() const;
+        [[nodiscard]] uint32_t GetVRamSize() const;
 
     private:
         bool isVkDeviceExtensionSupported(std::string extName);
@@ -27,7 +27,7 @@ namespace dxvk {
         VkPhysicalDeviceProperties m_deviceProperties{};
         VkPhysicalDevicePCIBusInfoPropertiesEXT m_devicePciBusProperties{};
         VkPhysicalDeviceMemoryProperties m_memoryProperties{};
-        u_int m_vkDriverVersion{};
+        uint32_t m_vkDriverVersion{};
         std::set<std::string> m_deviceExtensions{};
     };
 }

--- a/src/sysinfo/nvapi_adapter.h
+++ b/src/sysinfo/nvapi_adapter.h
@@ -4,6 +4,8 @@
 #include "../util/com_pointer.h"
 #include "nvapi_output.h"
 
+#include <set>
+
 namespace dxvk {
     class NvapiAdapter {
 
@@ -20,9 +22,12 @@ namespace dxvk {
         [[nodiscard]] u_int GetVRamSize() const;
 
     private:
+        bool isVkDeviceExtensionSupported(std::string extName);
+
         VkPhysicalDeviceProperties m_deviceProperties{};
         VkPhysicalDevicePCIBusInfoPropertiesEXT m_devicePciBusProperties{};
         VkPhysicalDeviceMemoryProperties m_memoryProperties{};
         u_int m_vkDriverVersion{};
+        std::set<std::string> m_deviceExtensions{};
     };
 }

--- a/src/util/util_op_code.h
+++ b/src/util/util_op_code.h
@@ -1,8 +1,8 @@
 #pragma once
 
 namespace dxvk {
-    inline std::string fromCode(const u_int code) {
-        static const std::map<u_int, std::string> codes {
+    inline std::string fromCode(const uint32_t code) {
+        static const std::map<uint32_t, std::string> codes {
             {  1, "NV_EXTN_OP_SHFL" },
             {  2, "NV_EXTN_OP_SHFL_UP" },
             {  3, "NV_EXTN_OP_SHFL_DOWN" },


### PR DESCRIPTION
One thought that came up is whether it's better to allocate `m_deviceExtensions` like we currently are, or if it would make more sense to use `std::vector` here so that `~NvapiAdapter()` can remain trivial. What's your preference on this @jp7677 ?