### PR TITLE
nvapi-adapter: Update to DXGIAdapter1

### DIFF
--- a/src/sysinfo/nvapi_adapter.cpp
+++ b/src/sysinfo/nvapi_adapter.cpp
@@ -10,7 +10,7 @@ namespace dxvk {
 
     NvapiAdapter::~NvapiAdapter() = default;
 
-    bool NvapiAdapter::Initialize(Com<IDXGIAdapter>& dxgiAdapter, std::vector<NvapiOutput*>& outputs) {
+    bool NvapiAdapter::Initialize(Com<IDXGIAdapter1>& dxgiAdapter, std::vector<NvapiOutput*>& outputs) {
         constexpr auto driverVersionEnvName = "DXVK_NVAPI_DRIVER_VERSION";
 
         // Query all outputs from DXVK

--- a/src/sysinfo/nvapi_adapter.h
+++ b/src/sysinfo/nvapi_adapter.h
@@ -13,7 +13,7 @@ namespace dxvk {
         NvapiAdapter(Vulkan& vulkan, Nvml& nvml);
         ~NvapiAdapter();
 
-        bool Initialize(Com<IDXGIAdapter>& dxgiAdapter, std::vector<NvapiOutput*>& outputs);
+        bool Initialize(Com<IDXGIAdapter1>& dxgiAdapter, std::vector<NvapiOutput*>& outputs);
         [[nodiscard]] std::string GetDeviceName() const;
         [[nodiscard]] VkDriverIdKHR GetDriverId() const;
         [[nodiscard]] uint32_t GetDriverVersion() const;

--- a/src/sysinfo/nvapi_adapter_registry.cpp
+++ b/src/sysinfo/nvapi_adapter_registry.cpp
@@ -18,7 +18,7 @@ namespace dxvk {
     }
 
     bool NvapiAdapterRegistry::Initialize() {
-        auto dxgiFactory = m_resourceFactory.CreateDXGIFactory();
+        auto dxgiFactory = m_resourceFactory.CreateDXGIFactory1();
         if (dxgiFactory == nullptr)
             return false;
 
@@ -31,8 +31,8 @@ namespace dxvk {
             log::write("NVML loaded and initialized successfully");
 
         // Query all D3D11 adapter from DXVK to honor any DXVK device filtering
-        Com<IDXGIAdapter> dxgiAdapter;
-        for (auto i = 0U; dxgiFactory->EnumAdapters(i, &dxgiAdapter) != DXGI_ERROR_NOT_FOUND; i++) {
+        Com<IDXGIAdapter1> dxgiAdapter;
+        for (auto i = 0U; dxgiFactory->EnumAdapters1(i, &dxgiAdapter) != DXGI_ERROR_NOT_FOUND; i++) {
             auto nvapiAdapter = new NvapiAdapter(*m_vulkan, *m_nvml);
             if (nvapiAdapter->Initialize(dxgiAdapter, m_nvapiOutputs))
                 m_nvapiAdapters.push_back(nvapiAdapter);

--- a/src/sysinfo/resource_factory.cpp
+++ b/src/sysinfo/resource_factory.cpp
@@ -5,9 +5,9 @@ namespace dxvk {
 
     ResourceFactory::~ResourceFactory()  = default;
 
-    Com<IDXGIFactory> ResourceFactory::CreateDXGIFactory() {
-        Com<IDXGIFactory> dxgiFactory;
-        if(FAILED(::CreateDXGIFactory(__uuidof(IDXGIFactory), (void**)&dxgiFactory)))
+    Com<IDXGIFactory1> ResourceFactory::CreateDXGIFactory1() {
+        Com<IDXGIFactory1> dxgiFactory;
+        if(FAILED(::CreateDXGIFactory1(__uuidof(IDXGIFactory1), (void**)&dxgiFactory)))
             return nullptr;
 
         return dxgiFactory;

--- a/src/sysinfo/resource_factory.h
+++ b/src/sysinfo/resource_factory.h
@@ -12,7 +12,7 @@ namespace dxvk {
         ResourceFactory();
         virtual ~ResourceFactory();
 
-        virtual Com<IDXGIFactory> CreateDXGIFactory();
+        virtual Com<IDXGIFactory1> CreateDXGIFactory1();
         virtual std::unique_ptr<Vulkan> CreateVulkan();
         virtual std::unique_ptr<Nvml> CreateNvml();
     };

--- a/tests/mock_factory.cpp
+++ b/tests/mock_factory.cpp
@@ -1,11 +1,11 @@
 class MockFactory : public ResourceFactory {
 
     public:
-    MockFactory(std::unique_ptr<IDXGIFactory> dxgiFactoryMock, std::unique_ptr<Vulkan> vulkanMock, std::unique_ptr<Nvml> nvmlMock)
-        : m_dxgiFactoryMock(std::move(dxgiFactoryMock)), m_vulkanMock(std::move(vulkanMock)), m_nvmlMock(std::move(nvmlMock)) {};
+    MockFactory(std::unique_ptr<IDXGIFactory1> dxgiFactory1Mock, std::unique_ptr<Vulkan> vulkanMock, std::unique_ptr<Nvml> nvmlMock)
+        : m_dxgiFactoryMock(std::move(dxgiFactory1Mock)), m_vulkanMock(std::move(vulkanMock)), m_nvmlMock(std::move(nvmlMock)) {};
 
-    Com<IDXGIFactory> CreateDXGIFactory() override {
-        Com<IDXGIFactory> dxgiFactory = m_dxgiFactoryMock.get();
+    Com<IDXGIFactory1> CreateDXGIFactory1() override {
+        Com<IDXGIFactory1> dxgiFactory = m_dxgiFactoryMock.get();
         return dxgiFactory;
     };
 
@@ -18,7 +18,7 @@ class MockFactory : public ResourceFactory {
     }
 
     private:
-    std::unique_ptr<IDXGIFactory> m_dxgiFactoryMock;
+    std::unique_ptr<IDXGIFactory1> m_dxgiFactoryMock;
     std::unique_ptr<Vulkan> m_vulkanMock;
     std::unique_ptr<Nvml> m_nvmlMock;
 };

--- a/tests/nvapi_sysinfo.cpp
+++ b/tests/nvapi_sysinfo.cpp
@@ -28,7 +28,7 @@ TEST_CASE("GetErrorMessage returns OK", "[.sysinfo]") {
 }
 
 TEST_CASE("Initialize returns device-not-found when DXVK reports no adapters", "[.sysinfo]") {
-    auto dxgiFactory = std::make_unique<DXGIFactoryMock>();
+    auto dxgiFactory = std::make_unique<DXGIFactory1Mock>();
     auto vulkan = std::make_unique<VulkanMock>();
     auto nvml = std::make_unique<NvmlMock>();
 
@@ -36,7 +36,7 @@ TEST_CASE("Initialize returns device-not-found when DXVK reports no adapters", "
         .RETURN(1);
     ALLOW_CALL(*dxgiFactory, Release())
         .RETURN(0);
-    ALLOW_CALL(*dxgiFactory, EnumAdapters(_, _))
+    ALLOW_CALL(*dxgiFactory, EnumAdapters1(_, _))
         .RETURN(DXGI_ERROR_NOT_FOUND);
 
     ALLOW_CALL(*vulkan, IsAvailable())
@@ -51,7 +51,7 @@ TEST_CASE("Initialize returns device-not-found when DXVK reports no adapters", "
 }
 
 TEST_CASE("Topology methods succeed", "[.sysinfo]") {
-    auto dxgiFactory = std::make_unique<DXGIFactoryMock>();
+    auto dxgiFactory = std::make_unique<DXGIFactory1Mock>();
     DXGIDxvkAdapterMock adapter1;
     auto vkDevice1 = reinterpret_cast<VkPhysicalDevice>(0x01); // Very evil, but works for testing since we use this only as identifier
     DXGIDxvkAdapterMock adapter2;
@@ -66,13 +66,13 @@ TEST_CASE("Topology methods succeed", "[.sysinfo]") {
         .RETURN(1);
     ALLOW_CALL(*dxgiFactory, Release())
         .RETURN(0);
-    ALLOW_CALL(*dxgiFactory, EnumAdapters(0U, _))
-        .LR_SIDE_EFFECT(*_2 = static_cast<IDXGIAdapter*>(&adapter1))
+    ALLOW_CALL(*dxgiFactory, EnumAdapters1(0U, _))
+        .LR_SIDE_EFFECT(*_2 = static_cast<IDXGIAdapter1*>(&adapter1))
         .RETURN(S_OK);
-    ALLOW_CALL(*dxgiFactory, EnumAdapters(1U, _))
-        .LR_SIDE_EFFECT(*_2 = static_cast<IDXGIAdapter*>(&adapter2))
+    ALLOW_CALL(*dxgiFactory, EnumAdapters1(1U, _))
+        .LR_SIDE_EFFECT(*_2 = static_cast<IDXGIAdapter1*>(&adapter2))
         .RETURN(S_OK);
-    ALLOW_CALL(*dxgiFactory, EnumAdapters(2U, _))
+    ALLOW_CALL(*dxgiFactory, EnumAdapters1(2U, _))
         .RETURN(DXGI_ERROR_NOT_FOUND);
 
     ALLOW_CALL(adapter1, QueryInterface(IDXGIVkInteropAdapter::guid, _))
@@ -307,7 +307,7 @@ TEST_CASE("Topology methods succeed", "[.sysinfo]") {
 }
 
 TEST_CASE("Sysinfo methods succeed", "[.sysinfo]") {
-    auto dxgiFactory = std::make_unique<DXGIFactoryMock>();
+    auto dxgiFactory = std::make_unique<DXGIFactory1Mock>();
     DXGIDxvkAdapterMock adapter;
     DXGIOutputMock output;
     auto vulkan = std::make_unique<VulkanMock>();
@@ -317,10 +317,10 @@ TEST_CASE("Sysinfo methods succeed", "[.sysinfo]") {
         .RETURN(1);
     ALLOW_CALL(*dxgiFactory, Release())
         .RETURN(0);
-    ALLOW_CALL(*dxgiFactory, EnumAdapters(0U, _))
-        .LR_SIDE_EFFECT(*_2 = static_cast<IDXGIAdapter*>(&adapter))
+    ALLOW_CALL(*dxgiFactory, EnumAdapters1(0U, _))
+        .LR_SIDE_EFFECT(*_2 = static_cast<IDXGIAdapter1*>(&adapter))
         .RETURN(S_OK);
-    ALLOW_CALL(*dxgiFactory, EnumAdapters(1U, _))
+    ALLOW_CALL(*dxgiFactory, EnumAdapters1(1U, _))
         .RETURN(DXGI_ERROR_NOT_FOUND);
 
     ALLOW_CALL(adapter, QueryInterface(IDXGIVkInteropAdapter::guid, _))

--- a/tests/nvapi_sysinfo_mocks.cpp
+++ b/tests/nvapi_sysinfo_mocks.cpp
@@ -2,7 +2,7 @@
 
 using namespace trompeloeil;
 
-class DXGIFactoryMock : public mock_interface<IDXGIFactory> {
+class DXGIFactory1Mock : public mock_interface<IDXGIFactory1> {
     MAKE_MOCK2(QueryInterface, HRESULT(REFIID, void**), override);
     MAKE_MOCK0(AddRef, ULONG(), override);
     MAKE_MOCK0(Release, ULONG(), override);
@@ -15,9 +15,11 @@ class DXGIFactoryMock : public mock_interface<IDXGIFactory> {
     IMPLEMENT_MOCK1(GetWindowAssociation);
     IMPLEMENT_MOCK3(CreateSwapChain);
     IMPLEMENT_MOCK2(CreateSoftwareAdapter);
+    IMPLEMENT_MOCK2(EnumAdapters1);
+    IMPLEMENT_MOCK0(IsCurrent);
 };
 
-class IDXGIDxvkAdapter : public IDXGIAdapter, public IDXGIVkInteropAdapter {};
+class IDXGIDxvkAdapter : public IDXGIAdapter1, public IDXGIVkInteropAdapter {};
 
 class DXGIDxvkAdapterMock : public mock_interface<IDXGIDxvkAdapter> {
     MAKE_MOCK2(QueryInterface, HRESULT(REFIID, void**), override);
@@ -31,6 +33,7 @@ class DXGIDxvkAdapterMock : public mock_interface<IDXGIDxvkAdapter> {
     IMPLEMENT_MOCK1(GetDesc);
     IMPLEMENT_MOCK2(CheckInterfaceSupport);
     IMPLEMENT_MOCK2(GetVulkanHandles);
+    IMPLEMENT_MOCK1(GetDesc1);
 };
 
 class DXGIOutputMock : public mock_interface<IDXGIOutput> {

--- a/tests/nvapi_sysinfo_util.cpp
+++ b/tests/nvapi_sysinfo_util.cpp
@@ -6,7 +6,7 @@ void ResetResourceFactory() {
     initializationCount = 0ULL;
 }
 
-void SetupResourceFactory(std::unique_ptr<DXGIFactoryMock> dxgiFactory, std::unique_ptr<Vulkan> vulkan, std::unique_ptr<Nvml> nvml) {
+void SetupResourceFactory(std::unique_ptr<DXGIFactory1Mock> dxgiFactory, std::unique_ptr<Vulkan> vulkan, std::unique_ptr<Nvml> nvml) {
     resourceFactory = std::make_unique<MockFactory>(std::move(dxgiFactory), std::move(vulkan), std::move(nvml));
     nvapiAdapterRegistry.reset();
     initializationCount = 0ULL;


### PR DESCRIPTION
We would need this for creating a D3D12Device for querying feature support.
This is supported since Win7, so safe to do.