### PR TITLE
Count initializations, guard `Initialize` and `Unload` with a mutex

### DIFF
--- a/src/nvapi_private.h
+++ b/src/nvapi_private.h
@@ -10,6 +10,7 @@
 #include <sstream>
 #include <fstream>
 #include <ctime>
+#include <mutex>
 
 #include <dxgi.h>
 #include <d3d11_1.h>


### PR DESCRIPTION
Fairly straightforward (but not very performant) solution to initialization refcounting issue.

Fixes #16.