### PR TITLE
build: Specify ar in the cross files

### DIFF
--- a/build-win32.txt
+++ b/build-win32.txt
@@ -1,6 +1,7 @@
 [binaries]
 cpp = 'i686-w64-mingw32-g++'
 strip = 'i686-w64-mingw32-strip'
+ar = 'i686-w64-mingw32-ar'
 
 [built-in options]
 cpp_args=['-msse', '-msse2']

--- a/build-win64.txt
+++ b/build-win64.txt
@@ -1,6 +1,7 @@
 [binaries]
 cpp = 'x86_64-w64-mingw32-g++'
 strip = 'x86_64-w64-mingw32-strip'
+ar = 'x86_64-w64-mingw32-ar'
 
 [built-in options]
 cpp_link_args = ['-static', '-static-libgcc', '-static-libstdc++']


### PR DESCRIPTION
Without doing this with Meson 0.49 we get:
  linker = self.cross_info.config['binaries']['ar']
  KeyError: 'ar'

This is fixed in newer Meson releases but Proton's build system is based
on Steam's Soldier runtime that will be stuck on 0.49 for a while.