### PR TITLE
nvapi: Use __func__ macro for function names.

### DIFF
--- a/src/nvapi.cpp
+++ b/src/nvapi.cpp
@@ -15,7 +15,7 @@ extern "C" {
     using namespace dxvk;
 
     NvAPI_Status __cdecl NvAPI_EnumLogicalGPUs(NvLogicalGpuHandle nvGPUHandle[NVAPI_MAX_LOGICAL_GPUS], NvU32 *pGpuCount) {
-        constexpr auto n = "NvAPI_EnumLogicalGPUs";
+        constexpr auto n = __func__;
 
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);
@@ -32,7 +32,7 @@ extern "C" {
     }
 
     NvAPI_Status __cdecl NvAPI_EnumPhysicalGPUs(NvPhysicalGpuHandle nvGPUHandle[NVAPI_MAX_PHYSICAL_GPUS], NvU32 *pGpuCount) {
-        constexpr auto n = "NvAPI_EnumPhysicalGPUs";
+        constexpr auto n = __func__;
 
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);
@@ -49,7 +49,7 @@ extern "C" {
     }
 
     NvAPI_Status __cdecl NvAPI_GetDisplayDriverVersion(NvDisplayHandle hNvDisplay, NV_DISPLAY_DRIVER_VERSION *pVersion) {
-        constexpr auto n = "NvAPI_GetDisplayDriverVersion";
+        constexpr auto n = __func__;
 
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);
@@ -70,7 +70,7 @@ extern "C" {
     }
 
     NvAPI_Status __cdecl NvAPI_GetPhysicalGPUsFromDisplay(NvDisplayHandle hNvDisp, NvPhysicalGpuHandle nvGPUHandle[NVAPI_MAX_PHYSICAL_GPUS], NvU32 *pGpuCount) {
-        constexpr auto n = "NvAPI_GetPhysicalGPUsFromDisplay";
+        constexpr auto n = __func__;
 
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);
@@ -89,7 +89,7 @@ extern "C" {
     }
 
     NvAPI_Status __cdecl NvAPI_EnumNvidiaDisplayHandle(NvU32 thisEnum, NvDisplayHandle *pNvDispHandle) {
-        constexpr auto n = "NvAPI_EnumNvidiaDisplayHandle";
+        constexpr auto n = __func__;
 
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);
@@ -112,7 +112,7 @@ extern "C" {
     }
 
     NvAPI_Status __cdecl NvAPI_GetInterfaceVersionString(NvAPI_ShortString szDesc) {
-        constexpr auto n = "NvAPI_GetInterfaceVersionString";
+        constexpr auto n = __func__;
 
         if (szDesc == nullptr)
             return InvalidArgument(n);
@@ -123,7 +123,7 @@ extern "C" {
     }
 
     NvAPI_Status __cdecl NvAPI_GetErrorMessage(NvAPI_Status nr, NvAPI_ShortString szDesc) {
-        constexpr auto n = "NvAPI_GetErrorMessage";
+        constexpr auto n = __func__;
 
         if (szDesc == nullptr)
             return InvalidArgument(n);
@@ -138,7 +138,7 @@ extern "C" {
     static auto initializationCount = 0ULL;
 
     NvAPI_Status __cdecl NvAPI_Unload() {
-        constexpr auto n = "NvAPI_Unload";
+        constexpr auto n = __func__;
 
         std::scoped_lock lock(initializationMutex);
 
@@ -152,7 +152,7 @@ extern "C" {
     }
 
     NvAPI_Status __cdecl NvAPI_Initialize() {
-        constexpr auto n = "NvAPI_Initialize";
+        constexpr auto n = __func__;
 
         std::scoped_lock lock(initializationMutex);
 

--- a/src/nvapi_d3d.cpp
+++ b/src/nvapi_d3d.cpp
@@ -9,27 +9,27 @@ extern "C" {
         // Fake-implement with a dumb passthrough, though no other NvAPI entry points
         // we're likely to implement should care about the actual handle value.
         *pHandle = (NVDX_ObjectHandle)pResource;
-        return Ok("NvAPI_D3D_GetObjectHandleForResource", alreadyLogged);
+        return Ok(__func__, alreadyLogged);
     }
 
     NvAPI_Status __cdecl NvAPI_D3D_SetResourceHint(IUnknown *pDev, NVDX_ObjectHandle obj, NVAPI_D3D_SETRESOURCEHINT_CATEGORY dwHintCategory, NvU32 dwHintName, NvU32 *pdwHintValue) {
         static bool alreadyLogged = false;
-        return NoImplementation("NvAPI_D3D_SetResourceHint", alreadyLogged);
+        return NoImplementation(__func__, alreadyLogged);
     }
 
     NvAPI_Status __cdecl NvAPI_D3D_BeginResourceRendering(IUnknown *pDeviceOrContext, NVDX_ObjectHandle obj, NvU32 Flags) {
         static bool alreadyLogged = false;
         // Synchronisation hints for SLI...
-        return Ok("NvAPI_D3D_BeginResourceRendering", alreadyLogged);
+        return Ok(__func__, alreadyLogged);
     }
 
     NvAPI_Status __cdecl NvAPI_D3D_EndResourceRendering(IUnknown *pDeviceOrContext, NVDX_ObjectHandle obj, NvU32 Flags) {
         static bool alreadyLogged = false;
-        return Ok("NvAPI_D3D_EndResourceRendering", alreadyLogged);
+        return Ok(__func__, alreadyLogged);
     }
 
     NvAPI_Status __cdecl NvAPI_D3D_GetCurrentSLIState(IUnknown *pDevice, NV_GET_CURRENT_SLI_STATE *pSliState) {
-        constexpr auto n = "NvAPI_D3D_GetCurrentSLIState";
+        constexpr auto n = __func__;
         static bool alreadyLoggedOk = false;
 
         if (pDevice == nullptr || pSliState == nullptr)
@@ -55,7 +55,7 @@ extern "C" {
     NvAPI_Status __cdecl NvAPI_D3D1x_GetGraphicsCapabilities(IUnknown *pDevice,
                                                     NvU32 structVersion,
                                                     NV_D3D1x_GRAPHICS_CAPS *pGraphicsCaps) {
-        constexpr auto n = "NvAPI_D3D1x_GetGraphicsCapabilities";
+        constexpr auto n = __func__;
         static bool alreadyLoggedOk = false;
 
         switch(structVersion) {

--- a/src/nvapi_d3d11.cpp
+++ b/src/nvapi_d3d11.cpp
@@ -8,7 +8,7 @@ extern "C" {
     using namespace dxvk;
 
     NvAPI_Status __cdecl NvAPI_D3D11_IsNvShaderExtnOpCodeSupported(IUnknown *pDeviceOrContext, NvU32 code, bool *supported) {
-        constexpr auto n = "NvAPI_D3D11_IsNvShaderExtnOpCodeSupported";
+        constexpr auto n = __func__;
 
         if (pDeviceOrContext == nullptr || supported == nullptr)
                 return InvalidArgument(n);
@@ -20,7 +20,7 @@ extern "C" {
     }
 
     NvAPI_Status __cdecl NvAPI_D3D11_SetDepthBoundsTest(IUnknown *pDeviceOrContext, NvU32 bEnable, float fMinDepth, float fMaxDepth) {
-        constexpr auto n = "NvAPI_D3D11_SetDepthBoundsTest";
+        constexpr auto n = __func__;
         static bool alreadyLoggedError = false;
         static bool alreadyLoggedOk = false;
 
@@ -34,7 +34,7 @@ extern "C" {
     }
 
     NvAPI_Status __cdecl NvAPI_D3D11_BeginUAVOverlap(IUnknown *pDeviceOrContext) {
-        constexpr auto n = "NvAPI_D3D11_BeginUAVOverlap";
+        constexpr auto n = __func__;
         static bool alreadyLoggedError = false;
         static bool alreadyLoggedOk = false;
 
@@ -48,7 +48,7 @@ extern "C" {
     }
 
     NvAPI_Status __cdecl NvAPI_D3D11_EndUAVOverlap(IUnknown *pDeviceOrContext) {
-        constexpr auto n = "NvAPI_D3D11_EndUAVOverlap";
+        constexpr auto n = __func__;
         static bool alreadyLoggedError = false;
         static bool alreadyLoggedOk = false;
 
@@ -62,7 +62,7 @@ extern "C" {
     }
 
     NvAPI_Status __cdecl NvAPI_D3D11_MultiDrawInstancedIndirect(ID3D11DeviceContext *pDevContext11, NvU32 drawCount, ID3D11Buffer *pBuffer, NvU32 alignedByteOffsetForArgs, NvU32 alignedByteStrideForArgs) {
-        constexpr auto n = "NvAPI_D3D11_MultiDrawInstancedIndirect";
+        constexpr auto n = __func__;
         static bool alreadyLoggedError = false;
         static bool alreadyLoggedOk = false;
 
@@ -76,7 +76,7 @@ extern "C" {
     }
 
     NvAPI_Status __cdecl NvAPI_D3D11_MultiDrawIndexedInstancedIndirect(ID3D11DeviceContext *pDevContext11, NvU32 drawCount, ID3D11Buffer *pBuffer, NvU32 alignedByteOffsetForArgs, NvU32 alignedByteStrideForArgs) {
-        constexpr auto n = "NvAPI_D3D11_MultiDrawIndexedInstancedIndirect";
+        constexpr auto n = __func__;
         static bool alreadyLoggedError = false;
         static bool alreadyLoggedOk = false;
 
@@ -90,7 +90,7 @@ extern "C" {
     }
 
     NvAPI_Status __cdecl NvAPI_D3D11_CreateCubinComputeShader(ID3D11Device* pDevice, const void* pCubin, NvU32 size, NvU32 blockX, NvU32 blockY, NvU32 blockZ, NVDX_ObjectHandle* phShader) {
-        constexpr auto n = "NvAPI_D3D11_CreateCubinComputeShader";
+        constexpr auto n = __func__;
         static bool alreadyLoggedError = false;
         static bool alreadyLoggedOk = false;
 
@@ -104,7 +104,7 @@ extern "C" {
     }
 
     NvAPI_Status __cdecl NvAPI_D3D11_CreateCubinComputeShaderWithName(ID3D11Device* pDevice, const void* pCubin, NvU32 size, NvU32 blockX, NvU32 blockY, NvU32 blockZ, const char* pShaderName, NVDX_ObjectHandle* phShader) {
-        constexpr auto n = "NvAPI_D3D11_CreateCubinComputeShaderWithName";
+        constexpr auto n = __func__;
         static bool alreadyLoggedError = false;
         static bool alreadyLoggedOk = false;
 
@@ -119,7 +119,7 @@ extern "C" {
     }
 
     NvAPI_Status __cdecl NvAPI_D3D11_LaunchCubinShader(ID3D11DeviceContext* pDeviceContext, NVDX_ObjectHandle hShader, NvU32 gridX, NvU32 gridY, NvU32 gridZ, const void* pParams, NvU32 paramSize, const NVDX_ObjectHandle* pReadResources, NvU32 numReadResources, const NVDX_ObjectHandle* pWriteResources, NvU32 numWriteResources) {
-        constexpr auto n = "NvAPI_D3D11_LaunchCubinShader";
+        constexpr auto n = __func__;
         static bool alreadyLoggedError = false;
         static bool alreadyLoggedOk = false;
 
@@ -133,7 +133,7 @@ extern "C" {
     }
 
     NvAPI_Status __cdecl NvAPI_D3D11_DestroyCubinComputeShader(ID3D11Device* pDevice, NVDX_ObjectHandle hShader) {
-        constexpr auto n = "NvAPI_D3D11_DestroyCubinComputeShader";
+        constexpr auto n = __func__;
         static bool alreadyLoggedError = false;
         static bool alreadyLoggedOk = false;
 
@@ -147,7 +147,7 @@ extern "C" {
     }
 
     NvAPI_Status __cdecl NvAPI_D3D11_IsFatbinPTXSupported(ID3D11Device* pDevice, bool* pSupported) {
-        constexpr auto n = "NvAPI_D3D11_IsFatbinPTXSupported";
+        constexpr auto n = __func__;
         static bool alreadyLoggedOk = false;
 
         if (pDevice == nullptr || pSupported == nullptr)
@@ -159,7 +159,7 @@ extern "C" {
     }
 
     NvAPI_Status __cdecl NvAPI_D3D11_CreateUnorderedAccessView(ID3D11Device* pDevice, ID3D11Resource* pResource, const D3D11_UNORDERED_ACCESS_VIEW_DESC* pDesc, ID3D11UnorderedAccessView** ppUAV, NvU32* pDriverHandle) {
-        constexpr auto n = "NvAPI_D3D11_CreateUnorderedAccessView";
+        constexpr auto n = __func__;
         static bool alreadyLoggedError = false;
         static bool alreadyLoggedOk = false;
 
@@ -173,7 +173,7 @@ extern "C" {
     }
 
     NvAPI_Status __cdecl NvAPI_D3D11_CreateShaderResourceView(ID3D11Device* pDevice, ID3D11Resource* pResource, const D3D11_SHADER_RESOURCE_VIEW_DESC* pDesc, ID3D11ShaderResourceView** ppSRV, NvU32* pDriverHandle) {
-        constexpr auto n = "NvAPI_D3D11_CreateShaderResourceView";
+        constexpr auto n = __func__;
         static bool alreadyLoggedError = false;
         static bool alreadyLoggedOk = false;
 
@@ -187,7 +187,7 @@ extern "C" {
     }
 
     NvAPI_Status __cdecl NvAPI_D3D11_GetResourceHandle(ID3D11Device* pDevice, ID3D11Resource* pResource, NVDX_ObjectHandle* phObject) {
-        constexpr auto n = "NvAPI_D3D11_GetResourceHandle";
+        constexpr auto n = __func__;
         static bool alreadyLoggedOk = false;
         static bool alreadyLoggedError = false;
 
@@ -201,7 +201,7 @@ extern "C" {
     }
 
     NvAPI_Status __cdecl NvAPI_D3D11_GetResourceGPUVirtualAddress(ID3D11Device* pDevice, const NVDX_ObjectHandle hResource, NvU64* pGpuVA) {
-        constexpr auto n = "NvAPI_D3D11_GetResourceGPUVirtualAddress";
+        constexpr auto n = __func__;
         static bool alreadyLoggedOk = false;
         static bool alreadyLoggedError = false;
 
@@ -216,7 +216,7 @@ extern "C" {
     }
 
     NvAPI_Status __cdecl NvAPI_D3D11_GetResourceGPUVirtualAddressEx(ID3D11Device* pDevice, NV_GET_GPU_VIRTUAL_ADDRESS* pParams) {
-        constexpr auto n = "NvAPI_D3D11_GetResourceGPUVirtualAddressEx";
+        constexpr auto n = __func__;
         static bool alreadyLoggedOk = false;
         static bool alreadyLoggedError = false;
 
@@ -236,7 +236,7 @@ extern "C" {
     }
 
     NvAPI_Status __cdecl NvAPI_D3D11_CreateSamplerState(ID3D11Device* pDevice, const D3D11_SAMPLER_DESC* pSamplerDesc, ID3D11SamplerState** ppSamplerState, NvU32* pDriverHandle) {
-        constexpr auto n = "NvAPI_D3D11_CreateSamplerState";
+        constexpr auto n = __func__;
         static bool alreadyLoggedError = false;
         static bool alreadyLoggedOk = false;
 
@@ -250,7 +250,7 @@ extern "C" {
     }
 
     NvAPI_Status __cdecl NvAPI_D3D11_GetCudaTextureObject(ID3D11Device* pDevice, NvU32 srvDriverHandle, NvU32 samplerDriverHandle, NvU32* pCudaTextureHandle) {
-        constexpr auto n = "NvAPI_D3D11_GetCudaTextureObject";
+        constexpr auto n = __func__;
         static bool alreadyLoggedError = false;
         static bool alreadyLoggedOk = false;
 

--- a/src/nvapi_d3d12.cpp
+++ b/src/nvapi_d3d12.cpp
@@ -8,7 +8,7 @@ extern "C" {
     using namespace dxvk;
 
     NvAPI_Status __cdecl NvAPI_D3D12_IsNvShaderExtnOpCodeSupported(ID3D12Device *pDevice, NvU32 opCode, bool *pSupported) {
-        constexpr auto n = "NvAPI_D3D12_IsNvShaderExtnOpCodeSupported";
+        constexpr auto n = __func__;
 
         if (pDevice == nullptr || pSupported == nullptr)
                 return InvalidArgument(n);
@@ -20,7 +20,7 @@ extern "C" {
     }
 
     NvAPI_Status __cdecl NvAPI_D3D12_CreateCubinComputeShaderWithName(ID3D12Device* pDevice, const void* cubinData, NvU32 cubinSize, NvU32 blockX, NvU32 blockY, NvU32 blockZ, const char* shaderName, NVDX_ObjectHandle* pShader) {
-        constexpr auto n = "NvAPI_D3D12_CreateCubinComputeShaderWithName";
+        constexpr auto n = __func__;
         static bool alreadyLoggedError = false;
         static bool alreadyLoggedOk = false;
 
@@ -38,7 +38,7 @@ extern "C" {
     }
 
     NvAPI_Status __cdecl NvAPI_D3D12_DestroyCubinComputeShader(ID3D12Device* pDevice, NVDX_ObjectHandle pShader) {
-        constexpr auto n = "NvAPI_D3D12_DestroyCubinComputeShader:";
+        constexpr auto n = __func__;
         static bool alreadyLoggedError = false;
         static bool alreadyLoggedOk = false;
 
@@ -52,7 +52,7 @@ extern "C" {
     }
 
     NvAPI_Status __cdecl NvAPI_D3D12_GetCudaTextureObject(ID3D12Device* pDevice, D3D12_CPU_DESCRIPTOR_HANDLE srvHandle, D3D12_CPU_DESCRIPTOR_HANDLE samplerHandle, NvU32* cudaTextureHandle) {
-        constexpr auto n = "NvAPI_D3D12_GetCudaTextureObject";
+        constexpr auto n = __func__;
         static bool alreadyLoggedError = false;
         static bool alreadyLoggedOk = false;
 
@@ -66,7 +66,7 @@ extern "C" {
     }
 
     NvAPI_Status __cdecl NvAPI_D3D12_GetCudaSurfaceObject(ID3D12Device* pDevice, D3D12_CPU_DESCRIPTOR_HANDLE uavHandle, NvU32* cudaSurfaceHandle) {
-        constexpr auto n = "NvAPI_D3D12_GetCudaSurfaceObject";
+        constexpr auto n = __func__;
         static bool alreadyLoggedError = false;
         static bool alreadyLoggedOk = false;
 
@@ -80,7 +80,7 @@ extern "C" {
     }
 
     NvAPI_Status __cdecl NvAPI_D3D12_LaunchCubinShader(ID3D12GraphicsCommandList* pCmdList, NVDX_ObjectHandle pShader, NvU32 blockX, NvU32 blockY, NvU32 blockZ, const void* params, NvU32 paramSize) {
-        constexpr auto n = "NvAPI_D3D12_LaunchCubinShader";
+        constexpr auto n = __func__;
         static bool alreadyLoggedError = false;
         static bool alreadyLoggedOk = false;
 
@@ -94,7 +94,7 @@ extern "C" {
     }
 
     NvAPI_Status __cdecl NvAPI_D3D12_CaptureUAVInfo(ID3D12Device* pDevice, NVAPI_UAV_INFO* pUAVInfo) {
-        constexpr auto n = "NvAPI_D3D12_CaptureUAVInfo";
+        constexpr auto n = __func__;
         static bool alreadyLoggedError = false;
         static bool alreadyLoggedOk = false;
 
@@ -108,7 +108,7 @@ extern "C" {
     }
 
     NvAPI_Status __cdecl NvAPI_D3D12_GetGraphicsCapabilities(IUnknown* pDevice, NvU32 structVersion, NV_D3D12_GRAPHICS_CAPS* pGraphicsCaps) {
-        constexpr auto n = "NvAPI_D3D12_GetGraphicsCapabilities";
+        constexpr auto n = __func__;
         static bool alreadyLogged = false;
 
         if(pDevice == nullptr || structVersion != NV_D3D12_GRAPHICS_CAPS_VER1)
@@ -127,7 +127,7 @@ extern "C" {
     }
 
     NvAPI_Status __cdecl NvAPI_D3D12_IsFatbinPTXSupported(ID3D12Device* pDevice, bool* isSupported) {
-        constexpr auto n = "NvAPI_D3D12_IsFatbinPTXSupported";
+        constexpr auto n = __func__;
         static bool alreadyLoggedError = false;
         static bool alreadyLoggedOk = false;
 

--- a/src/nvapi_disp.cpp
+++ b/src/nvapi_disp.cpp
@@ -7,7 +7,7 @@ extern "C" {
     using namespace dxvk;
 
     NvAPI_Status __cdecl NvAPI_Disp_GetHdrCapabilities(NvU32 displayId, NV_HDR_CAPABILITIES *pHdrCapabilities) {
-        constexpr auto n = "NvAPI_Disp_GetHdrCapabilities";
+        constexpr auto n = __func__;
 
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);
@@ -34,7 +34,7 @@ extern "C" {
     }
 
     NvAPI_Status __cdecl NvAPI_DISP_GetDisplayIdByDisplayName(const char *displayName, NvU32 *displayId) {
-        constexpr auto n = "NvAPI_DISP_GetDisplayIdByDisplayName";
+        constexpr auto n = __func__;
 
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);
@@ -52,7 +52,7 @@ extern "C" {
     }
 
     NvAPI_Status __cdecl NvAPI_DISP_GetGDIPrimaryDisplayId(NvU32 *displayId) {
-        constexpr auto n = "NvAPI_DISP_GetGDIPrimaryDisplayId";
+        constexpr auto n = __func__;
 
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);

--- a/src/nvapi_gpu.cpp
+++ b/src/nvapi_gpu.cpp
@@ -7,7 +7,7 @@ extern "C" {
     using namespace dxvk;
 
     NvAPI_Status __cdecl NvAPI_GPU_GetGPUType(NvPhysicalGpuHandle hPhysicalGpu, NV_GPU_TYPE *pGpuType) {
-        constexpr auto n = "NvAPI_GPU_GetGPUType";
+        constexpr auto n = __func__;
 
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);
@@ -25,7 +25,7 @@ extern "C" {
     }
 
     NvAPI_Status __cdecl NvAPI_GPU_GetPCIIdentifiers(NvPhysicalGpuHandle hPhysicalGpu, NvU32 *pDeviceId, NvU32 *pSubSystemId, NvU32 *pRevisionId, NvU32 *pExtDeviceId) {
-        constexpr auto n = "NvAPI_GPU_GetPCIIdentifiers";
+        constexpr auto n = __func__;
 
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);
@@ -46,7 +46,7 @@ extern "C" {
     }
 
     NvAPI_Status __cdecl NvAPI_GPU_GetFullName(NvPhysicalGpuHandle hPhysicalGpu, NvAPI_ShortString szName) {
-        constexpr auto n = "NvAPI_GPU_GetFullName";
+        constexpr auto n = __func__;
 
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);
@@ -64,7 +64,7 @@ extern "C" {
     }
 
     NvAPI_Status __cdecl NvAPI_GPU_GetBusId(NvPhysicalGpuHandle hPhysicalGpu, NvU32 *pBusId) {
-        constexpr auto n = "NvAPI_GPU_GetBusId";
+        constexpr auto n = __func__;
 
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);
@@ -82,7 +82,7 @@ extern "C" {
     }
 
     NvAPI_Status __cdecl NvAPI_GPU_GetPhysicalFrameBufferSize(NvPhysicalGpuHandle hPhysicalGpu, NvU32 *pSize) {
-        constexpr auto n = "NvAPI_GPU_GetPhysicalFrameBufferSize";
+        constexpr auto n = __func__;
 
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);
@@ -100,7 +100,7 @@ extern "C" {
     }
 
     NvAPI_Status __cdecl NvAPI_GPU_GetAdapterIdFromPhysicalGpu(NvPhysicalGpuHandle hPhysicalGpu, void *pOSAdapterId) {
-        constexpr auto n = "NvAPI_GPU_GetAdapterIdFromPhysicalGpu";
+        constexpr auto n = __func__;
 
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);
@@ -119,7 +119,7 @@ extern "C" {
     }
 
     NvAPI_Status __cdecl NvAPI_GPU_GetArchInfo(NvPhysicalGpuHandle hPhysicalGpu, NV_GPU_ARCH_INFO *pGpuArchInfo) {
-        constexpr auto n = "NvAPI_GPU_GetArchInfo";
+        constexpr auto n = __func__;
 
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);
@@ -172,7 +172,7 @@ extern "C" {
     }
 
     NvAPI_Status __cdecl NvAPI_GPU_GetVbiosVersionString(NvPhysicalGpuHandle hPhysicalGpu, NvAPI_ShortString szBiosRevision) {
-        constexpr auto n = "NvAPI_GPU_GetVbiosVersionString";
+        constexpr auto n = __func__;
 
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);
@@ -206,7 +206,7 @@ extern "C" {
     }
 
     NvAPI_Status __cdecl NvAPI_GPU_GetDynamicPstatesInfoEx(NvPhysicalGpuHandle hPhysicalGpu, NV_GPU_DYNAMIC_PSTATES_INFO_EX *pDynamicPstatesInfoEx) {
-        constexpr auto n = "NvAPI_GPU_GetDynamicPstatesInfoEx";
+        constexpr auto n = __func__;
         static bool alreadyLoggedNoNvml = false;
         static bool alreadyLoggedHandleInvalidated = false;
         static bool alreadyLoggedOk = false;
@@ -261,7 +261,7 @@ extern "C" {
     }
 
     NvAPI_Status __cdecl NvAPI_GPU_GetThermalSettings(NvPhysicalGpuHandle hPhysicalGpu, NvU32 sensorIndex, NV_GPU_THERMAL_SETTINGS *pThermalSettings) {
-        constexpr auto n = "NvAPI_GPU_GetThermalSettings";
+        constexpr auto n = __func__;
         static bool alreadyLoggedNoNvml = false;
         static bool alreadyLoggedHandleInvalidated = false;
         static bool alreadyLoggedOk = false;
@@ -335,7 +335,7 @@ extern "C" {
     }
 
     NvAPI_Status __cdecl NvAPI_GPU_GetCurrentPstate(NvPhysicalGpuHandle hPhysicalGpu, NV_GPU_PERF_PSTATE_ID *pCurrentPstate) {
-        constexpr auto n = "NvAPI_GPU_GetCurrentPstate";
+        constexpr auto n = __func__;
         static bool alreadyLoggedNoNvml = false;
         static bool alreadyLoggedHandleInvalidated = false;
         static bool alreadyLoggedOk = false;
@@ -372,7 +372,7 @@ extern "C" {
     }
 
     NvAPI_Status __cdecl NvAPI_GPU_GetAllClockFrequencies(NvPhysicalGpuHandle hPhysicalGpu, NV_GPU_CLOCK_FREQUENCIES *pClkFreqs) {
-        constexpr auto n = "NvAPI_GPU_GetAllClockFrequencies";
+        constexpr auto n = __func__;
         static bool alreadyLoggedNotSupported = false;
         static bool alreadyLoggedNoNvml = false;
         static bool alreadyLoggedHandleInvalidated = false;

--- a/src/nvapi_sys.cpp
+++ b/src/nvapi_sys.cpp
@@ -7,7 +7,7 @@ extern "C" {
     using namespace dxvk;
 
     NvAPI_Status __cdecl NvAPI_SYS_GetPhysicalGpuFromDisplayId(NvU32 displayId, NvPhysicalGpuHandle *hPhysicalGpu) {
-        constexpr auto n = "NvAPI_SYS_GetPhysicalGpuFromDisplayId";
+        constexpr auto n = __func__;
 
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);
@@ -22,7 +22,7 @@ extern "C" {
     }
 
     NvAPI_Status __cdecl NvAPI_SYS_GetDriverAndBranchVersion(NvU32* pDriverVersion, NvAPI_ShortString szBuildBranchString) {
-        constexpr auto n = "NvAPI_SYS_GetDriverAndBranchVersion";
+        constexpr auto n = __func__;
 
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);


### PR DESCRIPTION
Improves logging a bit by removing hard-coded strings for function
names.

Uses __func__ due to its being portable and accessible in all the
compilers after 90s, while __FUNCTION__ isn't portable and is a gnu
extension, and we know we build the project with more or less modern
compilers. The __PRETTY_FUNCTION__ isn't used as we only need to have a
function name printed out.