### PR TITLE
nvapi: Don't assume that DXVK_NVAPI_VERSION is always short

### DIFF
--- a/src/nvapi.cpp
+++ b/src/nvapi.cpp
@@ -122,7 +122,7 @@ extern "C" {
         // Ignore hNvDisplay and query the first adapter
         pVersion->drvVersion = nvapiAdapterRegistry->GetAdapter()->GetDriverVersion();
         pVersion->bldChangeListNum = 0;
-        strcpy(pVersion->szBuildBranchString, str::format(NVAPI_VERSION, "_", DXVK_NVAPI_VERSION).c_str());
+        snprintf(pVersion->szBuildBranchString, sizeof(pVersion->szBuildBranchString), "%s_%s", NVAPI_VERSION, DXVK_NVAPI_VERSION);
         strcpy(pVersion->szAdapterString, nvapiAdapterRegistry->GetAdapter()->GetDeviceName().c_str());
 
         return Ok(n);

--- a/src/nvapi_sys.cpp
+++ b/src/nvapi_sys.cpp
@@ -31,7 +31,7 @@ extern "C" {
             return InvalidArgument(n);
 
         *pDriverVersion = nvapiAdapterRegistry->GetAdapter()->GetDriverVersion();
-        strcpy(szBuildBranchString, str::format(NVAPI_VERSION, "_", DXVK_NVAPI_VERSION).c_str());
+        snprintf(szBuildBranchString, NVAPI_SHORT_STRING_MAX, "%s_%s", NVAPI_VERSION, DXVK_NVAPI_VERSION);
 
         return Ok(n);
     }


### PR DESCRIPTION
Some other uses of `strcpy()` (and friends) should be changed as well as the source can be any arbitrary string, but this is enough to fix the reliable bleeding-edge crash with God of War.