### PR TITLE
NvAPI_GPU_GetAllClockFrequencies

### DIFF
--- a/src/nvapi_gpu.cpp
+++ b/src/nvapi_gpu.cpp
@@ -348,4 +348,95 @@ extern "C" {
                 return Error(str::format(n, ": ", adapter->NvmlErrorString(result)));
         }
     }
+
+    NvAPI_Status __cdecl NvAPI_GPU_GetAllClockFrequencies(NvPhysicalGpuHandle hPhysicalGpu, NV_GPU_CLOCK_FREQUENCIES *pClkFreqs) {
+        constexpr auto n = "NvAPI_GPU_GetAllClockFrequencies";
+        static bool alreadyLoggedNoNvml = false;
+        static bool alreadyLoggedHandleInvalidated = false;
+        static bool alreadyLoggedOk = false;
+
+        if (nvapiAdapterRegistry == nullptr)
+            return ApiNotInitialized(n);
+
+        if (pClkFreqs == nullptr)
+            return InvalidArgument(n);
+
+        if (pClkFreqs->version != NV_GPU_CLOCK_FREQUENCIES_VER_1 && pClkFreqs->version != NV_GPU_CLOCK_FREQUENCIES_VER_2 && pClkFreqs->version != NV_GPU_CLOCK_FREQUENCIES_VER_3)
+            return IncompatibleStructVersion(n);
+
+        // Only check for CURRENT_FREQ, and not for the other types ie. BOOST or DEFAULT for now
+        if (pClkFreqs->ClockType != NV_GPU_CLOCK_FREQUENCIES_CURRENT_FREQ)
+            return NotSupported(n);
+
+        auto adapter = reinterpret_cast<NvapiAdapter*>(hPhysicalGpu);
+        if (!nvapiAdapterRegistry->IsAdapter(adapter))
+            return ExpectedPhysicalGpuHandle(n);
+
+        if (!adapter->HasNvml())
+            return NoImplementation(str::format(n, ": NVML not loaded"), alreadyLoggedNoNvml);
+
+        if (!adapter->HasNvmlDevice())
+            return HandleInvalidated(str::format(n, ": NVML available but current adapter is not NVML compatible"), alreadyLoggedHandleInvalidated);
+
+        // Reset all clock data for all domains
+        for (auto i = 0U; i < NVAPI_MAX_GPU_PUBLIC_CLOCKS; i++){
+            pClkFreqs->domain[i].bIsPresent = false;
+            pClkFreqs->domain[i].frequency = 0;
+        }
+
+        unsigned int clock;
+        // Seemingly we need to do nvml call on a "per clock unit" to get the clock
+        // Set the availability of the clock to TRUE and the nvml read clock in the nvapi struct
+        auto resultgpu = adapter->NvmlDeviceGetClockInfo(NVML_CLOCK_GRAPHICS, &clock);
+            switch (resultgpu) {
+                case NVML_SUCCESS:
+                    pClkFreqs->domain[NVAPI_GPU_PUBLIC_CLOCK_GRAPHICS].bIsPresent = true;
+                    pClkFreqs->domain[NVAPI_GPU_PUBLIC_CLOCK_GRAPHICS].frequency = (clock * 1000);
+                    break;
+
+                case NVML_ERROR_NOT_SUPPORTED:
+                    break;
+
+                case NVML_ERROR_GPU_IS_LOST:
+                    return HandleInvalidated(n);
+
+                default:
+                    return Error(str::format(n, ": ", adapter->NvmlErrorString(resultgpu)));
+            }
+
+        auto resultmem = adapter->NvmlDeviceGetClockInfo(NVML_CLOCK_MEM, &clock);
+            switch (resultmem) {
+                case NVML_SUCCESS:
+                    pClkFreqs->domain[NVAPI_GPU_PUBLIC_CLOCK_MEMORY].bIsPresent = true;
+                    pClkFreqs->domain[NVAPI_GPU_PUBLIC_CLOCK_MEMORY].frequency = (clock * 1000);
+                    break;
+
+                case NVML_ERROR_NOT_SUPPORTED:
+                    break;
+
+                case NVML_ERROR_GPU_IS_LOST:
+                    return HandleInvalidated(n);
+
+                default:
+                    return Error(str::format(n, ": ", adapter->NvmlErrorString(resultmem)));
+            }
+
+        auto resultvid = adapter->NvmlDeviceGetClockInfo(NVML_CLOCK_VIDEO, &clock);
+            switch (resultvid) {
+                case NVML_SUCCESS:
+                    pClkFreqs->domain[NVAPI_GPU_PUBLIC_CLOCK_VIDEO].bIsPresent = true;
+                    pClkFreqs->domain[NVAPI_GPU_PUBLIC_CLOCK_VIDEO].frequency = (clock * 1000);
+                    break;
+
+                case NVML_ERROR_NOT_SUPPORTED:
+                    break;
+
+                case NVML_ERROR_GPU_IS_LOST:
+                    return HandleInvalidated(n);
+
+                default:
+                    return Error(str::format(n, ": ", adapter->NvmlErrorString(resultvid)));
+            }
+       return Ok(n, alreadyLoggedOk);
+    }
 }

