### PR TITLE
Reverse logging logic

### DIFF
--- a/src/util/util_log.cpp
+++ b/src/util/util_log.cpp
@@ -9,8 +9,8 @@ namespace dxvk::log {
         alreadyInitialized = true;
 
         auto logLevel = env::getEnvVariable(logLevelEnvName);
-        if (logLevel == "none") {
-            skipAllLogging = true;
+        if (logLevel == "full") {
+            skipAllLogging = false;
             return;
         }
 
@@ -29,7 +29,7 @@ namespace dxvk::log {
 
     void write(const std::string& message) {
         static bool alreadyInitialized = false;
-        static bool skipAllLogging = false;
+        static bool skipAllLogging = true;
         static std::ofstream filestream;
         if (!alreadyInitialized)
             initialize(filestream, skipAllLogging, alreadyInitialized);


### PR DESCRIPTION
With this change, logging will only occur if `DXVK_NVAPI_LOG_LEVEL` is set to `full`.
The benefit of this is that if some function is used *a lot*, it won't cause performance issues by default.