### PR TITLE
nvapi-d3d12: Improve logging for NvAPI_D3D12_CreateCubinComputeShader

### DIFF
--- a/src/nvapi_d3d12.cpp
+++ b/src/nvapi_d3d12.cpp
@@ -35,7 +35,17 @@ extern "C" {
     }
 
     NvAPI_Status __cdecl NvAPI_D3D12_CreateCubinComputeShader(ID3D12Device* pDevice, const void* cubinData, NvU32 cubinSize, NvU32 blockX, NvU32 blockY, NvU32 blockZ, NVDX_ObjectHandle* pShader) {
-        return NvAPI_D3D12_CreateCubinComputeShaderWithName(pDevice, cubinData, cubinSize, blockX, blockY, blockZ, "", pShader);
+        constexpr auto n = __func__;
+        static bool alreadyLoggedError = false;
+        static bool alreadyLoggedOk = false;
+
+        if (pDevice == nullptr)
+            return InvalidArgument(n);
+
+        if (!NvapiD3d12Device::CreateCubinComputeShaderWithName(pDevice, cubinData, cubinSize, blockX, blockY, blockZ, "", pShader))
+            return Error(n, alreadyLoggedError);
+
+        return Ok(n, alreadyLoggedOk);
     }
 
     NvAPI_Status __cdecl NvAPI_D3D12_DestroyCubinComputeShader(ID3D12Device* pDevice, NVDX_ObjectHandle pShader) {


### PR DESCRIPTION
Change the logging behavior for NvAPI_D3D12_CreateCubinComputeShader to
distinguish from NvAPI_D3D12_CreateCubinComputeShaderWithName. This
matches the logging behavior for the functions of similar names for
NvAPI_D3D11.