--- a/src/nvapi_interface.cpp
+++ b/src/nvapi_interface.cpp
@@ -56,6 +56,7 @@ extern "C" {
         INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_GPU_GetDynamicPstatesInfoEx)
         INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_GPU_GetThermalSettings)
         INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_GPU_GetVbiosVersionString)
+        INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_GPU_GetAllClockFrequencies)
         INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_Disp_GetHdrCapabilities)
         INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_DISP_GetDisplayIdByDisplayName)
         INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_DISP_GetGDIPrimaryDisplayId)

--- a/src/sysinfo/nvapi_adapter.cpp
+++ b/src/sysinfo/nvapi_adapter.cpp
@@ -213,4 +213,8 @@ namespace dxvk {
     nvmlReturn_t NvapiAdapter::NvmlDeviceGetVbiosVersion(char* version, unsigned int length) const {
         return m_nvml.DeviceGetVbiosVersion(m_nvmlDevice, version, length);
     }
+
+    nvmlReturn_t NvapiAdapter::NvmlDeviceGetClockInfo(nvmlClockType_t type, unsigned int* clock) const {
+        return m_nvml.DeviceGetClockInfo(m_nvmlDevice, type, clock);
+    }
 }

--- a/src/sysinfo/nvapi_adapter.h
+++ b/src/sysinfo/nvapi_adapter.h
@@ -30,6 +30,7 @@ namespace dxvk {
         [[nodiscard]] nvmlReturn_t NvmlDeviceGetTemperature(nvmlTemperatureSensors_t sensorType, unsigned int* temp) const;
         [[nodiscard]] nvmlReturn_t NvmlDeviceGetUtilizationRates(nvmlUtilization_t* utilization) const;
         [[nodiscard]] nvmlReturn_t NvmlDeviceGetVbiosVersion(char* version, unsigned int length) const;
+        [[nodiscard]] nvmlReturn_t NvmlDeviceGetClockInfo(nvmlClockType_t type, unsigned int* clock) const;
 
     private:
         Vulkan& m_vulkan;

--- a/src/sysinfo/nvml.cpp
+++ b/src/sysinfo/nvml.cpp
@@ -21,6 +21,7 @@ namespace dxvk {
         m_nvmlDeviceGetTemperature = GetProcAddress<PFN_nvmlDeviceGetTemperature>("nvmlDeviceGetTemperature");
         m_nvmlDeviceGetUtilizationRates = GetProcAddress<PFN_nvmlDeviceGetUtilizationRates>("nvmlDeviceGetUtilizationRates");
         m_nvmlDeviceGetVbiosVersion = GetProcAddress<PFN_nvmlDeviceGetVbiosVersion>("nvmlDeviceGetVbiosVersion");
+        m_nvmlDeviceGetClockInfo = GetProcAddress<PFN_nvmlDeviceGetClockInfo>("nvmlDeviceGetClockInfo");
 
         if (m_nvmlInit_v2 == nullptr
             || m_nvmlShutdown == nullptr
@@ -28,7 +29,8 @@ namespace dxvk {
             || m_nvmlDeviceGetHandleByPciBusId_v2 == nullptr
             || m_nvmlDeviceGetTemperature == nullptr
             || m_nvmlDeviceGetUtilizationRates == nullptr
-            || m_nvmlDeviceGetVbiosVersion == nullptr)
+            || m_nvmlDeviceGetVbiosVersion == nullptr
+            || m_nvmlDeviceGetClockInfo == nullptr)
             log::write(str::format("NVML loaded but initialization failed"));
         else {
             auto result = m_nvmlInit_v2();
@@ -73,6 +75,10 @@ namespace dxvk {
 
     nvmlReturn_t Nvml::DeviceGetVbiosVersion(nvmlDevice_t device, char *version, unsigned int length) const {
         return m_nvmlDeviceGetVbiosVersion(device, version, length);
+    }
+
+    nvmlReturn_t Nvml::DeviceGetClockInfo(nvmlDevice_t device, nvmlClockType_t type, unsigned int *clock) const {
+        return m_nvmlDeviceGetClockInfo(device, type, clock);
     }
 
     template<typename T>

--- a/src/sysinfo/nvml.h
+++ b/src/sysinfo/nvml.h
@@ -15,6 +15,7 @@ namespace dxvk {
         [[nodiscard]] nvmlReturn_t DeviceGetTemperature(nvmlDevice_t device, nvmlTemperatureSensors_t sensorType, unsigned int *temp) const;
         [[nodiscard]] nvmlReturn_t DeviceGetUtilizationRates(nvmlDevice_t device, nvmlUtilization_t *utilization) const;
         [[nodiscard]] nvmlReturn_t DeviceGetVbiosVersion(nvmlDevice_t device, char *version, unsigned int length) const;
+        [[nodiscard]] nvmlReturn_t DeviceGetClockInfo(nvmlDevice_t device, nvmlClockType_t type, unsigned int *clock) const;
 
     private:
         typedef decltype(&nvmlInit_v2) PFN_nvmlInit_v2;
@@ -24,6 +25,7 @@ namespace dxvk {
         typedef decltype(&nvmlDeviceGetTemperature) PFN_nvmlDeviceGetTemperature;
         typedef decltype(&nvmlDeviceGetUtilizationRates) PFN_nvmlDeviceGetUtilizationRates;
         typedef decltype(&nvmlDeviceGetVbiosVersion) PFN_nvmlDeviceGetVbiosVersion;
+        typedef decltype(&nvmlDeviceGetClockInfo) PFN_nvmlDeviceGetClockInfo;
 
         HMODULE m_nvmlModule{};
         PFN_nvmlInit_v2 m_nvmlInit_v2{};
@@ -33,6 +35,7 @@ namespace dxvk {
         PFN_nvmlDeviceGetTemperature m_nvmlDeviceGetTemperature{};
         PFN_nvmlDeviceGetUtilizationRates m_nvmlDeviceGetUtilizationRates{};
         PFN_nvmlDeviceGetVbiosVersion m_nvmlDeviceGetVbiosVersion{};
+        PFN_nvmlDeviceGetClockInfo m_nvmlDeviceGetClockInfo{};
 
         template<typename T> T GetProcAddress(const char* name);
     };


### PR DESCRIPTION
Needs a bit of work i think. I am not really happy with the way nvml gets called 3 times for the 3 clocks. 
Since i dont really know much programming, i have not been able to slim this down, but i am sure it can be done.

I do not think we can get away without making nvml grab values 3 times, as the function for nvml is not the same as for nvapi, where nvapi just fills out whatever struct with all available clocks and returns this in `pClkFreqs`. nvml takes the calls in a 1-by-1 manner and only returns `unsigned int clock` (value without a struct?)
Since the structs for `nvmlClockType_t` is not the same as the enum for `NV_GPU_PUBLIC_CLOCK_ID` i cant seem to figure out how to make `nvmlClockType_t NVML_CLOCK_GRAPHICS` point to  `NV_GPU_PUBLIC_CLOCK_ID NVAPI_GPU_PUBLIC_CLOCK_GRAPHICS` in any meaningful way when trying to use that in a for loop or something.

Another culprit would also be if (maybe not very likely) the graphics clock is not available for the adapter, but the memory and/or video is.. this would not be read cos it would be escaped `return NotSupported(n);` from the first `NVML_ERROR_NOT_SUPPORTED` case in `resultgpu`, and thus no more clocks would be read.

Ideas? Sorry for my horrible explanation tho.. hehe.