### PR TITLE
nvapi: Implement NvAPI_GetInterfaceVersionStringEx

### DIFF
--- a/src/nvapi.cpp
+++ b/src/nvapi.cpp
@@ -136,7 +136,19 @@ extern "C" {
         if (szDesc == nullptr)
             return InvalidArgument(n);
 
-        strcpy(szDesc, "R470");
+        strcpy(szDesc, "DXVK-NVAPI");
+
+        return Ok(n);
+    }
+
+    NvAPI_Status __cdecl NvAPI_GetInterfaceVersionStringEx(NvAPI_ShortString szDesc) {
+        constexpr auto n = __func__;
+
+        if (szDesc == nullptr)
+            return InvalidArgument(n);
+
+        const std::string headerVersion = "R470";
+        strcpy(szDesc, str::format("DXVK-NVAPI", " ", DXVK_NVAPI_VERSION, " (", headerVersion , ")").c_str());
 
         return Ok(n);
     }

--- a/src/nvapi_interface.cpp
+++ b/src/nvapi_interface.cpp
@@ -98,6 +98,7 @@ extern "C" {
         INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_EnumNvidiaDisplayHandle)
         INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_EnumNvidiaUnAttachedDisplayHandle)
         INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_GetInterfaceVersionString)
+        INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_GetInterfaceVersionStringEx)
         INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_GetErrorMessage)
         INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_Unload)
         INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_Initialize)

--- a/tests/nvapi_sysinfo.cpp
+++ b/tests/nvapi_sysinfo.cpp
@@ -18,7 +18,13 @@ using namespace trompeloeil;
 TEST_CASE("GetInterfaceVersionString returns OK", "[.sysinfo]") {
     NvAPI_ShortString desc;
     REQUIRE(NvAPI_GetInterfaceVersionString(desc) == NVAPI_OK);
-    REQUIRE(strcmp(desc, "R470") == 0);
+    REQUIRE(strcmp(desc, "DXVK-NVAPI") == 0);
+}
+
+TEST_CASE("GetInterfaceVersionStringEx returns OK", "[.sysinfo]") {
+    NvAPI_ShortString desc;
+    REQUIRE(NvAPI_GetInterfaceVersionStringEx(desc) == NVAPI_OK);
+    REQUIRE(std::string(desc).rfind("DXVK-NVAPI", 0) == 0);
 }
 
 TEST_CASE("GetErrorMessage returns OK", "[.sysinfo]") {

--- a/tests/nvapi_system.cpp
+++ b/tests/nvapi_system.cpp
@@ -9,6 +9,7 @@ typedef void* (*PFN_NvAPI_QueryInterface)(unsigned int id);
 typedef decltype(&NvAPI_Initialize) PFN_NvAPI_Initialize;
 typedef decltype(&NvAPI_Unload) PFN_NvAPI_Unload;
 typedef decltype(&NvAPI_GetInterfaceVersionString) PFN_NvAPI_GetInterfaceVersionString;
+typedef decltype(&NvAPI_GetInterfaceVersionStringEx) PFN_NvAPI_GetInterfaceVersionStringEx;
 typedef decltype(&NvAPI_SYS_GetDriverAndBranchVersion) PFN_NvAPI_SYS_GetDriverAndBranchVersion;
 typedef decltype(&NvAPI_EnumPhysicalGPUs) PFN_NvAPI_EnumPhysicalGPUs;
 typedef decltype(&NvAPI_GPU_GetGPUType) PFN_NvAPI_GPU_GetGPUType;
@@ -84,6 +85,7 @@ TEST_CASE("Sysinfo methods succeed against local system", "[system]") {
     auto nvAPI_Initialize = GetNvAPIProcAddress<PFN_NvAPI_Initialize>(nvAPI_QueryInterface, "NvAPI_Initialize");
     auto nvAPI_Unload = GetNvAPIProcAddress<PFN_NvAPI_Unload>(nvAPI_QueryInterface, "NvAPI_Unload");
     auto nvAPI_GetInterfaceVersionString = GetNvAPIProcAddress<PFN_NvAPI_GetInterfaceVersionString>(nvAPI_QueryInterface, "NvAPI_GetInterfaceVersionString");
+    auto nvAPI_GetInterfaceVersionStringEx = GetNvAPIProcAddress<PFN_NvAPI_GetInterfaceVersionStringEx>(nvAPI_QueryInterface, "NvAPI_GetInterfaceVersionStringEx");
     auto nvAPI_SYS_GetDriverAndBranchVersion = GetNvAPIProcAddress<PFN_NvAPI_SYS_GetDriverAndBranchVersion>(nvAPI_QueryInterface, "NvAPI_SYS_GetDriverAndBranchVersion");
     auto nvAPI_EnumPhysicalGPUs = GetNvAPIProcAddress<PFN_NvAPI_EnumPhysicalGPUs>(nvAPI_QueryInterface, "NvAPI_EnumPhysicalGPUs");
     auto nvAPI_GPU_GetGPUType = GetNvAPIProcAddress<PFN_NvAPI_GPU_GetGPUType>(nvAPI_QueryInterface, "NvAPI_GPU_GetGPUType");
@@ -102,10 +104,12 @@ TEST_CASE("Sysinfo methods succeed against local system", "[system]") {
     NvAPI_Status result;
     REQUIRE(nvAPI_Initialize() == NVAPI_OK);
 
+    std::cout << "--------------------------------" << std::endl;
     NvAPI_ShortString desc;
     REQUIRE(nvAPI_GetInterfaceVersionString(desc) == NVAPI_OK);
-    std::cout << "--------------------------------" << std::endl;
-    std::cout << "Interface version:              " << desc << std::endl;
+    NvAPI_ShortString descEx;
+    REQUIRE(nvAPI_GetInterfaceVersionStringEx(descEx) == NVAPI_OK);
+    std::cout << "Interface version:              " << desc << " / " << descEx << std::endl;
 
     NvU32 version;
     NvAPI_ShortString branch;


### PR DESCRIPTION
Might become useful to identify `DXVK-NVAPI`.

- Needs header update, the `id` for `NvAPI_GetInterfaceVersionStringEx` is missing in `nvapi_interface.h`.