### PR TITLE
nvapi: Copy into NVAPI-Shortstring without writing out of bounds

### DIFF
--- a/src/nvapi.cpp
+++ b/src/nvapi.cpp
@@ -122,8 +122,8 @@ extern "C" {
         // Ignore hNvDisplay and query the first adapter
         pVersion->drvVersion = nvapiAdapterRegistry->GetAdapter()->GetDriverVersion();
         pVersion->bldChangeListNum = 0;
-        strcpy(pVersion->szBuildBranchString, str::format(NVAPI_VERSION, "_", DXVK_NVAPI_VERSION).c_str());
-        strcpy(pVersion->szAdapterString, nvapiAdapterRegistry->GetAdapter()->GetDeviceName().c_str());
+        str::tonvss(pVersion->szBuildBranchString, str::format(NVAPI_VERSION, "_", DXVK_NVAPI_VERSION));
+        str::tonvss(pVersion->szAdapterString, nvapiAdapterRegistry->GetAdapter()->GetDeviceName());
 
         return Ok(n);
     }
@@ -202,7 +202,7 @@ extern "C" {
         if (!nvapiAdapterRegistry->IsOutput(output))
             return ExpectedDisplayHandle(n);
 
-        strcpy(szDisplayName, output->GetDeviceName().c_str());
+        str::tonvss(szDisplayName, output->GetDeviceName());
 
         return Ok(n);
     }
@@ -213,7 +213,7 @@ extern "C" {
         if (szDesc == nullptr)
             return InvalidArgument(n);
 
-        strcpy(szDesc, "DXVK_NVAPI");
+        str::tonvss(szDesc, "DXVK_NVAPI");
 
         return Ok(n);
     }
@@ -225,7 +225,7 @@ extern "C" {
             return InvalidArgument(n);
 
         auto error = fromErrorNr(nr);
-        strcpy(szDesc, error.c_str());
+        str::tonvss(szDesc, error);
 
         return Ok(str::format(n, " (", nr, "/", error, ")"));
     }

