### PR TITLE
Implement NvAPI_GPU_GetPstates20 and NvAPI_GPU_GetCurrentPstate

### DIFF
--- a/src/nvapi_interface.cpp
+++ b/src/nvapi_interface.cpp
@@ -56,6 +56,7 @@ extern "C" {
         INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_GPU_GetDynamicPstatesInfoEx)
         INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_GPU_GetThermalSettings)
         INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_GPU_GetVbiosVersionString)
+        INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_GPU_GetCurrentPstate)
         INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_GPU_GetAllClockFrequencies)
         INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_Disp_GetHdrCapabilities)
         INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_DISP_GetDisplayIdByDisplayName)

--- a/src/sysinfo/nvapi_adapter.cpp
+++ b/src/sysinfo/nvapi_adapter.cpp
@@ -234,6 +234,10 @@ namespace dxvk {
         return m_nvml.DeviceGetVbiosVersion(m_nvmlDevice, version, length);
     }
 
+    nvmlReturn_t NvapiAdapter::GetNvmlPerformanceState(nvmlPstates_t *pState) const {
+        return m_nvml.DeviceGetPerformanceState(m_nvmlDevice, pState);
+    }
+
     nvmlReturn_t NvapiAdapter::GetNvmlDeviceClockInfo(nvmlClockType_t type, unsigned int* clock) const {
         return m_nvml.DeviceGetClockInfo(m_nvmlDevice, type, clock);
     }

