### PR TITLE
includes: Add missing standard library includes

### DIFF
--- a/src/nvapi_private.h
+++ b/src/nvapi_private.h
@@ -12,6 +12,10 @@
 #include <fstream>
 #include <ctime>
 #include <mutex>
+#include <memory>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
 #include <dxgi.h>
 #include <d3d11_1.h>


### PR DESCRIPTION
Fixes build errors on GCC 12.

By the way, we should also fix this:

```
[1/38] Generating version.h with a custom command
fatal: unsafe repository ('/github/workspace' is owned by someone else)
To add an exception for this directory, call:
	git config --global --add safe.directory /github/workspace
```

…, otherwise builds from GH Actions could report unexpected version to callers.