--- a/src/nvapi_drs.cpp
+++ b/src/nvapi_drs.cpp
@@ -19,11 +19,11 @@ extern "C" {
     }
 
     NvAPI_Status __cdecl NvAPI_DRS_FindProfileByName(NvDRSSessionHandle hSession, NvAPI_UnicodeString profileName, NvDRSProfileHandle* phProfile) {
-        return ProfileNotFound(str::format(__func__, " (", str::fromnvs(profileName), ")"));
+        return ProfileNotFound(str::format(__func__, " (", str::fromnvus(profileName), ")"));
     }
 
     NvAPI_Status __cdecl NvAPI_DRS_FindApplicationByName(NvDRSSessionHandle hSession, NvAPI_UnicodeString appName, NvDRSProfileHandle *phProfile, NVDRS_APPLICATION *pApplication) {
-        return ExecutableNotFound(str::format(__func__, " (", str::fromnvs(appName), ")"));
+        return ExecutableNotFound(str::format(__func__, " (", str::fromnvus(appName), ")"));
     }
 
     NvAPI_Status __cdecl NvAPI_DRS_GetBaseProfile(NvDRSSessionHandle hSession, NvDRSProfileHandle *phProfile) {

--- a/src/nvapi_gpu.cpp
+++ b/src/nvapi_gpu.cpp
@@ -58,7 +58,7 @@ extern "C" {
         if (!nvapiAdapterRegistry->IsAdapter(adapter))
             return ExpectedPhysicalGpuHandle(n);
 
-        strcpy(szName, adapter->GetDeviceName().c_str());
+        str::tonvss(szName, adapter->GetDeviceName());
 
         return Ok(n);
     }
@@ -298,7 +298,7 @@ extern "C" {
             return ExpectedPhysicalGpuHandle(n);
 
         if (!adapter->HasNvml() || !adapter->HasNvmlDevice()) {
-            strcpy(szBiosRevision, "N/A");
+            str::tonvss(szBiosRevision, "N/A");
             return Ok(n);
         }
 
@@ -306,7 +306,7 @@ extern "C" {
         auto result = adapter->GetNvmlDeviceVbiosVersion(version, NVML_DEVICE_INFOROM_VERSION_BUFFER_SIZE);
         switch (result) {
             case NVML_SUCCESS:
-                strcpy(szBiosRevision, version);
+                str::tonvss(szBiosRevision, version);
                 return Ok(n);
             case NVML_ERROR_NOT_SUPPORTED:
                 return NotSupported(n);

--- a/src/nvapi_sys.cpp
+++ b/src/nvapi_sys.cpp
@@ -31,7 +31,7 @@ extern "C" {
             return InvalidArgument(n);
 
         *pDriverVersion = nvapiAdapterRegistry->GetAdapter()->GetDriverVersion();
-        strcpy(szBuildBranchString, str::format(NVAPI_VERSION, "_", DXVK_NVAPI_VERSION).c_str());
+        str::tonvss(szBuildBranchString, str::format(NVAPI_VERSION, "_", DXVK_NVAPI_VERSION));
 
         return Ok(n);
     }

--- a/src/util/util_string.cpp
+++ b/src/util/util_string.cpp
@@ -35,4 +35,9 @@ namespace dxvk::str {
         auto w = std::wstring(reinterpret_cast<wchar_t*>(nvus));
         return {w.begin(), w.end()};
     }
+
+    void tonvss(NvAPI_ShortString nvss, std::string str) {
+        str.resize(NVAPI_SHORT_STRING_MAX);
+        strcpy(nvss, str.c_str());
+    }
 }

--- a/src/util/util_string.cpp
+++ b/src/util/util_string.cpp
@@ -37,7 +37,7 @@ namespace dxvk::str {
     }
 
     void tonvss(NvAPI_ShortString nvss, std::string str) {
-        str.resize(NVAPI_SHORT_STRING_MAX);
+        str.resize(NVAPI_SHORT_STRING_MAX - 1);
         strcpy(nvss, str.c_str());
     }
 }

--- a/src/util/util_string.cpp
+++ b/src/util/util_string.cpp
@@ -3,7 +3,6 @@
 namespace dxvk::str {
     std::string fromws(const WCHAR* ws) {
         auto len = ::WideCharToMultiByte(CP_UTF8, 0, ws, -1, nullptr, 0, nullptr, nullptr);
-
         if (len <= 1)
             return "";
 
@@ -21,7 +20,6 @@ namespace dxvk::str {
 
     std::wstring tows(const char* mbs) {
         auto len = ::MultiByteToWideChar(CP_UTF8, 0, mbs, -1, nullptr, 0);
-
         if (len <= 1)
             return L"";
 

--- a/src/util/util_string.cpp
+++ b/src/util/util_string.cpp
@@ -33,8 +33,8 @@ namespace dxvk::str {
         return result;
     }
 
-    std::string fromnvs(NvAPI_UnicodeString nvs) {
-        auto w = std::wstring(reinterpret_cast<wchar_t*>(nvs));
+    std::string fromnvus(NvAPI_UnicodeString nvus) {
+        auto w = std::wstring(reinterpret_cast<wchar_t*>(nvus));
         return {w.begin(), w.end()};
     }
 }

--- a/src/util/util_string.h
+++ b/src/util/util_string.h
@@ -14,7 +14,7 @@ namespace dxvk::str {
 
     std::wstring tows(const char* mbs);
 
-    std::string fromnvs(NvAPI_UnicodeString nvs);
+    std::string fromnvus(NvAPI_UnicodeString nvus);
 
     inline void format1(std::stringstream&) { }
 

--- a/src/util/util_string.h
+++ b/src/util/util_string.h
@@ -16,6 +16,8 @@ namespace dxvk::str {
 
     std::string fromnvus(NvAPI_UnicodeString nvus);
 
+    void tonvss(NvAPI_ShortString nvss, std::string str);
+
     inline void format1(std::stringstream&) { }
 
     template<typename... Tx>


### PR DESCRIPTION
DXVK_NVAPI_VERSION comes from the VCS tag, we should not asume that it is always short. The same applies for adapter and display names.

Fixes https://github.com/jp7677/dxvk-nvapi/issues/76