--- a/src/sysinfo/nvapi_adapter.h
+++ b/src/sysinfo/nvapi_adapter.h
@@ -30,6 +30,7 @@ namespace dxvk {
         [[nodiscard]] nvmlReturn_t GetNvmlDeviceTemperature(nvmlTemperatureSensors_t sensorType, unsigned int* temp) const;
         [[nodiscard]] nvmlReturn_t GetNvmlDeviceUtilizationRates(nvmlUtilization_t* utilization) const;
         [[nodiscard]] nvmlReturn_t GetNvmlDeviceVbiosVersion(char* version, unsigned int length) const;
+        [[nodiscard]] nvmlReturn_t GetNvmlPerformanceState(nvmlPstates_t* pState) const;
         [[nodiscard]] nvmlReturn_t GetNvmlDeviceClockInfo(nvmlClockType_t type, unsigned int* clock) const;
 
     private:

--- a/src/sysinfo/nvml.cpp
+++ b/src/sysinfo/nvml.cpp
@@ -21,6 +21,7 @@ namespace dxvk {
         m_nvmlDeviceGetTemperature = GetProcAddress<PFN_nvmlDeviceGetTemperature>("nvmlDeviceGetTemperature");
         m_nvmlDeviceGetUtilizationRates = GetProcAddress<PFN_nvmlDeviceGetUtilizationRates>("nvmlDeviceGetUtilizationRates");
         m_nvmlDeviceGetVbiosVersion = GetProcAddress<PFN_nvmlDeviceGetVbiosVersion>("nvmlDeviceGetVbiosVersion");
+        m_nvmlDeviceGetPerformanceState = GetProcAddress<PFN_nvmlDeviceGetPerformanceState>("nvmlDeviceGetPerformanceState");
         m_nvmlDeviceGetClockInfo = GetProcAddress<PFN_nvmlDeviceGetClockInfo>("nvmlDeviceGetClockInfo");
 
         if (m_nvmlInit_v2 == nullptr
@@ -30,6 +31,7 @@ namespace dxvk {
             || m_nvmlDeviceGetTemperature == nullptr
             || m_nvmlDeviceGetUtilizationRates == nullptr
             || m_nvmlDeviceGetVbiosVersion == nullptr
+            || m_nvmlDeviceGetPerformanceState == nullptr
             || m_nvmlDeviceGetClockInfo == nullptr)
             log::write(str::format("NVML loaded but initialization failed"));
         else {
@@ -75,6 +77,10 @@ namespace dxvk {
 
     nvmlReturn_t Nvml::DeviceGetVbiosVersion(nvmlDevice_t device, char *version, unsigned int length) const {
         return m_nvmlDeviceGetVbiosVersion(device, version, length);
+    }
+
+    nvmlReturn_t Nvml::DeviceGetPerformanceState(nvmlDevice_t device, nvmlPstates_t *pState) const {
+        return m_nvmlDeviceGetPerformanceState(device, pState);
     }
 
     nvmlReturn_t Nvml::DeviceGetClockInfo(nvmlDevice_t device, nvmlClockType_t type, unsigned int *clock) const {

--- a/src/sysinfo/nvml.h
+++ b/src/sysinfo/nvml.h
@@ -15,6 +15,7 @@ namespace dxvk {
         [[nodiscard]] virtual nvmlReturn_t DeviceGetTemperature(nvmlDevice_t device, nvmlTemperatureSensors_t sensorType, unsigned int *temp) const;
         [[nodiscard]] virtual nvmlReturn_t DeviceGetUtilizationRates(nvmlDevice_t device, nvmlUtilization_t *utilization) const;
         [[nodiscard]] virtual nvmlReturn_t DeviceGetVbiosVersion(nvmlDevice_t device, char *version, unsigned int length) const;
+        [[nodiscard]] virtual nvmlReturn_t DeviceGetPerformanceState(nvmlDevice_t device, nvmlPstates_t *pState) const;
         [[nodiscard]] virtual nvmlReturn_t DeviceGetClockInfo(nvmlDevice_t device, nvmlClockType_t type, unsigned int *clock) const;
 
     private:
@@ -25,6 +26,7 @@ namespace dxvk {
         typedef decltype(&nvmlDeviceGetTemperature) PFN_nvmlDeviceGetTemperature;
         typedef decltype(&nvmlDeviceGetUtilizationRates) PFN_nvmlDeviceGetUtilizationRates;
         typedef decltype(&nvmlDeviceGetVbiosVersion) PFN_nvmlDeviceGetVbiosVersion;
+        typedef decltype(&nvmlDeviceGetPerformanceState) PFN_nvmlDeviceGetPerformanceState;
         typedef decltype(&nvmlDeviceGetClockInfo) PFN_nvmlDeviceGetClockInfo;
 
         HMODULE m_nvmlModule{};
@@ -35,6 +37,7 @@ namespace dxvk {
         PFN_nvmlDeviceGetTemperature m_nvmlDeviceGetTemperature{};
         PFN_nvmlDeviceGetUtilizationRates m_nvmlDeviceGetUtilizationRates{};
         PFN_nvmlDeviceGetVbiosVersion m_nvmlDeviceGetVbiosVersion{};
+        PFN_nvmlDeviceGetPerformanceState m_nvmlDeviceGetPerformanceState{};
         PFN_nvmlDeviceGetClockInfo m_nvmlDeviceGetClockInfo{};
 
         template<typename T> T GetProcAddress(const char* name);

--- a/tests/nvapi_sysinfo_mocks.cpp
+++ b/tests/nvapi_sysinfo_mocks.cpp
@@ -69,5 +69,6 @@ class NvmlMock : public mock_interface<Nvml> {
     IMPLEMENT_CONST_MOCK3(DeviceGetTemperature);
     IMPLEMENT_CONST_MOCK2(DeviceGetUtilizationRates);
     IMPLEMENT_CONST_MOCK3(DeviceGetVbiosVersion);
+    IMPLEMENT_CONST_MOCK2(DeviceGetPerformanceState);
     IMPLEMENT_CONST_MOCK3(DeviceGetClockInfo);
 };

--- a/tests/nvapi_system.cpp
+++ b/tests/nvapi_system.cpp
@@ -21,6 +21,7 @@ typedef decltype(&NvAPI_GPU_GetArchInfo) PFN_NvAPI_GPU_GetArchInfo;
 typedef decltype(&NvAPI_GPU_GetVbiosVersionString) PFN_NvAPI_GPU_GetVbiosVersionString;
 typedef decltype(&NvAPI_GPU_GetDynamicPstatesInfoEx) PFN_NvAPI_GPU_GetDynamicPstatesInfoEx;
 typedef decltype(&NvAPI_GPU_GetThermalSettings) PFN_NvAPI_GPU_GetThermalSettings;
+typedef decltype(&NvAPI_GPU_GetCurrentPstate) PFN_NvAPI_GPU_GetCurrentPstate;
 typedef decltype(&NvAPI_GPU_GetAllClockFrequencies) PFN_NvAPI_GPU_GetAllClockFrequencies;
 
 template<typename T>
@@ -95,6 +96,7 @@ TEST_CASE("Sysinfo methods succeed against local system", "[system]") {
     auto nvAPI_GPU_GetVbiosVersionString = GetNvAPIProcAddress<PFN_NvAPI_GPU_GetVbiosVersionString>(nvAPI_QueryInterface, "NvAPI_GPU_GetVbiosVersionString");
     auto nvAPI_GPU_GetDynamicPstatesInfoEx = GetNvAPIProcAddress<PFN_NvAPI_GPU_GetDynamicPstatesInfoEx>(nvAPI_QueryInterface, "NvAPI_GPU_GetDynamicPstatesInfoEx");
     auto nvAPI_GPU_GetThermalSettings = GetNvAPIProcAddress<PFN_NvAPI_GPU_GetThermalSettings>(nvAPI_QueryInterface, "NvAPI_GPU_GetThermalSettings");
+    auto nvAPI_GPU_GetCurrentPstate = GetNvAPIProcAddress<PFN_NvAPI_GPU_GetCurrentPstate>(nvAPI_QueryInterface, "NvAPI_GPU_GetCurrentPstate");
     auto nvAPI_GPU_GetAllClockFrequencies = GetNvAPIProcAddress<PFN_NvAPI_GPU_GetAllClockFrequencies>(nvAPI_QueryInterface, "NvAPI_GPU_GetAllClockFrequencies");
 
     NvAPI_Status result;
@@ -185,6 +187,13 @@ TEST_CASE("Sysinfo methods succeed against local system", "[system]") {
         std::cout << "    Current GPU temperature:    ";
         result == NVAPI_OK
             ? std::cout << std::dec << settings.sensor[0].currentTemp << "C" << std::endl
+            : std::cout << "N/A" << std::endl;
+
+        NV_GPU_PERF_PSTATE_ID currentPstate;
+        result = nvAPI_GPU_GetCurrentPstate(handle, &currentPstate);
+        std::cout << "    Current performance state:  ";
+        result == NVAPI_OK
+            ? std::cout << "P" << std::dec << currentPstate << std::endl
             : std::cout << "N/A" << std::endl;
 
         NV_GPU_CLOCK_FREQUENCIES frequencies;


### PR DESCRIPTION
These two NvAPI functions provides the needed info for Unigine Heaven and Unigine Vulkan to display gpu/mem frequency aswell as temperatures.

There does not seem as any way to get voltages from nvml atm.