### PR TITLE
NVML 515

### DIFF
--- a/inc/nvml.h
+++ b/inc/nvml.h
@@ -1,42 +1,42 @@
 /*
- * Copyright 1993-2020 NVIDIA Corporation.  All rights reserved.
+ * Copyright 1993-2022 NVIDIA Corporation.  All rights reserved.
  *
- * NOTICE TO USER:   
+ * NOTICE TO USER:
  *
- * This source code is subject to NVIDIA ownership rights under U.S. and 
- * international Copyright laws.  Users and possessors of this source code 
- * are hereby granted a nonexclusive, royalty-free license to use this code 
+ * This source code is subject to NVIDIA ownership rights under U.S. and
+ * international Copyright laws.  Users and possessors of this source code
+ * are hereby granted a nonexclusive, royalty-free license to use this code
  * in individual and commercial software.
  *
- * NVIDIA MAKES NO REPRESENTATION ABOUT THE SUITABILITY OF THIS SOURCE 
- * CODE FOR ANY PURPOSE.  IT IS PROVIDED "AS IS" WITHOUT EXPRESS OR 
- * IMPLIED WARRANTY OF ANY KIND.  NVIDIA DISCLAIMS ALL WARRANTIES WITH 
- * REGARD TO THIS SOURCE CODE, INCLUDING ALL IMPLIED WARRANTIES OF 
+ * NVIDIA MAKES NO REPRESENTATION ABOUT THE SUITABILITY OF THIS SOURCE
+ * CODE FOR ANY PURPOSE.  IT IS PROVIDED "AS IS" WITHOUT EXPRESS OR
+ * IMPLIED WARRANTY OF ANY KIND.  NVIDIA DISCLAIMS ALL WARRANTIES WITH
+ * REGARD TO THIS SOURCE CODE, INCLUDING ALL IMPLIED WARRANTIES OF
  * MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE.
- * IN NO EVENT SHALL NVIDIA BE LIABLE FOR ANY SPECIAL, INDIRECT, INCIDENTAL, 
- * OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS 
- * OF USE, DATA OR PROFITS,  WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE 
- * OR OTHER TORTIOUS ACTION,  ARISING OUT OF OR IN CONNECTION WITH THE USE 
- * OR PERFORMANCE OF THIS SOURCE CODE.  
+ * IN NO EVENT SHALL NVIDIA BE LIABLE FOR ANY SPECIAL, INDIRECT, INCIDENTAL,
+ * OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+ * OF USE, DATA OR PROFITS,  WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE
+ * OR OTHER TORTIOUS ACTION,  ARISING OUT OF OR IN CONNECTION WITH THE USE
+ * OR PERFORMANCE OF THIS SOURCE CODE.
  *
- * U.S. Government End Users.   This source code is a "commercial item" as 
- * that term is defined at  48 C.F.R. 2.101 (OCT 1995), consisting  of 
- * "commercial computer  software"  and "commercial computer software 
- * documentation" as such terms are  used in 48 C.F.R. 12.212 (SEPT 1995) 
- * and is provided to the U.S. Government only as a commercial end item.  
- * Consistent with 48 C.F.R.12.212 and 48 C.F.R. 227.7202-1 through 
- * 227.7202-4 (JUNE 1995), all U.S. Government End Users acquire the 
- * source code with only those rights set forth herein. 
+ * U.S. Government End Users.   This source code is a "commercial item" as
+ * that term is defined at  48 C.F.R. 2.101 (OCT 1995), consisting  of
+ * "commercial computer  software"  and "commercial computer software
+ * documentation" as such terms are  used in 48 C.F.R. 12.212 (SEPT 1995)
+ * and is provided to the U.S. Government only as a commercial end item.
+ * Consistent with 48 C.F.R.12.212 and 48 C.F.R. 227.7202-1 through
+ * 227.7202-4 (JUNE 1995), all U.S. Government End Users acquire the
+ * source code with only those rights set forth herein.
  *
- * Any use of this source code in individual and commercial software must 
+ * Any use of this source code in individual and commercial software must
  * include, in the user documentation and internal comments to the code,
  * the above Disclaimer and U.S. Government End Users Notice.
  */
 
-/* 
+/*
 NVML API Reference
 
-The NVIDIA Management Library (NVML) is a C-based programmatic interface for monitoring and 
+The NVIDIA Management Library (NVML) is a C-based programmatic interface for monitoring and
 managing various states within NVIDIA Tesla &tm; GPUs. It is intended to be a platform for building
 3rd party applications, and is also the underlying library for the NVIDIA-supported nvidia-smi
 tool. NVML is thread-safe so it is safe to make simultaneous NVML calls from multiple threads.
@@ -58,7 +58,7 @@ Supported products:
     - All Geforce products, starting with the Fermi architecture
 
 The NVML library can be found at \%ProgramW6432\%\\"NVIDIA Corporation"\\NVSMI\\ on Windows. It is
-not be added to the system path by default. To dynamically link to NVML, add this path to the PATH 
+not be added to the system path by default. To dynamically link to NVML, add this path to the PATH
 environmental variable. To dynamically load NVML, call LoadLibrary with this path.
 
 On Linux the NVML library will be found on the standard library path. For 64 bit Linux, both the 32 bit
@@ -103,23 +103,29 @@ extern "C" {
  * guard if you need to support older versions of the API
  */
 #ifndef NVML_NO_UNVERSIONED_FUNC_DEFS
-    #define nvmlInit                                nvmlInit_v2
-    #define nvmlDeviceGetPciInfo                    nvmlDeviceGetPciInfo_v3
-    #define nvmlDeviceGetCount                      nvmlDeviceGetCount_v2
-    #define nvmlDeviceGetHandleByIndex              nvmlDeviceGetHandleByIndex_v2
-    #define nvmlDeviceGetHandleByPciBusId           nvmlDeviceGetHandleByPciBusId_v2
-    #define nvmlDeviceGetNvLinkRemotePciInfo        nvmlDeviceGetNvLinkRemotePciInfo_v2
-    #define nvmlDeviceRemoveGpu                     nvmlDeviceRemoveGpu_v2
-    #define nvmlDeviceGetGridLicensableFeatures     nvmlDeviceGetGridLicensableFeatures_v3
-    #define nvmlEventSetWait                        nvmlEventSetWait_v2
-    #define nvmlDeviceGetAttributes                 nvmlDeviceGetAttributes_v2
-    #define nvmlComputeInstanceGetInfo              nvmlComputeInstanceGetInfo_v2
-    #define nvmlDeviceGetComputeRunningProcesses    nvmlDeviceGetComputeRunningProcesses_v2
-    #define nvmlDeviceGetGraphicsRunningProcesses   nvmlDeviceGetGraphicsRunningProcesses_v2
-    #define nvmlBlacklistDeviceInfo_t               nvmlExcludedDeviceInfo_t
-    #define nvmlGetBlacklistDeviceCount             nvmlGetExcludedDeviceCount
-    #define nvmlGetBlacklistDeviceInfoByIndex       nvmlGetExcludedDeviceInfoByIndex
+    #define nvmlInit                                    nvmlInit_v2
+    #define nvmlDeviceGetPciInfo                        nvmlDeviceGetPciInfo_v3
+    #define nvmlDeviceGetCount                          nvmlDeviceGetCount_v2
+    #define nvmlDeviceGetHandleByIndex                  nvmlDeviceGetHandleByIndex_v2
+    #define nvmlDeviceGetHandleByPciBusId               nvmlDeviceGetHandleByPciBusId_v2
+    #define nvmlDeviceGetNvLinkRemotePciInfo            nvmlDeviceGetNvLinkRemotePciInfo_v2
+    #define nvmlDeviceRemoveGpu                         nvmlDeviceRemoveGpu_v2
+    #define nvmlDeviceGetGridLicensableFeatures         nvmlDeviceGetGridLicensableFeatures_v4
+    #define nvmlEventSetWait                            nvmlEventSetWait_v2
+    #define nvmlDeviceGetAttributes                     nvmlDeviceGetAttributes_v2
+    #define nvmlComputeInstanceGetInfo                  nvmlComputeInstanceGetInfo_v2
+    #define nvmlDeviceGetComputeRunningProcesses        nvmlDeviceGetComputeRunningProcesses_v3
+    #define nvmlDeviceGetGraphicsRunningProcesses       nvmlDeviceGetGraphicsRunningProcesses_v3
+    #define nvmlDeviceGetMPSComputeRunningProcesses     nvmlDeviceGetMPSComputeRunningProcesses_v3
+    #define nvmlBlacklistDeviceInfo_t                   nvmlExcludedDeviceInfo_t
+    #define nvmlGetBlacklistDeviceCount                 nvmlGetExcludedDeviceCount
+    #define nvmlGetBlacklistDeviceInfoByIndex           nvmlGetExcludedDeviceInfoByIndex
+    #define nvmlDeviceGetGpuInstancePossiblePlacements  nvmlDeviceGetGpuInstancePossiblePlacements_v2
+    #define nvmlVgpuInstanceGetLicenseInfo              nvmlVgpuInstanceGetLicenseInfo_v2
 #endif // #ifndef NVML_NO_UNVERSIONED_FUNC_DEFS
+
+#define NVML_STRUCT_VERSION(data, ver) (unsigned int)(sizeof(nvml ## data ## _v ## ver ## _t) | \
+                                                      (ver << 24U))
 
 /***************************************************************************************************/
 /** @defgroup nvmlDeviceStructs Device Structs
@@ -187,7 +193,7 @@ typedef struct nvmlPciInfo_st
  * @deprecated  Different GPU families can have different memory error counters
  *              See \ref nvmlDeviceGetMemoryErrorCounter
  */
-typedef struct nvmlEccErrorCounts_st 
+typedef struct nvmlEccErrorCounts_st
 {
     unsigned long long l1Cache;      //!< L1 cache errors
     unsigned long long l2Cache;      //!< L2 cache errors
@@ -195,25 +201,44 @@ typedef struct nvmlEccErrorCounts_st
     unsigned long long registerFile; //!< Register file errors
 } nvmlEccErrorCounts_t;
 
-/** 
+/**
  * Utilization information for a device.
  * Each sample period may be between 1 second and 1/6 second, depending on the product being queried.
  */
-typedef struct nvmlUtilization_st 
+typedef struct nvmlUtilization_st
 {
     unsigned int gpu;                //!< Percent of time over the past sample period during which one or more kernels was executing on the GPU
     unsigned int memory;             //!< Percent of time over the past sample period during which global (device) memory was being read or written
 } nvmlUtilization_t;
 
-/** 
- * Memory allocation information for a device.
+/**
+ * Memory allocation information for a device (v1).
+ * The total amount is equal to the sum of the amounts of free and used memory.
  */
-typedef struct nvmlMemory_st 
+typedef struct nvmlMemory_st
 {
-    unsigned long long total;        //!< Total installed FB memory (in bytes)
-    unsigned long long free;         //!< Unallocated FB memory (in bytes)
-    unsigned long long used;         //!< Allocated FB memory (in bytes). Note that the driver/GPU always sets aside a small amount of memory for bookkeeping
+    unsigned long long total;        //!< Total physical device memory (in bytes)
+    unsigned long long free;         //!< Unallocated device memory (in bytes)
+    unsigned long long used;         //!< Sum of Reserved and Allocated device memory (in bytes).
+                                     //!< Note that the driver/GPU always sets aside a small amount of memory for bookkeeping
 } nvmlMemory_t;
+
+/**
+ * Memory allocation information for a device (v2).
+ * 
+ * Version 2 adds versioning for the struct and the amount of system-reserved memory as an output.
+ * @note The \ref nvmlMemory_v2_t.used amount also includes the \ref nvmlMemory_v2_t.reserved amount.
+ */
+typedef struct nvmlMemory_v2_st
+{
+    unsigned int version;            //!< Structure format version (must be 2)
+    unsigned long long total;        //!< Total physical device memory (in bytes)
+    unsigned long long reserved;     //!< Device memory (in bytes) reserved for system use (driver or firmware)
+    unsigned long long free;         //!< Unallocated device memory (in bytes)
+    unsigned long long used;         //!< Allocated device memory (in bytes). Note that the driver/GPU always sets aside a small amount of memory for bookkeeping
+} nvmlMemory_v2_t;
+
+#define nvmlMemory_v2 NVML_STRUCT_VERSION(Memory, 2)
 
 /**
  * BAR1 Memory allocation Information for a device
@@ -226,7 +251,35 @@ typedef struct nvmlBAR1Memory_st
 }nvmlBAR1Memory_t;
 
 /**
+ * Information about running compute processes on the GPU, legacy version
+ * for older versions of the API.
+ */
+typedef struct nvmlProcessInfo_v1_st
+{
+    unsigned int        pid;                //!< Process ID
+    unsigned long long  usedGpuMemory;      //!< Amount of used GPU memory in bytes.
+                                            //! Under WDDM, \ref NVML_VALUE_NOT_AVAILABLE is always reported
+                                            //! because Windows KMD manages all the memory and not the NVIDIA driver
+} nvmlProcessInfo_v1_t;
+
+/**
  * Information about running compute processes on the GPU
+ */
+typedef struct nvmlProcessInfo_v2_st
+{
+    unsigned int        pid;                //!< Process ID
+    unsigned long long  usedGpuMemory;      //!< Amount of used GPU memory in bytes.
+                                            //! Under WDDM, \ref NVML_VALUE_NOT_AVAILABLE is always reported
+                                            //! because Windows KMD manages all the memory and not the NVIDIA driver
+    unsigned int        gpuInstanceId;      //!< If MIG is enabled, stores a valid GPU instance ID. gpuInstanceId is set to
+                                            //  0xFFFFFFFF otherwise.
+    unsigned int        computeInstanceId;  //!< If MIG is enabled, stores a valid compute instance ID. computeInstanceId is set to
+                                            //  0xFFFFFFFF otherwise.
+} nvmlProcessInfo_v2_t;
+
+/**
+ * Information about running compute processes on the GPU
+ * Version 2 adds versioning for the struct and the conf compute protected memory in output.
  */
 typedef struct nvmlProcessInfo_st
 {
@@ -274,11 +327,11 @@ typedef struct nvmlRowRemapperHistogramValues_st
 typedef enum nvmlBridgeChipType_enum
 {
     NVML_BRIDGE_CHIP_PLX = 0,
-    NVML_BRIDGE_CHIP_BRO4 = 1           
+    NVML_BRIDGE_CHIP_BRO4 = 1
 }nvmlBridgeChipType_t;
 
 /**
- * Maximum number of NvLink links supported 
+ * Maximum number of NvLink links supported
  */
 #define NVML_NVLINK_MAX_LINKS 12
 
@@ -300,7 +353,7 @@ typedef enum nvmlNvLinkUtilizationCountUnits_enum
  *  ** this is ONLY applicable with the units as packets or bytes
  *  ** as specified in \a nvmlNvLinkUtilizationCountUnits_t
  *  ** all packet filter descriptions are target GPU centric
- *  ** these can be "OR'd" together 
+ *  ** these can be "OR'd" together
  */
 typedef enum nvmlNvLinkUtilizationCountPktTypes_enum
 {
@@ -315,7 +368,7 @@ typedef enum nvmlNvLinkUtilizationCountPktTypes_enum
     NVML_NVLINK_COUNTER_PKTFILTER_ALL        = 0xFF     // all packets
 } nvmlNvLinkUtilizationCountPktTypes_t;
 
-/** 
+/**
  * Struct to define the NVLINK counter controls
  */
 typedef struct nvmlNvLinkUtilizationControl_st
@@ -348,10 +401,22 @@ typedef enum nvmlNvLinkErrorCounter_enum
     NVML_NVLINK_ERROR_DL_RECOVERY = 1,     // Data link transmit recovery error counter
     NVML_NVLINK_ERROR_DL_CRC_FLIT = 2,     // Data link receive flow control digit CRC error counter
     NVML_NVLINK_ERROR_DL_CRC_DATA = 3,     // Data link receive data CRC error counter
+    NVML_NVLINK_ERROR_DL_ECC_DATA = 4,     // Data link receive data ECC error counter
 
     // this must be last
     NVML_NVLINK_ERROR_COUNT
 } nvmlNvLinkErrorCounter_t;
+
+/**
+ * Enum to represent NvLink's remote device type
+ */
+typedef enum nvmlIntNvLinkDeviceType_enum
+{
+    NVML_NVLINK_DEVICE_TYPE_GPU     = 0x00,
+    NVML_NVLINK_DEVICE_TYPE_IBMNPU  = 0x01,
+    NVML_NVLINK_DEVICE_TYPE_SWITCH  = 0x02,
+    NVML_NVLINK_DEVICE_TYPE_UNKNOWN = 0xFF
+} nvmlIntNvLinkDeviceType_t;
 
 /**
  * Represents level relationships within a system between two GPUs
@@ -364,7 +429,7 @@ typedef enum nvmlGpuLevel_enum
     NVML_TOPOLOGY_MULTIPLE           = 20, // all devices that need not traverse a host bridge
     NVML_TOPOLOGY_HOSTBRIDGE         = 30, // all devices that are connected to the same host bridge
     NVML_TOPOLOGY_NODE               = 40, // all devices that are connected to the same NUMA node but possibly multiple host bridges
-    NVML_TOPOLOGY_SYSTEM             = 50, // all devices in the system
+    NVML_TOPOLOGY_SYSTEM             = 50  // all devices in the system
 
     // there is purposefully no COUNT here because of the need for spacing above
 } nvmlGpuTopologyLevel_t;
@@ -406,12 +471,12 @@ typedef enum nvmlGpuP2PCapsIndex_enum
  */
 typedef struct nvmlBridgeChipInfo_st
 {
-    nvmlBridgeChipType_t type;                  //!< Type of Bridge Chip 
+    nvmlBridgeChipType_t type;                  //!< Type of Bridge Chip
     unsigned int fwVersion;                     //!< Firmware Version. 0=Version is unavailable
 }nvmlBridgeChipInfo_t;
 
 /**
- * This structure stores the complete Hierarchy of the Bridge Chip within the board. The immediate 
+ * This structure stores the complete Hierarchy of the Bridge Chip within the board. The immediate
  * bridge is stored at index 0 of bridgeInfoList, parent to immediate bridge is at index 1 and so forth.
  */
 typedef struct nvmlBridgeChipHierarchy_st
@@ -429,12 +494,12 @@ typedef enum nvmlSamplingType_enum
     NVML_GPU_UTILIZATION_SAMPLES    = 1, //!< To represent percent of time during which one or more kernels was executing on the GPU
     NVML_MEMORY_UTILIZATION_SAMPLES = 2, //!< To represent percent of time during which global (device) memory was being read or written
     NVML_ENC_UTILIZATION_SAMPLES    = 3, //!< To represent percent of time during which NVENC remains busy
-    NVML_DEC_UTILIZATION_SAMPLES    = 4, //!< To represent percent of time during which NVDEC remains busy            
+    NVML_DEC_UTILIZATION_SAMPLES    = 4, //!< To represent percent of time during which NVDEC remains busy
     NVML_PROCESSOR_CLK_SAMPLES      = 5, //!< To represent processor clock samples
     NVML_MEMORY_CLK_SAMPLES         = 6, //!< To represent memory clock samples
-            
+
     // Keep this last
-    NVML_SAMPLINGTYPE_COUNT               
+    NVML_SAMPLINGTYPE_COUNT
 }nvmlSamplingType_t;
 
 /**
@@ -444,7 +509,7 @@ typedef enum nvmlPcieUtilCounter_enum
 {
     NVML_PCIE_UTIL_TX_BYTES             = 0, // 1KB granularity
     NVML_PCIE_UTIL_RX_BYTES             = 1, // 1KB granularity
-    
+
     // Keep this last
     NVML_PCIE_UTIL_COUNT
 } nvmlPcieUtilCounter_t;
@@ -452,7 +517,7 @@ typedef enum nvmlPcieUtilCounter_enum
 /**
  * Represents the type for sample value returned
  */
-typedef enum nvmlValueType_enum 
+typedef enum nvmlValueType_enum
 {
     NVML_VALUE_TYPE_DOUBLE = 0,
     NVML_VALUE_TYPE_UNSIGNED_INT = 1,
@@ -480,14 +545,14 @@ typedef union nvmlValue_st
 /**
  * Information for Sample
  */
-typedef struct nvmlSample_st 
+typedef struct nvmlSample_st
 {
     unsigned long long timeStamp;       //!< CPU Timestamp in microseconds
     nvmlValue_t sampleValue;        //!< Sample Value
 }nvmlSample_t;
 
 /**
- * Represents type of perf policy for which violation times can be queried 
+ * Represents type of perf policy for which violation times can be queried
  */
 typedef enum nvmlPerfPolicyType_enum
 {
@@ -514,6 +579,60 @@ typedef struct nvmlViolationTime_st
     unsigned long long violationTime;  //!< violationTime in Nanoseconds
 }nvmlViolationTime_t;
 
+#define NVML_MAX_THERMAL_SENSORS_PER_GPU  3
+
+typedef enum
+{
+    NVML_THERMAL_TARGET_NONE          = 0,
+    NVML_THERMAL_TARGET_GPU           = 1,     //!< GPU core temperature requires NvPhysicalGpuHandle
+    NVML_THERMAL_TARGET_MEMORY        = 2,     //!< GPU memory temperature requires NvPhysicalGpuHandle
+    NVML_THERMAL_TARGET_POWER_SUPPLY  = 4,     //!< GPU power supply temperature requires NvPhysicalGpuHandle
+    NVML_THERMAL_TARGET_BOARD         = 8,     //!< GPU board ambient temperature requires NvPhysicalGpuHandle
+    NVML_THERMAL_TARGET_VCD_BOARD     = 9,     //!< Visual Computing Device Board temperature requires NvVisualComputingDeviceHandle
+    NVML_THERMAL_TARGET_VCD_INLET     = 10,    //!< Visual Computing Device Inlet temperature requires NvVisualComputingDeviceHandle
+    NVML_THERMAL_TARGET_VCD_OUTLET    = 11,    //!< Visual Computing Device Outlet temperature requires NvVisualComputingDeviceHandle
+
+    NVML_THERMAL_TARGET_ALL           = 15,
+    NVML_THERMAL_TARGET_UNKNOWN       = -1,
+} nvmlThermalTarget_t;
+
+typedef enum
+{
+    NVML_THERMAL_CONTROLLER_NONE = 0,
+    NVML_THERMAL_CONTROLLER_GPU_INTERNAL,
+    NVML_THERMAL_CONTROLLER_ADM1032,
+    NVML_THERMAL_CONTROLLER_ADT7461,
+    NVML_THERMAL_CONTROLLER_MAX6649,
+    NVML_THERMAL_CONTROLLER_MAX1617,
+    NVML_THERMAL_CONTROLLER_LM99,
+    NVML_THERMAL_CONTROLLER_LM89,
+    NVML_THERMAL_CONTROLLER_LM64,
+    NVML_THERMAL_CONTROLLER_G781,
+    NVML_THERMAL_CONTROLLER_ADT7473,
+    NVML_THERMAL_CONTROLLER_SBMAX6649,
+    NVML_THERMAL_CONTROLLER_VBIOSEVT,
+    NVML_THERMAL_CONTROLLER_OS,
+    NVML_THERMAL_CONTROLLER_NVSYSCON_CANOAS,
+    NVML_THERMAL_CONTROLLER_NVSYSCON_E551,
+    NVML_THERMAL_CONTROLLER_MAX6649R,
+    NVML_THERMAL_CONTROLLER_ADT7473S,
+    NVML_THERMAL_CONTROLLER_UNKNOWN = -1,
+} nvmlThermalController_t;
+
+typedef struct
+{
+    unsigned int   count;
+    struct
+    {
+        nvmlThermalController_t controller;
+        unsigned int defaultMinTemp;
+        unsigned int defaultMaxTemp;
+        unsigned int currentTemp;
+        nvmlThermalTarget_t target;
+    } sensor[NVML_MAX_THERMAL_SENSORS_PER_GPU];
+
+} nvmlGpuThermalSettings_t;
+
 /** @} */
 
 /***************************************************************************************************/
@@ -522,42 +641,43 @@ typedef struct nvmlViolationTime_st
  */
 /***************************************************************************************************/
 
-/** 
- * Generic enable/disable enum. 
+/**
+ * Generic enable/disable enum.
  */
-typedef enum nvmlEnableState_enum 
+typedef enum nvmlEnableState_enum
 {
-    NVML_FEATURE_DISABLED    = 0,     //!< Feature disabled 
+    NVML_FEATURE_DISABLED    = 0,     //!< Feature disabled
     NVML_FEATURE_ENABLED     = 1      //!< Feature enabled
 } nvmlEnableState_t;
 
 //! Generic flag used to specify the default behavior of some functions. See description of particular functions for details.
-#define nvmlFlagDefault     0x00      
+#define nvmlFlagDefault     0x00
 //! Generic flag used to force some behavior. See description of particular functions for details.
-#define nvmlFlagForce       0x01      
+#define nvmlFlagForce       0x01
 
 /**
  *  * The Brand of the GPU
  *   */
 typedef enum nvmlBrandType_enum
 {
-    NVML_BRAND_UNKNOWN          = 0, 
-    NVML_BRAND_QUADRO           = 1,
-    NVML_BRAND_TESLA            = 2,
-    NVML_BRAND_NVS              = 3,
-    NVML_BRAND_GRID             = 4,   // Deprecated from API reporting. Keeping definition for backward compatibility.
-    NVML_BRAND_GEFORCE          = 5,
-    NVML_BRAND_TITAN            = 6,
-    NVML_BRAND_NVIDIA_VAPPS     = 7,   // NVIDIA Virtual Applications
-    NVML_BRAND_NVIDIA_VPC       = 8,   // NVIDIA Virtual PC
-    NVML_BRAND_NVIDIA_VCS       = 9,   // NVIDIA Virtual Compute Server
-    NVML_BRAND_NVIDIA_VWS       = 10,  // NVIDIA RTX Virtual Workstation
-    NVML_BRAND_NVIDIA_VGAMING   = 11,  // NVIDIA vGaming
-    NVML_BRAND_QUADRO_RTX       = 12,
-    NVML_BRAND_NVIDIA_RTX       = 13,
-    NVML_BRAND_NVIDIA           = 14,
-    NVML_BRAND_GEFORCE_RTX      = 15,  // Unused
-    NVML_BRAND_TITAN_RTX        = 16,  // Unused
+    NVML_BRAND_UNKNOWN              = 0,
+    NVML_BRAND_QUADRO               = 1,
+    NVML_BRAND_TESLA                = 2,
+    NVML_BRAND_NVS                  = 3,
+    NVML_BRAND_GRID                 = 4,   // Deprecated from API reporting. Keeping definition for backward compatibility.
+    NVML_BRAND_GEFORCE              = 5,
+    NVML_BRAND_TITAN                = 6,
+    NVML_BRAND_NVIDIA_VAPPS         = 7,   // NVIDIA Virtual Applications
+    NVML_BRAND_NVIDIA_VPC           = 8,   // NVIDIA Virtual PC
+    NVML_BRAND_NVIDIA_VCS           = 9,   // NVIDIA Virtual Compute Server
+    NVML_BRAND_NVIDIA_VWS           = 10,  // NVIDIA RTX Virtual Workstation
+    NVML_BRAND_NVIDIA_CLOUD_GAMING  = 11,  // NVIDIA Cloud Gaming
+    NVML_BRAND_NVIDIA_VGAMING       = NVML_BRAND_NVIDIA_CLOUD_GAMING,  // Deprecated from API reporting. Keeping definition for backward compatibility.
+    NVML_BRAND_QUADRO_RTX           = 12,
+    NVML_BRAND_NVIDIA_RTX           = 13,
+    NVML_BRAND_NVIDIA               = 14,
+    NVML_BRAND_GEFORCE_RTX          = 15,  // Unused
+    NVML_BRAND_TITAN_RTX            = 16,  // Unused
 
     // Keep this last
     NVML_BRAND_COUNT
@@ -586,34 +706,74 @@ typedef enum nvmlTemperatureThresholds_enum
     NVML_TEMPERATURE_THRESHOLD_COUNT
 } nvmlTemperatureThresholds_t;
 
-/** 
- * Temperature sensors. 
+/**
+ * Temperature sensors.
  */
-typedef enum nvmlTemperatureSensors_enum 
+typedef enum nvmlTemperatureSensors_enum
 {
     NVML_TEMPERATURE_GPU      = 0,    //!< Temperature sensor for the GPU die
-    
+
     // Keep this last
     NVML_TEMPERATURE_COUNT
 } nvmlTemperatureSensors_t;
 
-/** 
- * Compute mode. 
+/**
+ * Compute mode.
  *
  * NVML_COMPUTEMODE_EXCLUSIVE_PROCESS was added in CUDA 4.0.
- * Earlier CUDA versions supported a single exclusive mode, 
+ * Earlier CUDA versions supported a single exclusive mode,
  * which is equivalent to NVML_COMPUTEMODE_EXCLUSIVE_THREAD in CUDA 4.0 and beyond.
  */
-typedef enum nvmlComputeMode_enum 
+typedef enum nvmlComputeMode_enum
 {
     NVML_COMPUTEMODE_DEFAULT           = 0,  //!< Default compute mode -- multiple contexts per device
     NVML_COMPUTEMODE_EXCLUSIVE_THREAD  = 1,  //!< Support Removed
     NVML_COMPUTEMODE_PROHIBITED        = 2,  //!< Compute-prohibited mode -- no contexts per device
     NVML_COMPUTEMODE_EXCLUSIVE_PROCESS = 3,  //!< Compute-exclusive-process mode -- only one context per device, usable from multiple threads at a time
-    
+
     // Keep this last
     NVML_COMPUTEMODE_COUNT
 } nvmlComputeMode_t;
+
+/**
+ * Max Clock Monitors available
+ */
+#define MAX_CLK_DOMAINS			32
+
+/**
+ * Clock Monitor error types
+ */
+typedef struct nvmlClkMonFaultInfo_struct {
+    /**
+     * The Domain which faulted
+     */
+    unsigned int   clkApiDomain;
+
+    /**
+     * Faults Information
+     */
+    unsigned int   clkDomainFaultMask;
+} nvmlClkMonFaultInfo_t;
+
+/**
+ * Clock Monitor Status
+ */
+typedef struct nvmlClkMonStatus_status {
+    /**
+     * Fault status Indicator
+     */
+    unsigned int  bGlobalStatus;
+
+    /**
+     * Total faulted domain numbers
+     */
+    unsigned int   clkMonListSize;
+
+    /**
+     * The fault Information structure
+     */
+    nvmlClkMonFaultInfo_t clkMonList[MAX_CLK_DOMAINS];
+} nvmlClkMonStatus_t;
 
 /** 
  * ECC bit types.
@@ -643,54 +803,54 @@ typedef enum nvmlMemoryErrorType_enum
 {
     /**
      * A memory error that was corrected
-     * 
+     *
      * For ECC errors, these are single bit errors
      * For Texture memory, these are errors fixed by resend
      */
     NVML_MEMORY_ERROR_TYPE_CORRECTED = 0,
     /**
      * A memory error that was not corrected
-     * 
+     *
      * For ECC errors, these are double bit errors
      * For Texture memory, these are errors where the resend fails
      */
     NVML_MEMORY_ERROR_TYPE_UNCORRECTED = 1,
-    
-    
+
+
     // Keep this last
     NVML_MEMORY_ERROR_TYPE_COUNT //!< Count of memory error types
 
 } nvmlMemoryErrorType_t;
 
-/** 
- * ECC counter types. 
+/**
+ * ECC counter types.
  *
  * Note: Volatile counts are reset each time the driver loads. On Windows this is once per boot. On Linux this can be more frequent.
- *       On Linux the driver unloads when no active clients exist. If persistence mode is enabled or there is always a driver 
+ *       On Linux the driver unloads when no active clients exist. If persistence mode is enabled or there is always a driver
  *       client active (e.g. X11), then Linux also sees per-boot behavior. If not, volatile counts are reset each time a compute app
  *       is run.
  */
-typedef enum nvmlEccCounterType_enum 
+typedef enum nvmlEccCounterType_enum
 {
     NVML_VOLATILE_ECC      = 0,      //!< Volatile counts are reset each time the driver loads.
     NVML_AGGREGATE_ECC     = 1,      //!< Aggregate counts persist across reboots (i.e. for the lifetime of the device)
-    
+
     // Keep this last
     NVML_ECC_COUNTER_TYPE_COUNT      //!< Count of memory counter types
 } nvmlEccCounterType_t;
 
-/** 
- * Clock types. 
- * 
+/**
+ * Clock types.
+ *
  * All speeds are in Mhz.
  */
-typedef enum nvmlClockType_enum 
+typedef enum nvmlClockType_enum
 {
     NVML_CLOCK_GRAPHICS  = 0,        //!< Graphics clock domain
     NVML_CLOCK_SM        = 1,        //!< SM clock domain
     NVML_CLOCK_MEM       = 2,        //!< Memory clock domain
     NVML_CLOCK_VIDEO     = 3,        //!< Video encoder/decoder clock domain
-    
+
     // Keep this last
     NVML_CLOCK_COUNT //!< Count of clock types
 } nvmlClockType_t;
@@ -710,24 +870,26 @@ typedef enum nvmlClockId_enum
     NVML_CLOCK_ID_COUNT //!< Count of Clock Ids.
 } nvmlClockId_t;
 
-/** 
- * Driver models. 
+/**
+ * Driver models.
  *
  * Windows only.
  */
-typedef enum nvmlDriverModel_enum 
+typedef enum nvmlDriverModel_enum
 {
     NVML_DRIVER_WDDM      = 0,       //!< WDDM driver model -- GPU treated as a display device
     NVML_DRIVER_WDM       = 1        //!< WDM (TCC) model (recommended) -- GPU treated as a generic device
 } nvmlDriverModel_t;
 
+#define NVML_MAX_GPU_PERF_PSTATES 16
+
 /**
  * Allowed PStates.
  */
-typedef enum nvmlPStates_enum 
+typedef enum nvmlPStates_enum
 {
     NVML_PSTATE_0               = 0,       //!< Performance state 0 -- Maximum Performance
-    NVML_PSTATE_1               = 1,       //!< Performance state 1 
+    NVML_PSTATE_1               = 1,       //!< Performance state 1
     NVML_PSTATE_2               = 2,       //!< Performance state 2
     NVML_PSTATE_3               = 3,       //!< Performance state 3
     NVML_PSTATE_4               = 4,       //!< Performance state 4
@@ -741,7 +903,7 @@ typedef enum nvmlPStates_enum
     NVML_PSTATE_12              = 12,      //!< Performance state 12
     NVML_PSTATE_13              = 13,      //!< Performance state 13
     NVML_PSTATE_14              = 14,      //!< Performance state 14
-    NVML_PSTATE_15              = 15,      //!< Performance state 15 -- Minimum Performance 
+    NVML_PSTATE_15              = 15,      //!< Performance state 15 -- Minimum Performance
     NVML_PSTATE_UNKNOWN         = 32       //!< Unknown performance state
 } nvmlPstates_t;
 
@@ -763,10 +925,10 @@ typedef enum nvmlGom_enum
                                             //!< high bandwidth double precision
 } nvmlGpuOperationMode_t;
 
-/** 
+/**
  * Available infoROM objects.
  */
-typedef enum nvmlInforomObject_enum 
+typedef enum nvmlInforomObject_enum
 {
     NVML_INFOROM_OEM            = 0,       //!< An object defined by OEM
     NVML_INFOROM_ECC            = 1,       //!< The ECC object determining the level of ECC support
@@ -776,10 +938,10 @@ typedef enum nvmlInforomObject_enum
     NVML_INFOROM_COUNT                     //!< This counts the number of infoROM objects the driver knows about
 } nvmlInforomObject_t;
 
-/** 
- * Return values for NVML API calls. 
+/**
+ * Return values for NVML API calls.
  */
-typedef enum nvmlReturn_enum 
+typedef enum nvmlReturn_enum
 {
     // cppcheck-suppress *
     NVML_SUCCESS = 0,                        //!< The operation was successful
@@ -806,6 +968,7 @@ typedef enum nvmlReturn_enum
     NVML_ERROR_NO_DATA = 21,                 //!< No data
     NVML_ERROR_VGPU_ECC_NOT_SUPPORTED = 22,  //!< The requested vgpu operation is not available on target device, becasue ECC is enabled
     NVML_ERROR_INSUFFICIENT_RESOURCES = 23,  //!< Ran out of critical resources, other than memory
+    NVML_ERROR_FREQ_NOT_SUPPORTED = 24,  //!< Ran out of critical resources, other than memory
     NVML_ERROR_UNKNOWN = 999                 //!< An internal driver error occurred
 } nvmlReturn_t;
 
@@ -844,7 +1007,7 @@ typedef enum nvmlPageRetirementCause_enum
  */
 typedef enum nvmlRestrictedAPI_enum
 {
-    NVML_RESTRICTED_API_SET_APPLICATION_CLOCKS = 0,   //!< APIs that change application clocks, see nvmlDeviceSetApplicationsClocks 
+    NVML_RESTRICTED_API_SET_APPLICATION_CLOCKS = 0,   //!< APIs that change application clocks, see nvmlDeviceSetApplicationsClocks
                                                       //!< and see nvmlDeviceResetApplicationsClocks
     NVML_RESTRICTED_API_SET_AUTO_BOOSTED_CLOCKS = 1,  //!< APIs that enable/disable Auto Boosted clocks
                                                       //!< see nvmlDeviceSetAutoBoostedClocksEnabled
@@ -872,7 +1035,7 @@ typedef enum nvmlGpuVirtualizationMode {
     NVML_GPU_VIRTUALIZATION_MODE_PASSTHROUGH = 1,  //!< Device is associated with GPU-Passthorugh
     NVML_GPU_VIRTUALIZATION_MODE_VGPU = 2,  //!< Device is associated with vGPU inside virtual machine.
     NVML_GPU_VIRTUALIZATION_MODE_HOST_VGPU = 3,  //!< Device is associated with VGX hypervisor in vGPU mode
-    NVML_GPU_VIRTUALIZATION_MODE_HOST_VSGA = 4,  //!< Device is associated with VGX hypervisor in vSGA mode
+    NVML_GPU_VIRTUALIZATION_MODE_HOST_VSGA = 4   //!< Device is associated with VGX hypervisor in vSGA mode
 } nvmlGpuVirtualizationMode_t;
 
 /**
@@ -889,16 +1052,16 @@ typedef enum nvmlHostVgpuMode_enum
  */
 typedef enum nvmlVgpuVmIdType {
     NVML_VGPU_VM_ID_DOMAIN_ID = 0, //!< VM ID represents DOMAIN ID
-    NVML_VGPU_VM_ID_UUID = 1,      //!< VM ID represents UUID
+    NVML_VGPU_VM_ID_UUID = 1       //!< VM ID represents UUID
 } nvmlVgpuVmIdType_t;
 
 /**
- * vGPU GUEST info state.
+ * vGPU GUEST info state
  */
 typedef enum nvmlVgpuGuestInfoState_enum
 {
     NVML_VGPU_INSTANCE_GUEST_INFO_STATE_UNINITIALIZED = 0,  //!< Guest-dependent fields uninitialized
-    NVML_VGPU_INSTANCE_GUEST_INFO_STATE_INITIALIZED   = 1,  //!< Guest-dependent fields initialized
+    NVML_VGPU_INSTANCE_GUEST_INFO_STATE_INITIALIZED   = 1   //!< Guest-dependent fields initialized
 } nvmlVgpuGuestInfoState_t;
 
 /**
@@ -912,6 +1075,26 @@ typedef enum {
     NVML_GRID_LICENSE_FEATURE_CODE_GAMING       = 3,                                         //!< Gaming
     NVML_GRID_LICENSE_FEATURE_CODE_COMPUTE      = 4                                          //!< Compute
 } nvmlGridLicenseFeatureCode_t;
+
+/**
+ * Status codes for license expiry
+ */
+#define NVML_GRID_LICENSE_EXPIRY_NOT_AVAILABLE   0   //!< Expiry information not available
+#define NVML_GRID_LICENSE_EXPIRY_INVALID         1   //!< Invalid expiry or error fetching expiry
+#define NVML_GRID_LICENSE_EXPIRY_VALID           2   //!< Valid expiry
+#define NVML_GRID_LICENSE_EXPIRY_NOT_APPLICABLE  3   //!< Expiry not applicable
+#define NVML_GRID_LICENSE_EXPIRY_PERMANENT       4   //!< Permanent expiry
+
+/**
+ * vGPU queryable capabilities
+ */
+typedef enum nvmlVgpuCapability_enum
+{
+    NVML_VGPU_CAP_NVLINK_P2P                    = 0,  //!< P2P over NVLink is supported
+    NVML_VGPU_CAP_GPUDIRECT                     = 1,  //!< GPUDirect capability is supported
+    // Keep this last
+    NVML_VGPU_CAP_COUNT
+} nvmlVgpuCapability_t;
 
 /** @} */
 
@@ -966,12 +1149,12 @@ typedef unsigned int nvmlVgpuInstance_t;
  */
 typedef struct nvmlVgpuInstanceUtilizationSample_st
 {
-    nvmlVgpuInstance_t vgpuInstance;    //!< vGPU Instance
-    unsigned long long timeStamp;       //!< CPU Timestamp in microseconds
-    nvmlValue_t smUtil;                 //!< SM (3D/Compute) Util Value
-    nvmlValue_t memUtil;                //!< Frame Buffer Memory Util Value
-    nvmlValue_t encUtil;                //!< Encoder Util Value
-    nvmlValue_t decUtil;                //!< Decoder Util Value
+    nvmlVgpuInstance_t  vgpuInstance;       //!< vGPU Instance
+    unsigned long long  timeStamp;          //!< CPU Timestamp in microseconds
+    nvmlValue_t         smUtil;             //!< SM (3D/Compute) Util Value
+    nvmlValue_t         memUtil;            //!< Frame Buffer Memory Util Value
+    nvmlValue_t         encUtil;            //!< Encoder Util Value
+    nvmlValue_t         decUtil;            //!< Decoder Util Value
 } nvmlVgpuInstanceUtilizationSample_t;
 
 /**
@@ -979,28 +1162,73 @@ typedef struct nvmlVgpuInstanceUtilizationSample_st
  */
 typedef struct nvmlVgpuProcessUtilizationSample_st
 {
-    nvmlVgpuInstance_t vgpuInstance;                //!< vGPU Instance
-    unsigned int pid;                               //!< PID of process running within the vGPU VM
-    char processName[NVML_VGPU_NAME_BUFFER_SIZE];   //!< Name of process running within the vGPU VM
-    unsigned long long timeStamp;                   //!< CPU Timestamp in microseconds
-    unsigned int smUtil;                            //!< SM (3D/Compute) Util Value
-    unsigned int memUtil;                           //!< Frame Buffer Memory Util Value
-    unsigned int encUtil;                           //!< Encoder Util Value
-    unsigned int decUtil;                           //!< Decoder Util Value
+    nvmlVgpuInstance_t  vgpuInstance;                               //!< vGPU Instance
+    unsigned int        pid;                                        //!< PID of process running within the vGPU VM
+    char                processName[NVML_VGPU_NAME_BUFFER_SIZE];    //!< Name of process running within the vGPU VM
+    unsigned long long  timeStamp;                                  //!< CPU Timestamp in microseconds
+    unsigned int        smUtil;                                     //!< SM (3D/Compute) Util Value
+    unsigned int        memUtil;                                    //!< Frame Buffer Memory Util Value
+    unsigned int        encUtil;                                    //!< Encoder Util Value
+    unsigned int        decUtil;                                    //!< Decoder Util Value
 } nvmlVgpuProcessUtilizationSample_t;
+
+/**
+ * Structure to store the vGPU license expiry details
+ */
+typedef struct nvmlVgpuLicenseExpiry_st
+{
+    unsigned int    year;        //!< Year of license expiry
+    unsigned short  month;       //!< Month of license expiry
+    unsigned short  day;         //!< Day of license expiry
+    unsigned short  hour;        //!< Hour of license expiry
+    unsigned short  min;         //!< Minutes of license expiry
+    unsigned short  sec;         //!< Seconds of license expiry
+    unsigned char   status;      //!< License expiry status
+} nvmlVgpuLicenseExpiry_t;
+
+/**
+ * vGPU license state
+ */
+#define NVML_GRID_LICENSE_STATE_UNKNOWN                 0   //!< Unknown state
+#define NVML_GRID_LICENSE_STATE_UNINITIALIZED           1   //!< Uninitialized state
+#define NVML_GRID_LICENSE_STATE_UNLICENSED_UNRESTRICTED 2   //!< Unlicensed unrestricted state
+#define NVML_GRID_LICENSE_STATE_UNLICENSED_RESTRICTED   3   //!< Unlicensed restricted state
+#define NVML_GRID_LICENSE_STATE_UNLICENSED              4   //!< Unlicensed state
+#define NVML_GRID_LICENSE_STATE_LICENSED                5   //!< Licensed state
+
+typedef struct nvmlVgpuLicenseInfo_st
+{
+    unsigned char               isLicensed;     //!< License status
+    nvmlVgpuLicenseExpiry_t     licenseExpiry;  //!< License expiry information
+    unsigned int                currentState;   //!< Current license state
+} nvmlVgpuLicenseInfo_t;
 
 /**
  * Structure to store utilization value and process Id
  */
 typedef struct nvmlProcessUtilizationSample_st
 {
-    unsigned int pid;                   //!< PID of process
-    unsigned long long timeStamp;       //!< CPU Timestamp in microseconds
-    unsigned int smUtil;                //!< SM (3D/Compute) Util Value
-    unsigned int memUtil;               //!< Frame Buffer Memory Util Value
-    unsigned int encUtil;               //!< Encoder Util Value
-    unsigned int decUtil;               //!< Decoder Util Value
+    unsigned int        pid;            //!< PID of process
+    unsigned long long  timeStamp;      //!< CPU Timestamp in microseconds
+    unsigned int        smUtil;         //!< SM (3D/Compute) Util Value
+    unsigned int        memUtil;        //!< Frame Buffer Memory Util Value
+    unsigned int        encUtil;        //!< Encoder Util Value
+    unsigned int        decUtil;        //!< Decoder Util Value
 } nvmlProcessUtilizationSample_t;
+
+/**
+ * Structure to store license expiry date and time values
+ */
+typedef struct nvmlGridLicenseExpiry_st
+{
+    unsigned int   year;        //!< Year value of license expiry
+    unsigned short month;       //!< Month value of license expiry
+    unsigned short day;         //!< Day value of license expiry
+    unsigned short hour;        //!< Hour value of license expiry
+    unsigned short min;         //!< Minutes value of license expiry
+    unsigned short sec;         //!< Seconds value of license expiry
+    unsigned char  status;      //!< License expiry status
+} nvmlGridLicenseExpiry_t;
 
 /**
  * Structure containing vGPU software licensable feature information
@@ -1010,8 +1238,9 @@ typedef struct nvmlGridLicensableFeature_st
     nvmlGridLicenseFeatureCode_t    featureCode;                                 //!< Licensed feature code
     unsigned int                    featureState;                                //!< Non-zero if feature is currently licensed, otherwise zero
     char                            licenseInfo[NVML_GRID_LICENSE_BUFFER_SIZE];  //!< Deprecated.
-    char                            productName[NVML_GRID_LICENSE_BUFFER_SIZE];
+    char                            productName[NVML_GRID_LICENSE_BUFFER_SIZE];  //!< Product name of feature
     unsigned int                    featureEnabled;                              //!< Non-zero if feature is enabled, otherwise zero
+    nvmlGridLicenseExpiry_t         licenseExpiry;                               //!< License expiry structure containing date and time
 } nvmlGridLicensableFeature_t;
 
 /**
@@ -1023,6 +1252,11 @@ typedef struct nvmlGridLicensableFeatures_st
     unsigned int                licensableFeaturesCount;                                      //!< Entries returned in \a gridLicensableFeatures array
     nvmlGridLicensableFeature_t gridLicensableFeatures[NVML_GRID_LICENSE_FEATURE_MAX_COUNT];  //!< Array of vGPU software licensable features.
 } nvmlGridLicensableFeatures_t;
+
+/**
+ * GSP firmware
+ */
+#define NVML_GSP_FIRMWARE_VERSION_BUF_SIZE 0x40
 
 /**
  * Simplified chip architecture
@@ -1038,6 +1272,62 @@ typedef struct nvmlGridLicensableFeatures_st
 #define NVML_DEVICE_ARCH_UNKNOWN   0xffffffff // Anything else, presumably something newer
 
 typedef unsigned int nvmlDeviceArchitecture_t;
+
+/**
+ * PCI bus types
+ */
+#define NVML_BUS_TYPE_UNKNOWN  0
+#define NVML_BUS_TYPE_PCI      1
+#define NVML_BUS_TYPE_PCIE     2
+#define NVML_BUS_TYPE_FPCI     3
+#define NVML_BUS_TYPE_AGP      4
+
+typedef unsigned int nvmlBusType_t;
+
+/**
+ * Device Power Source
+ */
+#define NVML_POWER_SOURCE_AC      0x00000000
+#define NVML_POWER_SOURCE_BATTERY 0x00000001
+
+typedef unsigned int nvmlPowerSource_t;
+
+/*
+ * Device PCIE link Max Speed
+ */
+#define NVML_PCIE_LINK_MAX_SPEED_INVALID   0x00000000
+#define NVML_PCIE_LINK_MAX_SPEED_2500MBPS  0x00000001
+#define NVML_PCIE_LINK_MAX_SPEED_5000MBPS  0x00000002
+#define NVML_PCIE_LINK_MAX_SPEED_8000MBPS  0x00000003
+#define NVML_PCIE_LINK_MAX_SPEED_16000MBPS 0x00000004
+#define NVML_PCIE_LINK_MAX_SPEED_32000MBPS 0x00000005
+
+/*
+ * Adaptive clocking status
+ */
+#define NVML_ADAPTIVE_CLOCKING_INFO_STATUS_DISABLED 0x00000000
+#define NVML_ADAPTIVE_CLOCKING_INFO_STATUS_ENABLED  0x00000001
+
+#define NVML_MAX_GPU_UTILIZATIONS 8
+typedef enum nvmlGpuUtilizationDomainId_t
+{
+    NVML_GPU_UTILIZATION_DOMAIN_GPU    = 0, //!< Graphics engine domain
+    NVML_GPU_UTILIZATION_DOMAIN_FB     = 1, //!< Frame buffer domain
+    NVML_GPU_UTILIZATION_DOMAIN_VID    = 2, //!< Video engine domain
+    NVML_GPU_UTILIZATION_DOMAIN_BUS    = 3, //!< Bus interface domain
+} nvmlGpuUtilizationDomainId_t;
+
+typedef struct nvmlGpuDynamicPstatesInfo_st
+{
+    unsigned int       flags;          //!< Reserved for future use
+    struct
+    {
+        unsigned int   bIsPresent;     //!< Set if this utilization domain is present on this GPU
+        unsigned int   percentage;     //!< Percentage of time where the domain is considered busy in the last 1-second interval
+        unsigned int   incThreshold;   //!< Utilization threshold that can trigger a perf-increasing P-State change when crossed
+        unsigned int   decThreshold;   //!< Utilization threshold that can trigger a perf-decreasing P-State change when crossed
+    } utilization[NVML_MAX_GPU_UTILIZATIONS];
+} nvmlGpuDynamicPstatesInfo_t;
 
 /** @} */
 /** @} */
@@ -1278,7 +1568,26 @@ typedef unsigned int nvmlDeviceArchitecture_t;
  */
 #define NVML_FI_DEV_NVSWITCH_CONNECTED_LINK_COUNT   147  //!< Number of NVLinks connected to NVSwitch
 
-#define NVML_FI_MAX 148 //!< One greater than the largest field ID defined above
+/* NvLink ECC Data Error Counters
+ *
+ * Lane ID needs to be specified in the scopeId field in nvmlFieldValue_t.
+ *
+ */
+#define NVML_FI_DEV_NVLINK_ECC_DATA_ERROR_COUNT_L0    148 //!< NVLink data ECC Error Counter for Link 0
+#define NVML_FI_DEV_NVLINK_ECC_DATA_ERROR_COUNT_L1    149 //!< NVLink data ECC Error Counter for Link 1
+#define NVML_FI_DEV_NVLINK_ECC_DATA_ERROR_COUNT_L2    150 //!< NVLink data ECC Error Counter for Link 2
+#define NVML_FI_DEV_NVLINK_ECC_DATA_ERROR_COUNT_L3    151 //!< NVLink data ECC Error Counter for Link 3
+#define NVML_FI_DEV_NVLINK_ECC_DATA_ERROR_COUNT_L4    152 //!< NVLink data ECC Error Counter for Link 4
+#define NVML_FI_DEV_NVLINK_ECC_DATA_ERROR_COUNT_L5    153 //!< NVLink data ECC Error Counter for Link 5
+#define NVML_FI_DEV_NVLINK_ECC_DATA_ERROR_COUNT_L6    154 //!< NVLink data ECC Error Counter for Link 6
+#define NVML_FI_DEV_NVLINK_ECC_DATA_ERROR_COUNT_L7    155 //!< NVLink data ECC Error Counter for Link 7
+#define NVML_FI_DEV_NVLINK_ECC_DATA_ERROR_COUNT_L8    156 //!< NVLink data ECC Error Counter for Link 8
+#define NVML_FI_DEV_NVLINK_ECC_DATA_ERROR_COUNT_L9    157 //!< NVLink data ECC Error Counter for Link 9
+#define NVML_FI_DEV_NVLINK_ECC_DATA_ERROR_COUNT_L10   158 //!< NVLink data ECC Error Counter for Link 10
+#define NVML_FI_DEV_NVLINK_ECC_DATA_ERROR_COUNT_L11   159 //!< NVLink data ECC Error Counter for Link 11
+#define NVML_FI_DEV_NVLINK_ECC_DATA_ERROR_COUNT_TOTAL 160 //!< NvLink data ECC Error Counter total for all Links
+
+#define NVML_FI_MAX 161 //!< One greater than the largest field ID defined above
 
 /**
  * Information for a Field Value Sample
@@ -1305,47 +1614,47 @@ typedef struct nvmlFieldValue_st
 
 typedef struct nvmlUnit_st* nvmlUnit_t;
 
-/** 
- * Description of HWBC entry 
+/**
+ * Description of HWBC entry
  */
-typedef struct nvmlHwbcEntry_st 
+typedef struct nvmlHwbcEntry_st
 {
     unsigned int hwbcId;
     char firmwareVersion[32];
 } nvmlHwbcEntry_t;
 
-/** 
- * Fan state enum. 
+/**
+ * Fan state enum.
  */
-typedef enum nvmlFanState_enum 
+typedef enum nvmlFanState_enum
 {
     NVML_FAN_NORMAL       = 0,     //!< Fan is working properly
     NVML_FAN_FAILED       = 1      //!< Fan has failed
 } nvmlFanState_t;
 
-/** 
- * Led color enum. 
+/**
+ * Led color enum.
  */
-typedef enum nvmlLedColor_enum 
+typedef enum nvmlLedColor_enum
 {
     NVML_LED_COLOR_GREEN       = 0,     //!< GREEN, indicates good health
     NVML_LED_COLOR_AMBER       = 1      //!< AMBER, indicates problem
 } nvmlLedColor_t;
 
 
-/** 
+/**
  * LED states for an S-class unit.
  */
-typedef struct nvmlLedState_st 
+typedef struct nvmlLedState_st
 {
     char cause[256];               //!< If amber, a text description of the cause
     nvmlLedColor_t color;          //!< GREEN or AMBER
 } nvmlLedState_t;
 
-/** 
+/**
  * Static S-class unit info.
  */
-typedef struct nvmlUnitInfo_st 
+typedef struct nvmlUnitInfo_st
 {
     char name[96];                      //!< Product name
     char id[96];                        //!< Product identifier
@@ -1353,11 +1662,11 @@ typedef struct nvmlUnitInfo_st
     char firmwareVersion[96];           //!< Firmware version
 } nvmlUnitInfo_t;
 
-/** 
+/**
  * Power usage information for an S-class unit.
  * The power supply state is a human readable string that equals "Normal" or contains
  * a combination of "Abnormal" plus one or more of the following:
- *    
+ *
  *    - High voltage
  *    - Fan failure
  *    - Heatsink temperature
@@ -1366,9 +1675,9 @@ typedef struct nvmlUnitInfo_st
  *    - Low-voltage
  *    - SI2C remote off command
  *    - MOD_DISABLE input
- *    - Short pin transition 
+ *    - Short pin transition
 */
-typedef struct nvmlPSUInfo_st 
+typedef struct nvmlPSUInfo_st
 {
     char state[256];                 //!< The power supply state
     unsigned int current;            //!< PSU current (A)
@@ -1376,19 +1685,19 @@ typedef struct nvmlPSUInfo_st
     unsigned int power;              //!< PSU power draw (W)
 } nvmlPSUInfo_t;
 
-/** 
+/**
  * Fan speed reading for a single fan in an S-class unit.
  */
-typedef struct nvmlUnitFanInfo_st 
+typedef struct nvmlUnitFanInfo_st
 {
     unsigned int speed;              //!< Fan speed (RPM)
     nvmlFanState_t state;            //!< Flag that indicates whether fan is working properly
 } nvmlUnitFanInfo_t;
 
-/** 
+/**
  * Fan speed readings for an entire S-class unit.
  */
-typedef struct nvmlUnitFanSpeeds_st 
+typedef struct nvmlUnitFanSpeeds_st
 {
     nvmlUnitFanInfo_t fans[24];      //!< Fan speed data for each fan
     unsigned int count;              //!< Number of fans in unit
@@ -1397,12 +1706,12 @@ typedef struct nvmlUnitFanSpeeds_st
 /** @} */
 
 /***************************************************************************************************/
-/** @addtogroup nvmlEvents 
+/** @addtogroup nvmlEvents
  *  @{
  */
 /***************************************************************************************************/
 
-/** 
+/**
  * Handle to an event set
  */
 typedef struct nvmlEventSet_st* nvmlEventSet_t;
@@ -1412,7 +1721,7 @@ typedef struct nvmlEventSet_st* nvmlEventSet_t;
  * Event Types which user can be notified about.
  * See description of particular functions for details.
  *
- * See \ref nvmlDeviceRegisterEvents and \ref nvmlDeviceGetSupportedEventTypes to check which devices 
+ * See \ref nvmlDeviceRegisterEvents and \ref nvmlDeviceGetSupportedEventTypes to check which devices
  * support each event.
  *
  * Types can be combined with bitwise or operator '|' when passed to \ref nvmlDeviceRegisterEvents
@@ -1467,7 +1776,7 @@ typedef struct nvmlEventSet_st* nvmlEventSet_t;
         )
 /** @} */
 
-/** 
+/**
  * Information about occurred event
  */
 typedef struct nvmlEventData_st
@@ -1504,13 +1813,13 @@ typedef struct nvmlEventData_st
  */
 #define nvmlClocksThrottleReasonApplicationsClocksSetting 0x0000000000000002LL
 
-/** 
- * @deprecated Renamed to \ref nvmlClocksThrottleReasonApplicationsClocksSetting 
+/**
+ * @deprecated Renamed to \ref nvmlClocksThrottleReasonApplicationsClocksSetting
  *             as the name describes the situation more accurately.
  */
-#define nvmlClocksThrottleReasonUserDefinedClocks         nvmlClocksThrottleReasonApplicationsClocksSetting 
+#define nvmlClocksThrottleReasonUserDefinedClocks         nvmlClocksThrottleReasonApplicationsClocksSetting
 
-/** SW Power Scaling algorithm is reducing the clocks below requested clocks 
+/** SW Power Scaling algorithm is reducing the clocks below requested clocks
  *
  * @see nvmlDeviceGetPowerUsage
  * @see nvmlDeviceSetPowerManagementLimit
@@ -1519,7 +1828,7 @@ typedef struct nvmlEventData_st
 #define nvmlClocksThrottleReasonSwPowerCap                0x0000000000000004LL
 
 /** HW Slowdown (reducing the core clocks by a factor of 2 or more) is engaged
- * 
+ *
  * This is an indicator of:
  *   - temperature being too high
  *   - External Power Brake Assertion is triggered (e.g. by the system power supply)
@@ -1554,7 +1863,7 @@ typedef struct nvmlEventData_st
 #define nvmlClocksThrottleReasonSwThermalSlowdown         0x0000000000000020LL
 
 /** HW Thermal Slowdown (reducing the core clocks by a factor of 2 or more) is engaged
- * 
+ *
  * This is an indicator of:
  *   - temperature being too high
  *
@@ -1565,7 +1874,7 @@ typedef struct nvmlEventData_st
 #define nvmlClocksThrottleReasonHwThermalSlowdown         0x0000000000000040LL
 
 /** HW Power Brake Slowdown (reducing the core clocks by a factor of 2 or more) is engaged
- * 
+ *
  * This is an indicator of:
  *   - External Power Brake Assertion being triggered (e.g. by the system power supply)
  *
@@ -1587,7 +1896,7 @@ typedef struct nvmlEventData_st
  * */
 #define nvmlClocksThrottleReasonNone                      0x0000000000000000LL
 
-/** Bit mask representing all supported clocks throttling reasons 
+/** Bit mask representing all supported clocks throttling reasons
  * New reasons might be added to this list in the future
  */
 #define nvmlClocksThrottleReasonAll (nvmlClocksThrottleReasonNone \
@@ -1609,7 +1918,7 @@ typedef struct nvmlEventData_st
  *
  *  Set of APIs designed to provide per process information about usage of GPU.
  *
- *  @note All accounting statistics and accounting mode live in nvidia driver and reset 
+ *  @note All accounting statistics and accounting mode live in nvidia driver and reset
  *        to default (Disabled) when driver unloads.
  *        It is advised to run with persistence mode enabled.
  *
@@ -1625,19 +1934,19 @@ typedef struct nvmlAccountingStats_st {
                                                 //! Utilization stats just like returned by \ref nvmlDeviceGetUtilizationRates but for the life time of a
                                                 //! process (not just the last sample period).
                                                 //! Set to NVML_VALUE_NOT_AVAILABLE if nvmlDeviceGetUtilizationRates is not supported
-    
+
     unsigned int memoryUtilization;             //!< Percent of time over the process's lifetime during which global (device) memory was being read or written.
                                                 //! Set to NVML_VALUE_NOT_AVAILABLE if nvmlDeviceGetUtilizationRates is not supported
-    
+
     unsigned long long maxMemoryUsage;          //!< Maximum total memory in bytes that was ever allocated by the process.
                                                 //! Set to NVML_VALUE_NOT_AVAILABLE if nvmlProcessInfo_t->usedGpuMemory is not supported
-    
 
-    unsigned long long time;                    //!< Amount of time in ms during which the compute context was active. The time is reported as 0 if 
+
+    unsigned long long time;                    //!< Amount of time in ms during which the compute context was active. The time is reported as 0 if
                                                 //!< the process is not terminated
-    
+
     unsigned long long startTime;               //!< CPU Timestamp in usec representing start time for the process
-    
+
     unsigned int isRunning;                     //!< Flag to represent if the process is running (1 for running, 0 for terminated)
 
     unsigned int reserved[5];                   //!< Reserved for future use
@@ -1657,7 +1966,7 @@ typedef struct nvmlAccountingStats_st {
 typedef enum nvmlEncoderQueryType_enum
 {
     NVML_ENCODER_QUERY_H264 = 0,        //!< H264 encoder
-    NVML_ENCODER_QUERY_HEVC = 1,        //!< HEVC encoder
+    NVML_ENCODER_QUERY_HEVC = 1         //!< HEVC encoder
 }nvmlEncoderType_t;
 
 /**
@@ -1692,7 +2001,7 @@ typedef enum nvmlFBCSessionType_enum
     NVML_FBC_SESSION_TYPE_TOSYS,           //!< ToSys
     NVML_FBC_SESSION_TYPE_CUDA,            //!< Cuda
     NVML_FBC_SESSION_TYPE_VID,             //!< Vid
-    NVML_FBC_SESSION_TYPE_HWENC,           //!< HEnc
+    NVML_FBC_SESSION_TYPE_HWENC            //!< HEnc
 } nvmlFBCSessionType_t;
 
 /**
@@ -1744,7 +2053,7 @@ typedef struct nvmlFBCSessionInfo_st
 typedef enum nvmlDetachGpuState_enum
 {
     NVML_DETACH_GPU_KEEP         = 0,
-    NVML_DETACH_GPU_REMOVE,
+    NVML_DETACH_GPU_REMOVE
 } nvmlDetachGpuState_t;
 
 /**
@@ -1753,7 +2062,7 @@ typedef enum nvmlDetachGpuState_enum
 typedef enum nvmlPcieLinkState_enum
 {
     NVML_PCIE_LINK_KEEP         = 0,
-    NVML_PCIE_LINK_SHUT_DOWN,
+    NVML_PCIE_LINK_SHUT_DOWN
 } nvmlPcieLinkState_t;
 
 /** @} */
@@ -1761,7 +2070,7 @@ typedef enum nvmlPcieLinkState_enum
 /***************************************************************************************************/
 /** @defgroup nvmlInitializationAndCleanup Initialization and Cleanup
  * This chapter describes the methods that handle NVML initialization and cleanup.
- * It is the user's responsibility to call \ref nvmlInit_v2() before calling any other methods, and 
+ * It is the user's responsibility to call \ref nvmlInit_v2() before calling any other methods, and
  * nvmlShutdown() once NVML is no longer being used.
  *  @{
  */
@@ -1777,21 +2086,21 @@ typedef enum nvmlPcieLinkState_enum
  *       modifying the behaviour of nvmlInit().
  * \note In NVML 5.319 new nvmlInit_v2 has replaced nvmlInit"_v1" (default in NVML 4.304 and older) that
  *       did initialize all GPU devices in the system.
- *       
+ *
  * This allows NVML to communicate with a GPU
  * when other GPUs in the system are unstable or in a bad state.  When using this API, GPUs are
  * discovered and initialized in nvmlDeviceGetHandleBy* functions instead.
- * 
+ *
  * \note To contrast nvmlInit_v2 with nvmlInit"_v1", NVML 4.304 nvmlInit"_v1" will fail when any detected GPU is in
  *       a bad or unstable state.
- * 
+ *
  * For all products.
  *
  * This method, should be called once before invoking any other methods in the library.
  * A reference count of the number of initializations is maintained.  Shutdown only occurs
  * when the reference count reaches zero.
- * 
- * @return 
+ *
+ * @return
  *         - \ref NVML_SUCCESS                   if NVML has been properly initialized
  *         - \ref NVML_ERROR_DRIVER_NOT_LOADED   if NVIDIA driver is not running
  *         - \ref NVML_ERROR_NO_PERMISSION       if NVML does not have permission to talk to the driver
@@ -1803,12 +2112,12 @@ nvmlReturn_t DECLDIR nvmlInit_v2(void);
  * nvmlInitWithFlags is a variant of nvmlInit(), that allows passing a set of boolean values
  *       modifying the behaviour of nvmlInit().
  *       Other than the "flags" parameter it is completely similar to \ref nvmlInit_v2.
- *       
+ *
  * For all products.
  *
  * @param flags                                 behaviour modifier flags
  *
- * @return 
+ * @return
  *         - \ref NVML_SUCCESS                   if NVML has been properly initialized
  *         - \ref NVML_ERROR_DRIVER_NOT_LOADED   if NVIDIA driver is not running
  *         - \ref NVML_ERROR_NO_PERMISSION       if NVML does not have permission to talk to the driver
@@ -1818,15 +2127,15 @@ nvmlReturn_t DECLDIR nvmlInitWithFlags(unsigned int flags);
 
 /**
  * Shut down NVML by releasing all GPU resources previously allocated with \ref nvmlInit_v2().
- * 
+ *
  * For all products.
  *
  * This method should be called after NVML work is done, once for each call to \ref nvmlInit_v2()
  * A reference count of the number of initializations is maintained.  Shutdown only occurs
  * when the reference count reaches zero.  For backwards compatibility, no error is reported if
  * nvmlShutdown() is called more times than nvmlInit().
- * 
- * @return 
+ *
+ * @return
  *         - \ref NVML_SUCCESS                 if NVML has been properly shut down
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
@@ -1924,7 +2233,7 @@ const DECLDIR char* nvmlErrorString(nvmlReturn_t result);
 
 /**
  * Retrieves the version of the system's graphics driver.
- * 
+ *
  * For all products.
  *
  * The version identifier is an alphanumeric string.  It will not exceed 80 characters in length
@@ -1933,17 +2242,17 @@ const DECLDIR char* nvmlErrorString(nvmlReturn_t result);
  * @param version                              Reference in which to return the version identifier
  * @param length                               The maximum allowed length of the string returned in \a version
  *
- * @return 
+ * @return
  *         - \ref NVML_SUCCESS                 if \a version has been set
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a version is NULL
- *         - \ref NVML_ERROR_INSUFFICIENT_SIZE if \a length is too small 
+ *         - \ref NVML_ERROR_INSUFFICIENT_SIZE if \a length is too small
  */
 nvmlReturn_t DECLDIR nvmlSystemGetDriverVersion(char *version, unsigned int length);
 
 /**
  * Retrieves the version of the NVML library.
- * 
+ *
  * For all products.
  *
  * The version identifier is an alphanumeric string.  It will not exceed 80 characters in length
@@ -1952,10 +2261,10 @@ nvmlReturn_t DECLDIR nvmlSystemGetDriverVersion(char *version, unsigned int leng
  * @param version                              Reference in which to return the version identifier
  * @param length                               The maximum allowed length of the string returned in \a version
  *
- * @return 
+ * @return
  *         - \ref NVML_SUCCESS                 if \a version has been set
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a version is NULL
- *         - \ref NVML_ERROR_INSUFFICIENT_SIZE if \a length is too small 
+ *         - \ref NVML_ERROR_INSUFFICIENT_SIZE if \a length is too small
  */
 nvmlReturn_t DECLDIR nvmlSystemGetNVMLVersion(char *version, unsigned int length);
 
@@ -2009,8 +2318,8 @@ nvmlReturn_t DECLDIR nvmlSystemGetCudaDriverVersion_v2(int *cudaDriverVersion);
  * @param pid                                  The identifier of the process
  * @param name                                 Reference in which to return the process name
  * @param length                               The maximum allowed length of the string returned in \a name
- * 
- * @return 
+ *
+ * @return
  *         - \ref NVML_SUCCESS                 if \a name has been set
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a name is NULL or \a length is 0.
@@ -2025,7 +2334,7 @@ nvmlReturn_t DECLDIR nvmlSystemGetProcessName(unsigned int pid, char *name, unsi
 /***************************************************************************************************/
 /** @defgroup nvmlUnitQueries Unit Queries
  * This chapter describes that queries that NVML can perform against each unit. For S-class systems only.
- * In each case the device is identified with an nvmlUnit_t handle. This handle is obtained by 
+ * In each case the device is identified with an nvmlUnit_t handle. This handle is obtained by
  * calling \ref nvmlUnitGetHandleByIndex().
  *  @{
  */
@@ -2037,8 +2346,8 @@ nvmlReturn_t DECLDIR nvmlSystemGetProcessName(unsigned int pid, char *name, unsi
  * For S-class products.
  *
  * @param unitCount                            Reference in which to return the number of units
- * 
- * @return 
+ *
+ * @return
  *         - \ref NVML_SUCCESS                 if \a unitCount has been set
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a unitCount is NULL
@@ -2051,15 +2360,15 @@ nvmlReturn_t DECLDIR nvmlUnitGetCount(unsigned int *unitCount);
  *
  * For S-class products.
  *
- * Valid indices are derived from the \a unitCount returned by \ref nvmlUnitGetCount(). 
+ * Valid indices are derived from the \a unitCount returned by \ref nvmlUnitGetCount().
  *   For example, if \a unitCount is 2 the valid indices are 0 and 1, corresponding to UNIT 0 and UNIT 1.
  *
  * The order in which NVML enumerates units has no guarantees of consistency between reboots.
  *
  * @param index                                The index of the target unit, >= 0 and < \a unitCount
  * @param unit                                 Reference in which to return the unit handle
- * 
- * @return 
+ *
+ * @return
  *         - \ref NVML_SUCCESS                 if \a unit has been set
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a index is invalid or \a unit is NULL
@@ -2076,8 +2385,8 @@ nvmlReturn_t DECLDIR nvmlUnitGetHandleByIndex(unsigned int index, nvmlUnit_t *un
  *
  * @param unit                                 The identifier of the target unit
  * @param info                                 Reference in which to return the unit information
- * 
- * @return 
+ *
+ * @return
  *         - \ref NVML_SUCCESS                 if \a info has been populated
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a unit is invalid or \a info is NULL
@@ -2093,14 +2402,14 @@ nvmlReturn_t DECLDIR nvmlUnitGetUnitInfo(nvmlUnit_t unit, nvmlUnitInfo_t *info);
  *
  * @param unit                                 The identifier of the target unit
  * @param state                                Reference in which to return the current LED state
- * 
- * @return 
+ *
+ * @return
  *         - \ref NVML_SUCCESS                 if \a state has been set
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a unit is invalid or \a state is NULL
  *         - \ref NVML_ERROR_NOT_SUPPORTED     if this is not an S-class product
  *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
- * 
+ *
  * @see nvmlUnitSetLedState()
  */
 nvmlReturn_t DECLDIR nvmlUnitGetLedState(nvmlUnit_t unit, nvmlLedState_t *state);
@@ -2114,8 +2423,8 @@ nvmlReturn_t DECLDIR nvmlUnitGetLedState(nvmlUnit_t unit, nvmlLedState_t *state)
  *
  * @param unit                                 The identifier of the target unit
  * @param psu                                  Reference in which to return the PSU information
- * 
- * @return 
+ *
+ * @return
  *         - \ref NVML_SUCCESS                 if \a psu has been populated
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a unit is invalid or \a psu is NULL
@@ -2129,14 +2438,14 @@ nvmlReturn_t DECLDIR nvmlUnitGetPsuInfo(nvmlUnit_t unit, nvmlPSUInfo_t *psu);
  *
  * For S-class products.
  *
- * Depending on the product, readings may be available for intake (type=0), 
+ * Depending on the product, readings may be available for intake (type=0),
  * exhaust (type=1) and board (type=2).
  *
  * @param unit                                 The identifier of the target unit
  * @param type                                 The type of reading to take
  * @param temp                                 Reference in which to return the intake temperature
- * 
- * @return 
+ *
+ * @return
  *         - \ref NVML_SUCCESS                 if \a temp has been populated
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a unit or \a type is invalid or \a temp is NULL
@@ -2154,8 +2463,8 @@ nvmlReturn_t DECLDIR nvmlUnitGetTemperature(nvmlUnit_t unit, unsigned int type, 
  *
  * @param unit                                 The identifier of the target unit
  * @param fanSpeeds                            Reference in which to return the fan speed information
- * 
- * @return 
+ *
+ * @return
  *         - \ref NVML_SUCCESS                 if \a fanSpeeds has been populated
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a unit is invalid or \a fanSpeeds is NULL
@@ -2175,8 +2484,8 @@ nvmlReturn_t DECLDIR nvmlUnitGetFanSpeedInfo(nvmlUnit_t unit, nvmlUnitFanSpeeds_
  * @param deviceCount                          Reference in which to provide the \a devices array size, and
  *                                             to return the number of attached GPU devices
  * @param devices                              Reference in which to return the references to the attached GPU devices
- * 
- * @return 
+ *
+ * @return
  *         - \ref NVML_SUCCESS                 if \a deviceCount and \a devices have been populated
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INSUFFICIENT_SIZE if \a deviceCount indicates that the \a devices array is too small
@@ -2187,7 +2496,7 @@ nvmlReturn_t DECLDIR nvmlUnitGetDevices(nvmlUnit_t unit, unsigned int *deviceCou
 
 /**
  * Retrieves the IDs and firmware versions for any Host Interface Cards (HICs) in the system.
- * 
+ *
  * For S-class products.
  *
  * The \a hwbcCount argument is expected to be set to the size of the input \a hwbcEntries array.
@@ -2196,7 +2505,7 @@ nvmlReturn_t DECLDIR nvmlUnitGetDevices(nvmlUnit_t unit, unsigned int *deviceCou
  * @param hwbcCount                            Size of hwbcEntries array
  * @param hwbcEntries                          Array holding information about hwbc
  *
- * @return 
+ * @return
  *         - \ref NVML_SUCCESS                 if \a hwbcCount and \a hwbcEntries have been populated
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if either \a hwbcCount or \a hwbcEntries is NULL
@@ -2208,16 +2517,16 @@ nvmlReturn_t DECLDIR nvmlSystemGetHicVersion(unsigned int *hwbcCount, nvmlHwbcEn
 /***************************************************************************************************/
 /** @defgroup nvmlDeviceQueries Device Queries
  * This chapter describes that queries that NVML can perform against each device.
- * In each case the device is identified with an nvmlDevice_t handle. This handle is obtained by  
+ * In each case the device is identified with an nvmlDevice_t handle. This handle is obtained by
  * calling one of \ref nvmlDeviceGetHandleByIndex_v2(), \ref nvmlDeviceGetHandleBySerial(),
- * \ref nvmlDeviceGetHandleByPciBusId_v2(). or \ref nvmlDeviceGetHandleByUUID(). 
+ * \ref nvmlDeviceGetHandleByPciBusId_v2(). or \ref nvmlDeviceGetHandleByUUID().
  *  @{
  */
 /***************************************************************************************************/
 
  /**
  * Retrieves the number of compute devices in the system. A compute device is a single GPU.
- * 
+ *
  * For all products.
  *
  * Note: New nvmlDeviceGetCount_v2 (default in NVML 5.319) returns count of all devices in the system
@@ -2228,8 +2537,8 @@ nvmlReturn_t DECLDIR nvmlSystemGetHicVersion(unsigned int *hwbcCount, nvmlHwbcEn
  *       Old _v1 version of nvmlDeviceGetCount doesn't count devices that NVML has no permission to talk to.
  *
  * @param deviceCount                          Reference in which to return the number of accessible devices
- * 
- * @return 
+ *
+ * @return
  *         - \ref NVML_SUCCESS                 if \a deviceCount has been set
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a deviceCount is NULL
@@ -2259,15 +2568,15 @@ nvmlReturn_t DECLDIR nvmlDeviceGetAttributes_v2(nvmlDevice_t device, nvmlDeviceA
 
 /**
  * Acquire the handle for a particular device, based on its index.
- * 
+ *
  * For all products.
  *
- * Valid indices are derived from the \a accessibleDevices count returned by 
- *   \ref nvmlDeviceGetCount_v2(). For example, if \a accessibleDevices is 2 the valid indices  
+ * Valid indices are derived from the \a accessibleDevices count returned by
+ *   \ref nvmlDeviceGetCount_v2(). For example, if \a accessibleDevices is 2 the valid indices
  *   are 0 and 1, corresponding to GPU 0 and GPU 1.
  *
  * The order in which NVML enumerates devices has no guarantees of consistency between reboots. For that reason it
- *   is recommended that devices be looked up by their PCI ids or UUID. See 
+ *   is recommended that devices be looked up by their PCI ids or UUID. See
  *   \ref nvmlDeviceGetHandleByUUID() and \ref nvmlDeviceGetHandleByPciBusId_v2().
  *
  * Note: The NVML index may not correlate with other APIs, such as the CUDA device index.
@@ -2275,7 +2584,7 @@ nvmlReturn_t DECLDIR nvmlDeviceGetAttributes_v2(nvmlDevice_t device, nvmlDeviceA
  * Starting from NVML 5, this API causes NVML to initialize the target GPU
  * NVML may initialize additional GPUs if:
  *  - The target GPU is an SLI slave
- * 
+ *
  * Note: New nvmlDeviceGetCount_v2 (default in NVML 5.319) returns count of all devices in the system
  *       even if nvmlDeviceGetHandleByIndex_v2 returns NVML_ERROR_NO_PERMISSION for such device.
  *       Update your code to handle this error, or use NVML 4.304 or older nvml header file.
@@ -2289,8 +2598,8 @@ nvmlReturn_t DECLDIR nvmlDeviceGetAttributes_v2(nvmlDevice_t device, nvmlDeviceA
  *
  * @param index                                The index of the target GPU, >= 0 and < \a accessibleDevices
  * @param device                               Reference in which to return the device handle
- * 
- * @return 
+ *
+ * @return
  *         - \ref NVML_SUCCESS                  if \a device has been set
  *         - \ref NVML_ERROR_UNINITIALIZED      if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT   if \a index is invalid or \a device is NULL
@@ -2313,7 +2622,7 @@ nvmlReturn_t DECLDIR nvmlDeviceGetHandleByIndex_v2(unsigned int index, nvmlDevic
  * This number corresponds to the value printed directly on the board, and to the value returned by
  *   \ref nvmlDeviceGetSerial().
  *
- * @deprecated Since more than one GPU can exist on a single board this function is deprecated in favor 
+ * @deprecated Since more than one GPU can exist on a single board this function is deprecated in favor
  *             of \ref nvmlDeviceGetHandleByUUID.
  *             For dual GPU boards this function will return NVML_ERROR_INVALID_ARGUMENT.
  *
@@ -2322,8 +2631,8 @@ nvmlReturn_t DECLDIR nvmlDeviceGetHandleByIndex_v2(unsigned int index, nvmlDevic
  *
  * @param serial                               The board serial number of the target GPU
  * @param device                               Reference in which to return the device handle
- * 
- * @return 
+ *
+ * @return
  *         - \ref NVML_SUCCESS                  if \a device has been set
  *         - \ref NVML_ERROR_UNINITIALIZED      if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT   if \a serial is invalid, \a device is NULL or more than one
@@ -2346,11 +2655,11 @@ nvmlReturn_t DECLDIR nvmlDeviceGetHandleBySerial(const char *serial, nvmlDevice_
  *
  * @param uuid                                 The UUID of the target GPU or MIG instance
  * @param device                               Reference in which to return the device handle or MIG device handle
- * 
+ *
  * Starting from NVML 5, this API causes NVML to initialize the target GPU
  * NVML may initialize additional GPUs as it searches for the target GPU
  *
- * @return 
+ * @return
  *         - \ref NVML_SUCCESS                  if \a device has been set
  *         - \ref NVML_ERROR_UNINITIALIZED      if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT   if \a uuid is invalid or \a device is null
@@ -2366,7 +2675,7 @@ nvmlReturn_t DECLDIR nvmlDeviceGetHandleByUUID(const char *uuid, nvmlDevice_t *d
 
 /**
  * Acquire the handle for a particular device, based on its PCI bus id.
- * 
+ *
  * For all products.
  *
  * This value corresponds to the nvmlPciInfo_t::busId returned by \ref nvmlDeviceGetPciInfo_v3().
@@ -2375,13 +2684,13 @@ nvmlReturn_t DECLDIR nvmlDeviceGetHandleByUUID(const char *uuid, nvmlDevice_t *d
  * NVML may initialize additional GPUs if:
  *  - The target GPU is an SLI slave
  *
- * \note NVML 4.304 and older version of nvmlDeviceGetHandleByPciBusId"_v1" returns NVML_ERROR_NOT_FOUND 
+ * \note NVML 4.304 and older version of nvmlDeviceGetHandleByPciBusId"_v1" returns NVML_ERROR_NOT_FOUND
  *       instead of NVML_ERROR_NO_PERMISSION.
  *
  * @param pciBusId                             The PCI bus id of the target GPU
  * @param device                               Reference in which to return the device handle
- * 
- * @return 
+ *
+ * @return
  *         - \ref NVML_SUCCESS                  if \a device has been set
  *         - \ref NVML_ERROR_UNINITIALIZED      if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT   if \a pciBusId is invalid or \a device is NULL
@@ -2395,8 +2704,8 @@ nvmlReturn_t DECLDIR nvmlDeviceGetHandleByUUID(const char *uuid, nvmlDevice_t *d
 nvmlReturn_t DECLDIR nvmlDeviceGetHandleByPciBusId_v2(const char *pciBusId, nvmlDevice_t *device);
 
 /**
- * Retrieves the name of this device. 
- * 
+ * Retrieves the name of this device.
+ *
  * For all products.
  *
  * The name is an alphanumeric string that denotes a particular product, e.g. Tesla &tm; C2070. It will not
@@ -2409,8 +2718,8 @@ nvmlReturn_t DECLDIR nvmlDeviceGetHandleByPciBusId_v2(const char *pciBusId, nvml
  * @param device                               The identifier of the target device
  * @param name                                 Reference in which to return the product name
  * @param length                               The maximum allowed length of the string returned in \a name
- * 
- * @return 
+ *
+ * @return
  *         - \ref NVML_SUCCESS                 if \a name has been set
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid, or \a name is NULL
@@ -2443,13 +2752,13 @@ nvmlReturn_t DECLDIR nvmlDeviceGetBrand(nvmlDevice_t device, nvmlBrandType_t *ty
  * Retrieves the NVML index of this device.
  *
  * For all products.
- * 
- * Valid indices are derived from the \a accessibleDevices count returned by 
- *   \ref nvmlDeviceGetCount_v2(). For example, if \a accessibleDevices is 2 the valid indices  
+ *
+ * Valid indices are derived from the \a accessibleDevices count returned by
+ *   \ref nvmlDeviceGetCount_v2(). For example, if \a accessibleDevices is 2 the valid indices
  *   are 0 and 1, corresponding to GPU 0 and GPU 1.
  *
  * The order in which NVML enumerates devices has no guarantees of consistency between reboots. For that reason it
- *   is recommended that devices be looked up by their PCI ids or GPU UUID. See 
+ *   is recommended that devices be looked up by their PCI ids or GPU UUID. See
  *   \ref nvmlDeviceGetHandleByPciBusId_v2() and \ref nvmlDeviceGetHandleByUUID().
  *
  * When used with MIG device handles this API returns indices that can be
@@ -2461,7 +2770,7 @@ nvmlReturn_t DECLDIR nvmlDeviceGetBrand(nvmlDevice_t device, nvmlBrandType_t *ty
  * @param device                               The identifier of the target device
  * @param index                                Reference in which to return the NVML index of the device
  *
- * @return 
+ * @return
  *         - \ref NVML_SUCCESS                 if \a index has been set
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid, or \a index is NULL
@@ -2485,8 +2794,8 @@ nvmlReturn_t DECLDIR nvmlDeviceGetIndex(nvmlDevice_t device, unsigned int *index
  * @param device                               The identifier of the target device
  * @param serial                               Reference in which to return the board/module serial number
  * @param length                               The maximum allowed length of the string returned in \a serial
- * 
- * @return 
+ *
+ * @return
  *         - \ref NVML_SUCCESS                 if \a serial has been set
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid, or \a serial is NULL
@@ -2559,11 +2868,11 @@ nvmlReturn_t DECLDIR nvmlDeviceGetMemoryAffinity(nvmlDevice_t device, unsigned i
  *
  * @param device                               The identifier of the target device
  * @param cpuSetSize                           The size of the cpuSet array that is safe to access
- * @param cpuSet                               Array reference in which to return a bitmask of CPUs, 64 CPUs per 
+ * @param cpuSet                               Array reference in which to return a bitmask of CPUs, 64 CPUs per
  *                                                 unsigned long on 64-bit machines, 32 on 32-bit machines
  * @param scope                                Scope that change the default behavior
  *
- * @return 
+ * @return
  *         - \ref NVML_SUCCESS                 if \a cpuAffinity has been filled
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid, cpuSetSize == 0, cpuSet is NULL or sope is invalid
@@ -2585,10 +2894,10 @@ nvmlReturn_t DECLDIR nvmlDeviceGetCpuAffinityWithinScope(nvmlDevice_t device, un
  *
  * @param device                               The identifier of the target device
  * @param cpuSetSize                           The size of the cpuSet array that is safe to access
- * @param cpuSet                               Array reference in which to return a bitmask of CPUs, 64 CPUs per 
+ * @param cpuSet                               Array reference in which to return a bitmask of CPUs, 64 CPUs per
  *                                                 unsigned long on 64-bit machines, 32 on 32-bit machines
  *
- * @return 
+ * @return
  *         - \ref NVML_SUCCESS                 if \a cpuAffinity has been filled
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid, cpuSetSize == 0, or cpuSet is NULL
@@ -2599,8 +2908,8 @@ nvmlReturn_t DECLDIR nvmlDeviceGetCpuAffinityWithinScope(nvmlDevice_t device, un
 nvmlReturn_t DECLDIR nvmlDeviceGetCpuAffinity(nvmlDevice_t device, unsigned int cpuSetSize, unsigned long *cpuSet);
 
 /**
- * Sets the ideal affinity for the calling thread and device using the guidelines 
- * given in nvmlDeviceGetCpuAffinity().  Note, this is a change as of version 8.0.  
+ * Sets the ideal affinity for the calling thread and device using the guidelines
+ * given in nvmlDeviceGetCpuAffinity().  Note, this is a change as of version 8.0.
  * Older versions set the affinity for a calling process and all children.
  * Currently supports up to 1024 processors.
  *
@@ -2609,7 +2918,7 @@ nvmlReturn_t DECLDIR nvmlDeviceGetCpuAffinity(nvmlDevice_t device, unsigned int 
  *
  * @param device                               The identifier of the target device
  *
- * @return 
+ * @return
  *         - \ref NVML_SUCCESS                 if the calling process has been successfully bound
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid
@@ -2628,7 +2937,7 @@ nvmlReturn_t DECLDIR nvmlDeviceSetCpuAffinity(nvmlDevice_t device);
  *
  * @param device                               The identifier of the target device
  *
- * @return 
+ * @return
  *         - \ref NVML_SUCCESS                 if the calling process has been successfully unbound
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
@@ -2662,7 +2971,7 @@ nvmlReturn_t DECLDIR nvmlDeviceGetTopologyCommonAncestor(nvmlDevice_t device1, n
  *
  * @param device                               The identifier of the first device
  * @param level                                The \ref nvmlGpuTopologyLevel_t level to search for other GPUs
- * @param count                                When zero, is set to the number of matching GPUs such that \a deviceArray 
+ * @param count                                When zero, is set to the number of matching GPUs such that \a deviceArray
  *                                             can be malloc'd.  When non-zero, \a deviceArray will be filled with \a count
  *                                             number of device handles.
  * @param deviceArray                          An array of device handles for GPUs found at \a level
@@ -2681,7 +2990,7 @@ nvmlReturn_t DECLDIR nvmlDeviceGetTopologyNearestGpus(nvmlDevice_t device, nvmlG
  * Supported on Linux only.
  *
  * @param cpuNumber                            The CPU number
- * @param count                                When zero, is set to the number of matching GPUs such that \a deviceArray 
+ * @param count                                When zero, is set to the number of matching GPUs such that \a deviceArray
  *                                             can be malloc'd.  When non-zero, \a deviceArray will be filled with \a count
  *                                             number of device handles.
  * @param deviceArray                          An array of device handles for GPUs found with affinity to \a cpuNumber
@@ -2695,18 +3004,18 @@ nvmlReturn_t DECLDIR nvmlDeviceGetTopologyNearestGpus(nvmlDevice_t device, nvmlG
 nvmlReturn_t DECLDIR nvmlSystemGetTopologyGpuSet(unsigned int cpuNumber, unsigned int *count, nvmlDevice_t *deviceArray);
 
 /**
- * Retrieve the status for a given p2p capability index between a given pair of GPU 
- * 
- * @param device1                              The first device 
+ * Retrieve the status for a given p2p capability index between a given pair of GPU
+ *
+ * @param device1                              The first device
  * @param device2                              The second device
  * @param p2pIndex                             p2p Capability Index being looked for between \a device1 and \a device2
  * @param p2pStatus                            Reference in which to return the status of the \a p2pIndex
  *                                             between \a device1 and \a device2
- * @return 
+ * @return
  *         - \ref NVML_SUCCESS         if \a p2pStatus has been populated
  *         - \ref NVML_ERROR_INVALID_ARGUMENT     if \a device1 or \a device2 or \a p2pIndex is invalid or \a p2pStatus is NULL
  *         - \ref NVML_ERROR_UNKNOWN              on any unexpected error
- */ 
+ */
 nvmlReturn_t DECLDIR nvmlDeviceGetP2PStatus(nvmlDevice_t device1, nvmlDevice_t device2, nvmlGpuP2PCapsIndex_t p2pIndex,nvmlGpuP2PStatus_t *p2pStatus);
 
 /**
@@ -2725,12 +3034,12 @@ nvmlReturn_t DECLDIR nvmlDeviceGetP2PStatus(nvmlDevice_t device1, nvmlDevice_t d
  * @param device                               The identifier of the target device
  * @param uuid                                 Reference in which to return the GPU UUID
  * @param length                               The maximum allowed length of the string returned in \a uuid
- * 
- * @return 
+ *
+ * @return
  *         - \ref NVML_SUCCESS                 if \a uuid has been set
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid, or \a uuid is NULL
- *         - \ref NVML_ERROR_INSUFFICIENT_SIZE if \a length is too small 
+ *         - \ref NVML_ERROR_INSUFFICIENT_SIZE if \a length is too small
  *         - \ref NVML_ERROR_NOT_SUPPORTED     if the device does not support this feature
  *         - \ref NVML_ERROR_GPU_IS_LOST       if the target GPU has fallen off the bus or is otherwise inaccessible
  *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
@@ -2763,7 +3072,7 @@ nvmlReturn_t DECLDIR nvmlDeviceGetUUID(nvmlDevice_t device, char *uuid, unsigned
 nvmlReturn_t DECLDIR nvmlVgpuInstanceGetMdevUUID(nvmlVgpuInstance_t vgpuInstance, char *mdevUuid, unsigned int size);
 
 /**
- * Retrieves minor number for the device. The minor number for the device is such that the Nvidia device node file for 
+ * Retrieves minor number for the device. The minor number for the device is such that the Nvidia device node file for
  * each GPU will have the form /dev/nvidia[minor number].
  *
  * For all products.
@@ -2805,7 +3114,7 @@ nvmlReturn_t DECLDIR nvmlDeviceGetBoardPartNumber(nvmlDevice_t device, char* par
  *
  * For all products with an inforom.
  *
- * Fermi and higher parts have non-volatile on-board memory for persisting device info, such as aggregate 
+ * Fermi and higher parts have non-volatile on-board memory for persisting device info, such as aggregate
  * ECC counts. The version of the data structures in this memory may change from time to time. It will not
  * exceed 16 characters in length (including the NULL terminator).
  * See \ref nvmlConstants::NVML_DEVICE_INFOROM_VERSION_BUFFER_SIZE.
@@ -2817,11 +3126,11 @@ nvmlReturn_t DECLDIR nvmlDeviceGetBoardPartNumber(nvmlDevice_t device, char* par
  * @param version                              Reference in which to return the infoROM version
  * @param length                               The maximum allowed length of the string returned in \a version
  *
- * @return 
+ * @return
  *         - \ref NVML_SUCCESS                 if \a version has been set
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a version is NULL
- *         - \ref NVML_ERROR_INSUFFICIENT_SIZE if \a length is too small 
+ *         - \ref NVML_ERROR_INSUFFICIENT_SIZE if \a length is too small
  *         - \ref NVML_ERROR_NOT_SUPPORTED     if the device does not have an infoROM
  *         - \ref NVML_ERROR_GPU_IS_LOST       if the target GPU has fallen off the bus or is otherwise inaccessible
  *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
@@ -2835,7 +3144,7 @@ nvmlReturn_t DECLDIR nvmlDeviceGetInforomVersion(nvmlDevice_t device, nvmlInforo
  *
  * For all products with an inforom.
  *
- * Image version just like VBIOS version uniquely describes the exact version of the infoROM flashed on the board 
+ * Image version just like VBIOS version uniquely describes the exact version of the infoROM flashed on the board
  * in contrast to infoROM object version which is only an indicator of supported features.
  * Version string will not exceed 16 characters in length (including the NULL terminator).
  * See \ref nvmlConstants::NVML_DEVICE_INFOROM_VERSION_BUFFER_SIZE.
@@ -2844,11 +3153,11 @@ nvmlReturn_t DECLDIR nvmlDeviceGetInforomVersion(nvmlDevice_t device, nvmlInforo
  * @param version                              Reference in which to return the infoROM image version
  * @param length                               The maximum allowed length of the string returned in \a version
  *
- * @return 
+ * @return
  *         - \ref NVML_SUCCESS                 if \a version has been set
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a version is NULL
- *         - \ref NVML_ERROR_INSUFFICIENT_SIZE if \a length is too small 
+ *         - \ref NVML_ERROR_INSUFFICIENT_SIZE if \a length is too small
  *         - \ref NVML_ERROR_NOT_SUPPORTED     if the device does not have an infoROM
  *         - \ref NVML_ERROR_GPU_IS_LOST       if the target GPU has fallen off the bus or is otherwise inaccessible
  *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
@@ -2869,14 +3178,14 @@ nvmlReturn_t DECLDIR nvmlDeviceGetInforomImageVersion(nvmlDevice_t device, char 
  * @param device                               The identifier of the target device
  * @param checksum                             Reference in which to return the infoROM configuration checksum
  *
- * @return 
+ * @return
  *         - \ref NVML_SUCCESS                 if \a checksum has been set
  *         - \ref NVML_ERROR_CORRUPTED_INFOROM if the device's checksum couldn't be retrieved due to infoROM corruption
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a checksum is NULL
  *         - \ref NVML_ERROR_NOT_SUPPORTED     if the device does not support this feature
  *         - \ref NVML_ERROR_GPU_IS_LOST       if the target GPU has fallen off the bus or is otherwise inaccessible
- *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error 
+ *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
  */
 nvmlReturn_t DECLDIR nvmlDeviceGetInforomConfigurationChecksum(nvmlDevice_t device, unsigned int *checksum);
 
@@ -2887,13 +3196,13 @@ nvmlReturn_t DECLDIR nvmlDeviceGetInforomConfigurationChecksum(nvmlDevice_t devi
  *
  * @param device                               The identifier of the target device
  *
- * @return 
+ * @return
  *         - \ref NVML_SUCCESS                 if infoROM is not corrupted
  *         - \ref NVML_ERROR_CORRUPTED_INFOROM if the device's infoROM is corrupted
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_NOT_SUPPORTED     if the device does not support this feature
  *         - \ref NVML_ERROR_GPU_IS_LOST       if the target GPU has fallen off the bus or is otherwise inaccessible
- *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error 
+ *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
  */
 nvmlReturn_t DECLDIR nvmlDeviceValidateInforom(nvmlDevice_t device);
 
@@ -2909,8 +3218,8 @@ nvmlReturn_t DECLDIR nvmlDeviceValidateInforom(nvmlDevice_t device);
  *
  * @param device                               The identifier of the target device
  * @param display                              Reference in which to return the display mode
- * 
- * @return 
+ *
+ * @return
  *         - \ref NVML_SUCCESS                 if \a display has been set
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid or \a display is NULL
@@ -2934,8 +3243,8 @@ nvmlReturn_t DECLDIR nvmlDeviceGetDisplayMode(nvmlDevice_t device, nvmlEnableSta
  *
  * @param device                               The identifier of the target device
  * @param isActive                             Reference in which to return the display active state
- * 
- * @return 
+ *
+ * @return
  *         - \ref NVML_SUCCESS                 if \a isActive has been set
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid or \a isActive is NULL
@@ -2951,15 +3260,15 @@ nvmlReturn_t DECLDIR nvmlDeviceGetDisplayActive(nvmlDevice_t device, nvmlEnableS
  * For all products.
  * For Linux only.
  *
- * When driver persistence mode is enabled the driver software state is not torn down when the last 
- * client disconnects. By default this feature is disabled. 
+ * When driver persistence mode is enabled the driver software state is not torn down when the last
+ * client disconnects. By default this feature is disabled.
  *
  * See \ref nvmlEnableState_t for details on allowed modes.
  *
  * @param device                               The identifier of the target device
  * @param mode                                 Reference in which to return the current driver persistence mode
- * 
- * @return 
+ *
+ * @return
  *         - \ref NVML_SUCCESS                 if \a mode has been set
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid or \a mode is NULL
@@ -2973,15 +3282,15 @@ nvmlReturn_t DECLDIR nvmlDeviceGetPersistenceMode(nvmlDevice_t device, nvmlEnabl
 
 /**
  * Retrieves the PCI attributes of this device.
- * 
+ *
  * For all products.
  *
  * See \ref nvmlPciInfo_t for details on the available PCI info.
  *
  * @param device                               The identifier of the target device
  * @param pci                                  Reference in which to return the PCI info
- * 
- * @return 
+ *
+ * @return
  *         - \ref NVML_SUCCESS                 if \a pci has been populated
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid or \a pci is NULL
@@ -2995,13 +3304,13 @@ nvmlReturn_t DECLDIR nvmlDeviceGetPciInfo_v3(nvmlDevice_t device, nvmlPciInfo_t 
  *
  * I.E. for a generation 2 PCIe device attached to a generation 1 PCIe bus the max link generation this function will
  * report is generation 1.
- * 
+ *
  * For Fermi &tm; or newer fully supported devices.
- * 
+ *
  * @param device                               The identifier of the target device
  * @param maxLinkGen                           Reference in which to return the max PCIe link generation
- * 
- * @return 
+ *
+ * @return
  *         - \ref NVML_SUCCESS                 if \a maxLinkGen has been populated
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid or \a maxLinkGen is null
@@ -3016,13 +3325,13 @@ nvmlReturn_t DECLDIR nvmlDeviceGetMaxPcieLinkGeneration(nvmlDevice_t device, uns
  *
  * I.E. for a device with a 16x PCIe bus width attached to a 8x PCIe system bus this function will report
  * a max link width of 8.
- * 
+ *
  * For Fermi &tm; or newer fully supported devices.
- * 
+ *
  * @param device                               The identifier of the target device
  * @param maxLinkWidth                         Reference in which to return the max PCIe link generation
- * 
- * @return 
+ *
+ * @return
  *         - \ref NVML_SUCCESS                 if \a maxLinkWidth has been populated
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid or \a maxLinkWidth is null
@@ -3034,13 +3343,13 @@ nvmlReturn_t DECLDIR nvmlDeviceGetMaxPcieLinkWidth(nvmlDevice_t device, unsigned
 
 /**
  * Retrieves the current PCIe link generation
- * 
+ *
  * For Fermi &tm; or newer fully supported devices.
- * 
+ *
  * @param device                               The identifier of the target device
  * @param currLinkGen                          Reference in which to return the current PCIe link generation
- * 
- * @return 
+ *
+ * @return
  *         - \ref NVML_SUCCESS                 if \a currLinkGen has been populated
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid or \a currLinkGen is null
@@ -3052,13 +3361,13 @@ nvmlReturn_t DECLDIR nvmlDeviceGetCurrPcieLinkGeneration(nvmlDevice_t device, un
 
 /**
  * Retrieves the current PCIe link width
- * 
+ *
  * For Fermi &tm; or newer fully supported devices.
- * 
+ *
  * @param device                               The identifier of the target device
  * @param currLinkWidth                        Reference in which to return the current PCIe link generation
- * 
- * @return 
+ *
+ * @return
  *         - \ref NVML_SUCCESS                 if \a currLinkWidth has been populated
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid or \a currLinkWidth is null
@@ -3070,7 +3379,7 @@ nvmlReturn_t DECLDIR nvmlDeviceGetCurrPcieLinkWidth(nvmlDevice_t device, unsigne
 
 /**
  * Retrieve PCIe utilization information.
- * This function is querying a byte counter over a 20ms interval and thus is the 
+ * This function is querying a byte counter over a 20ms interval and thus is the
  *   PCIe throughput over that interval.
  *
  * For Maxwell &tm; or newer fully supported devices.
@@ -3091,7 +3400,7 @@ nvmlReturn_t DECLDIR nvmlDeviceGetCurrPcieLinkWidth(nvmlDevice_t device, unsigne
  */
 nvmlReturn_t DECLDIR nvmlDeviceGetPcieThroughput(nvmlDevice_t device, nvmlPcieUtilCounter_t counter, unsigned int *value);
 
-/**  
+/**
  * Retrieve the PCIe replay counter.
  *
  * For Kepler &tm; or newer fully supported devices.
@@ -3119,8 +3428,8 @@ nvmlReturn_t DECLDIR nvmlDeviceGetPcieReplayCounter(nvmlDevice_t device, unsigne
  * @param device                               The identifier of the target device
  * @param type                                 Identify which clock domain to query
  * @param clock                                Reference in which to return the clock speed in MHz
- * 
- * @return 
+ *
+ * @return
  *         - \ref NVML_SUCCESS                 if \a clock has been set
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid or \a clock is NULL
@@ -3143,8 +3452,8 @@ nvmlReturn_t DECLDIR nvmlDeviceGetClockInfo(nvmlDevice_t device, nvmlClockType_t
  * @param device                               The identifier of the target device
  * @param type                                 Identify which clock domain to query
  * @param clock                                Reference in which to return the clock speed in MHz
- * 
- * @return 
+ *
+ * @return
  *         - \ref NVML_SUCCESS                 if \a clock has been set
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid or \a clock is NULL
@@ -3163,8 +3472,8 @@ nvmlReturn_t DECLDIR nvmlDeviceGetMaxClockInfo(nvmlDevice_t device, nvmlClockTyp
  * @param device                               The identifier of the target device
  * @param clockType                            Identify which clock domain to query
  * @param clockMHz                             Reference in which to return the clock in MHz
- * 
- * @return 
+ *
+ * @return
  *         - \ref NVML_SUCCESS                 if \a clockMHz has been set
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid or \a clockMHz is NULL or \a clockType is invalid
@@ -3175,7 +3484,7 @@ nvmlReturn_t DECLDIR nvmlDeviceGetMaxClockInfo(nvmlDevice_t device, nvmlClockTyp
 nvmlReturn_t DECLDIR nvmlDeviceGetApplicationsClock(nvmlDevice_t device, nvmlClockType_t clockType, unsigned int *clockMHz);
 
 /**
- * Retrieves the default applications clock that GPU boots with or 
+ * Retrieves the default applications clock that GPU boots with or
  * defaults to after \ref nvmlDeviceResetApplicationsClocks call.
  *
  * For Kepler &tm; or newer fully supported devices.
@@ -3183,8 +3492,8 @@ nvmlReturn_t DECLDIR nvmlDeviceGetApplicationsClock(nvmlDevice_t device, nvmlClo
  * @param device                               The identifier of the target device
  * @param clockType                            Identify which clock domain to query
  * @param clockMHz                             Reference in which to return the default clock in MHz
- * 
- * @return 
+ *
+ * @return
  *         - \ref NVML_SUCCESS                 if \a clockMHz has been set
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid or \a clockMHz is NULL or \a clockType is invalid
@@ -3212,8 +3521,8 @@ nvmlReturn_t DECLDIR nvmlDeviceGetDefaultApplicationsClock(nvmlDevice_t device, 
  * For Fermi &tm; or newer non-GeForce fully supported devices and Maxwell or newer GeForce devices.
  *
  * @param device                               The identifier of the target device
- * 
- * @return 
+ *
+ * @return
  *         - \ref NVML_SUCCESS                 if new settings were successfully set
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid
@@ -3271,9 +3580,9 @@ nvmlReturn_t DECLDIR nvmlDeviceGetMaxCustomerBoostClock(nvmlDevice_t device, nvm
  * @param count                                Reference in which to provide the \a clocksMHz array size, and
  *                                             to return the number of elements
  * @param clocksMHz                            Reference in which to return the clock in MHz
- * 
- * @return 
- *         - \ref NVML_SUCCESS                 if \a count and \a clocksMHz have been populated 
+ *
+ * @return
+ *         - \ref NVML_SUCCESS                 if \a count and \a clocksMHz have been populated
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid or \a count is NULL
  *         - \ref NVML_ERROR_NOT_SUPPORTED     if the device does not support this feature
@@ -3297,14 +3606,14 @@ nvmlReturn_t DECLDIR nvmlDeviceGetSupportedMemoryClocks(nvmlDevice_t device, uns
  * @param count                                Reference in which to provide the \a clocksMHz array size, and
  *                                             to return the number of elements
  * @param clocksMHz                            Reference in which to return the clocks in MHz
- * 
- * @return 
- *         - \ref NVML_SUCCESS                 if \a count and \a clocksMHz have been populated 
+ *
+ * @return
+ *         - \ref NVML_SUCCESS                 if \a count and \a clocksMHz have been populated
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_NOT_FOUND         if the specified \a memoryClockMHz is not a supported frequency
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid or \a clock is NULL
  *         - \ref NVML_ERROR_NOT_SUPPORTED     if the device does not support this feature
- *         - \ref NVML_ERROR_INSUFFICIENT_SIZE if \a count is too small 
+ *         - \ref NVML_ERROR_INSUFFICIENT_SIZE if \a count is too small
  *         - \ref NVML_ERROR_GPU_IS_LOST       if the target GPU has fallen off the bus or is otherwise inaccessible
  *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
  *
@@ -3409,7 +3718,7 @@ nvmlReturn_t DECLDIR nvmlDeviceSetDefaultAutoBoostedClocksEnabled(nvmlDevice_t d
  *
  * Note: The reported speed is the intended fan speed.  If the fan is physically blocked and unable to spin, the
  * output will not match the actual fan speed.
- * 
+ *
  * For all discrete products with dedicated fans.
  *
  * The fan speed is expressed as a percentage of the product's maximum noise tolerance fan speed.
@@ -3417,8 +3726,8 @@ nvmlReturn_t DECLDIR nvmlDeviceSetDefaultAutoBoostedClocksEnabled(nvmlDevice_t d
  *
  * @param device                               The identifier of the target device
  * @param speed                                Reference in which to return the fan speed percentage
- * 
- * @return 
+ *
+ * @return
  *         - \ref NVML_SUCCESS                 if \a speed has been set
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid or \a speed is NULL
@@ -3454,10 +3763,65 @@ nvmlReturn_t DECLDIR nvmlDeviceGetFanSpeed(nvmlDevice_t device, unsigned int *sp
  */
 nvmlReturn_t DECLDIR nvmlDeviceGetFanSpeed_v2(nvmlDevice_t device, unsigned int fan, unsigned int * speed);
 
+/**
+ * Sets the speed of the fan control policy to default.
+ *
+ * For all cuda-capable discrete products with fans
+ *
+ * @param device                        The identifier of the target device
+ * @param fan                           The index of the fan, starting at zero
+ *
+ * return
+ *         NVML_SUCCESS                 if speed has been adjusted
+ *         NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
+ *         NVML_ERROR_INVALID_ARGUMENT  if device is invalid
+ *         NVML_ERROR_NOT_SUPPORTED     if the device does not support this
+ *                                      (doesn't have fans)
+ *         NVML_ERROR_UNKNOWN           on any unexpected error
+ */
+nvmlReturn_t DECLDIR nvmlDeviceSetDefaultFanSpeed_v2(nvmlDevice_t device, unsigned int fan);
 
 /**
- * Retrieves the current temperature readings for the device, in degrees C. 
- * 
+ * Retrieves the min and max fan speed that user can set for the GPU fan.
+ *
+ * For all cuda-capable discrete products with fans
+ *
+ * @param device                        The identifier of the target device
+ * @param minSpeed                      The minimum speed allowed to set
+ * @param maxSpeed                      The maximum speed allowed to set
+ *
+ * return
+ *         NVML_SUCCESS                 if speed has been adjusted
+ *         NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
+ *         NVML_ERROR_INVALID_ARGUMENT  if device is invalid
+ *         NVML_ERROR_NOT_SUPPORTED     if the device does not support this
+ *                                      (doesn't have fans)
+ *         NVML_ERROR_UNKNOWN           on any unexpected error
+ */
+nvmlReturn_t DECLDIR nvmlDeviceGetMinMaxFanSpeed(nvmlDevice_t device, unsigned int * minSpeed,
+                                                 unsigned int * maxSpeed);
+
+/**
+ * Retrieves the number of fans on the device.
+ *
+ * For all discrete products with dedicated fans.
+ *
+ * @param device                               The identifier of the target device
+ * @param numFans                              The number of fans
+ *
+ * @return
+ *         - \ref NVML_SUCCESS                 if \a fan number query was successful
+ *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
+ *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid or \a numFans is NULL
+ *         - \ref NVML_ERROR_NOT_SUPPORTED     if the device does not have a fan
+ *         - \ref NVML_ERROR_GPU_IS_LOST       if the target GPU has fallen off the bus or is otherwise inaccessible
+ *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
+ */
+nvmlReturn_t DECLDIR nvmlDeviceGetNumFans(nvmlDevice_t device, unsigned int *numFans);
+
+/**
+ * Retrieves the current temperature readings for the device, in degrees C.
+ *
  * For all products.
  *
  * See \ref nvmlTemperatureSensors_t for details on available temperature sensors.
@@ -3465,8 +3829,8 @@ nvmlReturn_t DECLDIR nvmlDeviceGetFanSpeed_v2(nvmlDevice_t device, unsigned int 
  * @param device                               The identifier of the target device
  * @param sensorType                           Flag that indicates which sensor reading to retrieve
  * @param temp                                 Reference in which to return the temperature reading
- * 
- * @return 
+ *
+ * @return
  *         - \ref NVML_SUCCESS                 if \a temp has been set
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid, \a sensorType is invalid or \a temp is NULL
@@ -3517,7 +3881,24 @@ nvmlReturn_t DECLDIR nvmlDeviceGetTemperatureThreshold(nvmlDevice_t device, nvml
 nvmlReturn_t DECLDIR nvmlDeviceSetTemperatureThreshold(nvmlDevice_t device, nvmlTemperatureThresholds_t thresholdType, int *temp);
 
 /**
- * Retrieves the current performance state for the device. 
+ * Used to execute a list of thermal system instructions.
+ *
+ * @param device                               The identifier of the target device
+ * @param sensorIndex                          The index of the thermal sensor
+ * @param pThermalSettings                     Reference in which to return the thermal sensor information
+ *
+ * @return
+ *         - \ref NVML_SUCCESS                 if \a pThermalSettings has been set
+ *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
+ *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid or \a pThermalSettings is NULL
+ *         - \ref NVML_ERROR_NOT_SUPPORTED     if the device does not support this feature
+ *         - \ref NVML_ERROR_GPU_IS_LOST       if the target GPU has fallen off the bus or is otherwise inaccessible
+ *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
+ */
+nvmlReturn_t DECLDIR nvmlDeviceGetThermalSettings(nvmlDevice_t device, unsigned int sensorIndex, nvmlGpuThermalSettings_t *pThermalSettings);
+
+/**
+ * Retrieves the current performance state for the device.
  *
  * For Fermi &tm; or newer fully supported devices.
  *
@@ -3525,8 +3906,8 @@ nvmlReturn_t DECLDIR nvmlDeviceSetTemperatureThreshold(nvmlDevice_t device, nvml
  *
  * @param device                               The identifier of the target device
  * @param pState                               Reference in which to return the performance state reading
- * 
- * @return 
+ *
+ * @return
  *         - \ref NVML_SUCCESS                 if \a pState has been set
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid or \a pState is NULL
@@ -3547,7 +3928,7 @@ nvmlReturn_t DECLDIR nvmlDeviceGetPerformanceState(nvmlDevice_t device, nvmlPsta
  * @param clocksThrottleReasons                 Reference in which to return bitmask of active clocks throttle
  *                                                  reasons
  *
- * @return 
+ * @return
  *         - \ref NVML_SUCCESS                 if \a clocksThrottleReasons has been set
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid or \a clocksThrottleReasons is NULL
@@ -3561,7 +3942,7 @@ nvmlReturn_t DECLDIR nvmlDeviceGetPerformanceState(nvmlDevice_t device, nvmlPsta
 nvmlReturn_t DECLDIR nvmlDeviceGetCurrentClocksThrottleReasons(nvmlDevice_t device, unsigned long long *clocksThrottleReasons);
 
 /**
- * Retrieves bitmask of supported clocks throttle reasons that can be returned by 
+ * Retrieves bitmask of supported clocks throttle reasons that can be returned by
  * \ref nvmlDeviceGetCurrentClocksThrottleReasons
  *
  * For all fully supported products.
@@ -3572,7 +3953,7 @@ nvmlReturn_t DECLDIR nvmlDeviceGetCurrentClocksThrottleReasons(nvmlDevice_t devi
  * @param supportedClocksThrottleReasons       Reference in which to return bitmask of supported
  *                                              clocks throttle reasons
  *
- * @return 
+ * @return
  *         - \ref NVML_SUCCESS                 if \a supportedClocksThrottleReasons has been set
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid or \a supportedClocksThrottleReasons is NULL
@@ -3587,7 +3968,7 @@ nvmlReturn_t DECLDIR nvmlDeviceGetSupportedClocksThrottleReasons(nvmlDevice_t de
 /**
  * Deprecated: Use \ref nvmlDeviceGetPerformanceState. This function exposes an incorrect generalization.
  *
- * Retrieve the current performance state for the device. 
+ * Retrieve the current performance state for the device.
  *
  * For Fermi &tm; or newer fully supported devices.
  *
@@ -3595,8 +3976,8 @@ nvmlReturn_t DECLDIR nvmlDeviceGetSupportedClocksThrottleReasons(nvmlDevice_t de
  *
  * @param device                               The identifier of the target device
  * @param pState                               Reference in which to return the performance state reading
- * 
- * @return 
+ *
+ * @return
  *         - \ref NVML_SUCCESS                 if \a pState has been set
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid or \a pState is NULL
@@ -3617,16 +3998,16 @@ nvmlReturn_t DECLDIR nvmlDeviceGetPowerState(nvmlDevice_t device, nvmlPstates_t 
  * For from the Kepler or newer families.
  *     - Does not require \a NVML_INFOROM_POWER object.
  *
- * This flag indicates whether any power management algorithm is currently active on the device. An 
- * enabled state does not necessarily mean the device is being actively throttled -- only that 
+ * This flag indicates whether any power management algorithm is currently active on the device. An
+ * enabled state does not necessarily mean the device is being actively throttled -- only that
  * that the driver will do so if the appropriate conditions are met.
  *
  * See \ref nvmlEnableState_t for details on allowed modes.
  *
  * @param device                               The identifier of the target device
  * @param mode                                 Reference in which to return the current power management mode
- * 
- * @return 
+ *
+ * @return
  *         - \ref NVML_SUCCESS                 if \a mode has been set
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid or \a mode is NULL
@@ -3644,13 +4025,13 @@ nvmlReturn_t DECLDIR nvmlDeviceGetPowerManagementMode(nvmlDevice_t device, nvmlE
  * The power limit defines the upper boundary for the card's power draw. If
  * the card's total power draw reaches this limit the power management algorithm kicks in.
  *
- * This reading is only available if power management mode is supported. 
+ * This reading is only available if power management mode is supported.
  * See \ref nvmlDeviceGetPowerManagementMode.
  *
  * @param device                               The identifier of the target device
  * @param limit                                Reference in which to return the power management limit in milliwatts
- * 
- * @return 
+ *
+ * @return
  *         - \ref NVML_SUCCESS                 if \a limit has been set
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid or \a limit is NULL
@@ -3668,8 +4049,8 @@ nvmlReturn_t DECLDIR nvmlDeviceGetPowerManagementLimit(nvmlDevice_t device, unsi
  * @param device                               The identifier of the target device
  * @param minLimit                             Reference in which to return the minimum power management limit in milliwatts
  * @param maxLimit                             Reference in which to return the maximum power management limit in milliwatts
- * 
- * @return 
+ *
+ * @return
  *         - \ref NVML_SUCCESS                 if \a minLimit and \a maxLimit have been set
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid or \a minLimit or \a maxLimit is NULL
@@ -3689,8 +4070,8 @@ nvmlReturn_t DECLDIR nvmlDeviceGetPowerManagementLimitConstraints(nvmlDevice_t d
  *
  * @param device                               The identifier of the target device
  * @param defaultLimit                         Reference in which to return the default power management limit in milliwatts
- * 
- * @return 
+ *
+ * @return
  *         - \ref NVML_SUCCESS                 if \a defaultLimit has been set
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid or \a defaultLimit is NULL
@@ -3711,8 +4092,8 @@ nvmlReturn_t DECLDIR nvmlDeviceGetPowerManagementDefaultLimit(nvmlDevice_t devic
  *
  * @param device                               The identifier of the target device
  * @param power                                Reference in which to return the power usage information
- * 
- * @return 
+ *
+ * @return
  *         - \ref NVML_SUCCESS                 if \a power has been populated
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid or \a power is NULL
@@ -3751,7 +4132,7 @@ nvmlReturn_t DECLDIR nvmlDeviceGetTotalEnergyConsumption(nvmlDevice_t device, un
  * @param device                           The device to communicate with
  * @param limit                            Reference in which to return the power management limit in milliwatts
  *
- * @return 
+ * @return
  *         - \ref NVML_SUCCESS                 if \a limit has been set
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid or \a limit is NULL
@@ -3771,8 +4152,8 @@ nvmlReturn_t DECLDIR nvmlDeviceGetEnforcedPowerLimit(nvmlDevice_t device, unsign
  * @param device                               The identifier of the target device
  * @param current                              Reference in which to return the current GOM
  * @param pending                              Reference in which to return the pending GOM
- * 
- * @return 
+ *
+ * @return
  *         - \ref NVML_SUCCESS                 if \a mode has been populated
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid or \a current or \a pending is NULL
@@ -3786,26 +4167,29 @@ nvmlReturn_t DECLDIR nvmlDeviceGetEnforcedPowerLimit(nvmlDevice_t device, unsign
 nvmlReturn_t DECLDIR nvmlDeviceGetGpuOperationMode(nvmlDevice_t device, nvmlGpuOperationMode_t *current, nvmlGpuOperationMode_t *pending);
 
 /**
- * Retrieves the amount of used, free and total memory available on the device, in bytes.
- * 
+ * Retrieves the amount of used, free, reserved and total memory available on the device, in bytes.
+ * The reserved amount is supported on version 2 only.
+ *
  * For all products.
  *
  * Enabling ECC reduces the amount of total available memory, due to the extra required parity bits.
  * Under WDDM most device memory is allocated and managed on startup by Windows.
  *
- * Under Linux and Windows TCC, the reported amount of used memory is equal to the sum of memory allocated 
+ * Under Linux and Windows TCC, the reported amount of used memory is equal to the sum of memory allocated
  * by all active channels on the device.
  *
- * See \ref nvmlMemory_t for details on available memory info.
+ * See \ref nvmlMemory_v2_t for details on available memory info.
  *
  * @note In MIG mode, if device handle is provided, the API returns aggregate
  *       information, only if the caller has appropriate privileges. Per-instance
  *       information can be queried by using specific MIG device handles.
+ * 
+ * @note nvmlDeviceGetMemoryInfo_v2 adds additional memory information.
  *
  * @param device                               The identifier of the target device
  * @param memory                               Reference in which to return the memory information
- * 
- * @return 
+ *
+ * @return
  *         - \ref NVML_SUCCESS                 if \a memory has been populated
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_NO_PERMISSION     if the user doesn't have permission to perform this operation
@@ -3814,6 +4198,7 @@ nvmlReturn_t DECLDIR nvmlDeviceGetGpuOperationMode(nvmlDevice_t device, nvmlGpuO
  *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
  */
 nvmlReturn_t DECLDIR nvmlDeviceGetMemoryInfo(nvmlDevice_t device, nvmlMemory_t *memory);
+nvmlReturn_t DECLDIR nvmlDeviceGetMemoryInfo_v2(nvmlDevice_t device, nvmlMemory_v2_t *memory);
 
 /**
  * Retrieves the current compute mode for the device.
@@ -3824,8 +4209,8 @@ nvmlReturn_t DECLDIR nvmlDeviceGetMemoryInfo(nvmlDevice_t device, nvmlMemory_t *
  *
  * @param device                               The identifier of the target device
  * @param mode                                 Reference in which to return the current compute mode
- * 
- * @return 
+ *
+ * @return
  *         - \ref NVML_SUCCESS                 if \a mode has been set
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid or \a mode is NULL
@@ -3876,8 +4261,8 @@ nvmlReturn_t DECLDIR nvmlDeviceGetCudaComputeCapability(nvmlDevice_t device, int
  * @param device                               The identifier of the target device
  * @param current                              Reference in which to return the current ECC mode
  * @param pending                              Reference in which to return the pending ECC mode
- * 
- * @return 
+ *
+ * @return
  *         - \ref NVML_SUCCESS                 if \a current and \a pending have been set
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid or either \a current or \a pending is NULL
@@ -3890,14 +4275,38 @@ nvmlReturn_t DECLDIR nvmlDeviceGetCudaComputeCapability(nvmlDevice_t device, int
 nvmlReturn_t DECLDIR nvmlDeviceGetEccMode(nvmlDevice_t device, nvmlEnableState_t *current, nvmlEnableState_t *pending);
 
 /**
+ * Retrieves the default ECC modes for the device.
+ *
+ * For Fermi &tm; or newer fully supported devices.
+ * Only applicable to devices with ECC.
+ * Requires \a NVML_INFOROM_ECC version 1.0 or higher.
+ *
+ * See \ref nvmlEnableState_t for details on allowed modes.
+ *
+ * @param device                               The identifier of the target device
+ * @param defaultMode                          Reference in which to return the default ECC mode
+ *
+ * @return
+ *         - \ref NVML_SUCCESS                 if \a current and \a pending have been set
+ *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
+ *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid or \a default is NULL
+ *         - \ref NVML_ERROR_NOT_SUPPORTED     if the device does not support this feature
+ *         - \ref NVML_ERROR_GPU_IS_LOST       if the target GPU has fallen off the bus or is otherwise inaccessible
+ *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
+ *
+ * @see nvmlDeviceSetEccMode()
+ */
+nvmlReturn_t DECLDIR nvmlDeviceGetDefaultEccMode(nvmlDevice_t device, nvmlEnableState_t *defaultMode);
+
+/**
  * Retrieves the device boardId from 0-N.
- * Devices with the same boardId indicate GPUs connected to the same PLX.  Use in conjunction with 
+ * Devices with the same boardId indicate GPUs connected to the same PLX.  Use in conjunction with
  *  \ref nvmlDeviceGetMultiGpuBoard() to decide if they are on the same board as well.
- *  The boardId returned is a unique ID for the current configuration.  Uniqueness and ordering across 
+ *  The boardId returned is a unique ID for the current configuration.  Uniqueness and ordering across
  *  reboots and system configurations is not guaranteed (i.e. if a Tesla K40c returns 0x100 and
- *  the two GPUs on a Tesla K10 in the same system returns 0x200 it is not guaranteed they will 
+ *  the two GPUs on a Tesla K10 in the same system returns 0x200 it is not guaranteed they will
  *  always return those values but they will always be different from each other).
- *  
+ *
  *
  * For Fermi &tm; or newer fully supported devices.
  *
@@ -3942,18 +4351,18 @@ nvmlReturn_t DECLDIR nvmlDeviceGetMultiGpuBoard(nvmlDevice_t device, unsigned in
  * Requires \a NVML_INFOROM_ECC version 1.0 or higher.
  * Requires ECC Mode to be enabled.
  *
- * The total error count is the sum of errors across each of the separate memory systems, i.e. the total set of 
+ * The total error count is the sum of errors across each of the separate memory systems, i.e. the total set of
  * errors across the entire device.
  *
  * See \ref nvmlMemoryErrorType_t for a description of available error types.\n
  * See \ref nvmlEccCounterType_t for a description of available counter types.
  *
  * @param device                               The identifier of the target device
- * @param errorType                            Flag that specifies the type of the errors. 
- * @param counterType                          Flag that specifies the counter-type of the errors. 
+ * @param errorType                            Flag that specifies the type of the errors.
+ * @param counterType                          Flag that specifies the counter-type of the errors.
  * @param eccCounts                            Reference in which to return the specified ECC errors
- * 
- * @return 
+ *
+ * @return
  *         - \ref NVML_SUCCESS                 if \a eccCounts has been set
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device, \a errorType or \a counterType is invalid, or \a eccCounts is NULL
@@ -3987,11 +4396,11 @@ nvmlReturn_t DECLDIR nvmlDeviceGetTotalEccErrors(nvmlDevice_t device, nvmlMemory
  * See \ref nvmlEccErrorCounts_t for a description of provided detailed ECC counts.
  *
  * @param device                               The identifier of the target device
- * @param errorType                            Flag that specifies the type of the errors. 
- * @param counterType                          Flag that specifies the counter-type of the errors. 
+ * @param errorType                            Flag that specifies the type of the errors.
+ * @param counterType                          Flag that specifies the counter-type of the errors.
  * @param eccCounts                            Reference in which to return the specified ECC errors
- * 
- * @return 
+ *
+ * @return
  *         - \ref NVML_SUCCESS                 if \a eccCounts has been populated
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device, \a errorType or \a counterType is invalid, or \a eccCounts is NULL
@@ -4022,14 +4431,14 @@ nvmlReturn_t DECLDIR nvmlDeviceGetDetailedEccErrors(nvmlDevice_t device, nvmlMem
  * See \ref nvmlMemoryErrorType_t for a description of available memory error types.\n
  * See \ref nvmlEccCounterType_t for a description of available counter types.\n
  * See \ref nvmlMemoryLocation_t for a description of available counter locations.\n
- * 
+ *
  * @param device                               The identifier of the target device
  * @param errorType                            Flag that specifies the type of error.
- * @param counterType                          Flag that specifies the counter-type of the errors. 
- * @param locationType                         Specifies the location of the counter. 
+ * @param counterType                          Flag that specifies the counter-type of the errors.
+ * @param locationType                         Specifies the location of the counter.
  * @param count                                Reference in which to return the ECC counter
- * 
- * @return 
+ *
+ * @return
  *         - \ref NVML_SUCCESS                 if \a count has been populated
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device, \a bitTyp,e \a counterType or \a locationType is
@@ -4056,8 +4465,8 @@ nvmlReturn_t DECLDIR nvmlDeviceGetMemoryErrorCounter(nvmlDevice_t device, nvmlMe
  *
  * @param device                               The identifier of the target device
  * @param utilization                          Reference in which to return the utilization information
- * 
- * @return 
+ *
+ * @return
  *         - \ref NVML_SUCCESS                 if \a utilization has been populated
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid or \a utilization is NULL
@@ -4096,7 +4505,7 @@ nvmlReturn_t DECLDIR nvmlDeviceGetEncoderUtilization(nvmlDevice_t device, unsign
  * @param device                            The identifier of the target device
  * @param encoderQueryType                  Type of encoder to query
  * @param encoderCapacity                   Reference to an unsigned int for the encoder capacity
- * 
+ *
  * @return
  *         - \ref NVML_SUCCESS                  if \a encoderCapacity is fetched
  *         - \ref NVML_ERROR_UNINITIALIZED      if the library has not been successfully initialized
@@ -4117,7 +4526,7 @@ nvmlReturn_t DECLDIR nvmlDeviceGetEncoderCapacity (nvmlDevice_t device, nvmlEnco
  * @param sessionCount                      Reference to an unsigned int for count of active encoder sessions
  * @param averageFps                        Reference to an unsigned int for trailing average FPS of all active sessions
  * @param averageLatency                    Reference to an unsigned int for encode latency in microseconds
- * 
+ *
  * @return
  *         - \ref NVML_SUCCESS                  if \a sessionCount, \a averageFps and \a averageLatency is fetched
  *         - \ref NVML_ERROR_UNINITIALIZED      if the library has not been successfully initialized
@@ -4146,7 +4555,7 @@ nvmlReturn_t DECLDIR nvmlDeviceGetEncoderStats (nvmlDevice_t device, unsigned in
  * @param device                            The identifier of the target device
  * @param sessionCount                      Reference to caller supplied array size, and returns the number of sessions.
  * @param sessionInfos                      Reference in which to return the session information
- * 
+ *
  * @return
  *         - \ref NVML_SUCCESS                  if \a sessionInfos is fetched
  *         - \ref NVML_ERROR_UNINITIALIZED      if the library has not been successfully initialized
@@ -4241,15 +4650,15 @@ nvmlReturn_t DECLDIR nvmlDeviceGetFBCSessions(nvmlDevice_t device, unsigned int 
  * @param device                               The identifier of the target device
  * @param current                              Reference in which to return the current driver model
  * @param pending                              Reference in which to return the pending driver model
- * 
- * @return 
+ *
+ * @return
  *         - \ref NVML_SUCCESS                 if either \a current and/or \a pending have been set
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid or both \a current and \a pending are NULL
  *         - \ref NVML_ERROR_NOT_SUPPORTED     if the platform is not windows
  *         - \ref NVML_ERROR_GPU_IS_LOST       if the target GPU has fallen off the bus or is otherwise inaccessible
  *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
- * 
+ *
  * @see nvmlDeviceSetDriverModel()
  */
 nvmlReturn_t DECLDIR nvmlDeviceGetDriverModel(nvmlDevice_t device, nvmlDriverModel_t *current, nvmlDriverModel_t *pending);
@@ -4259,18 +4668,18 @@ nvmlReturn_t DECLDIR nvmlDeviceGetDriverModel(nvmlDevice_t device, nvmlDriverMod
  *
  * For all products.
  *
- * The VBIOS version may change from time to time. It will not exceed 32 characters in length 
+ * The VBIOS version may change from time to time. It will not exceed 32 characters in length
  * (including the NULL terminator).  See \ref nvmlConstants::NVML_DEVICE_VBIOS_VERSION_BUFFER_SIZE.
  *
  * @param device                               The identifier of the target device
  * @param version                              Reference to which to return the VBIOS version
  * @param length                               The maximum allowed length of the string returned in \a version
- * 
- * @return 
+ *
+ * @return
  *         - \ref NVML_SUCCESS                 if \a version has been set
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid, or \a version is NULL
- *         - \ref NVML_ERROR_INSUFFICIENT_SIZE if \a length is too small 
+ *         - \ref NVML_ERROR_INSUFFICIENT_SIZE if \a length is too small
  *         - \ref NVML_ERROR_GPU_IS_LOST       if the target GPU has fallen off the bus or is otherwise inaccessible
  *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
  */
@@ -4278,21 +4687,21 @@ nvmlReturn_t DECLDIR nvmlDeviceGetVbiosVersion(nvmlDevice_t device, char *versio
 
 /**
  * Get Bridge Chip Information for all the bridge chips on the board.
- * 
+ *
  * For all fully supported products.
  * Only applicable to multi-GPU products.
- * 
+ *
  * @param device                                The identifier of the target device
  * @param bridgeHierarchy                       Reference to the returned bridge chip Hierarchy
- * 
- * @return 
+ *
+ * @return
  *         - \ref NVML_SUCCESS                 if bridge chip exists
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid, or \a bridgeInfo is NULL
  *         - \ref NVML_ERROR_NOT_SUPPORTED     if bridge chip not supported on the device
  *         - \ref NVML_ERROR_GPU_IS_LOST       if the target GPU has fallen off the bus or is otherwise inaccessible
  *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
- * 
+ *
  */
 nvmlReturn_t DECLDIR nvmlDeviceGetBridgeChipInfo(nvmlDevice_t device, nvmlBridgeChipHierarchy_t *bridgeHierarchy);
 
@@ -4337,7 +4746,7 @@ nvmlReturn_t DECLDIR nvmlDeviceGetBridgeChipInfo(nvmlDevice_t device, nvmlBridge
  *
  * @see \ref nvmlSystemGetProcessName
  */
-nvmlReturn_t DECLDIR nvmlDeviceGetComputeRunningProcesses_v2(nvmlDevice_t device, unsigned int *infoCount, nvmlProcessInfo_t *infos);
+nvmlReturn_t DECLDIR nvmlDeviceGetComputeRunningProcesses_v3(nvmlDevice_t device, unsigned int *infoCount, nvmlProcessInfo_t *infos);
 
 /**
  * Get information about processes with a graphics context on a device
@@ -4361,7 +4770,7 @@ nvmlReturn_t DECLDIR nvmlDeviceGetComputeRunningProcesses_v2(nvmlDevice_t device
  *       specific MIG device handles.
  *       Querying per-instance information using MIG device handles is not supported if the device is in vGPU Host virtualization mode.
  *
- * @param device                               The identifier of the target device
+ * @param device                               The device handle or MIG device handle
  * @param infoCount                            Reference in which to provide the \a infos array size, and
  *                                             to return the number of returned elements
  * @param infos                                Reference in which to return the process information
@@ -4380,7 +4789,50 @@ nvmlReturn_t DECLDIR nvmlDeviceGetComputeRunningProcesses_v2(nvmlDevice_t device
  *
  * @see \ref nvmlSystemGetProcessName
  */
-nvmlReturn_t DECLDIR nvmlDeviceGetGraphicsRunningProcesses_v2(nvmlDevice_t device, unsigned int *infoCount, nvmlProcessInfo_t *infos);
+nvmlReturn_t DECLDIR nvmlDeviceGetGraphicsRunningProcesses_v3(nvmlDevice_t device, unsigned int *infoCount, nvmlProcessInfo_t *infos);
+
+/**
+ * Get information about processes with a MPS compute context on a device
+ *
+ * For Volta &tm; or newer fully supported devices.
+ *
+ * This function returns information only about compute running processes (e.g. CUDA application which have
+ * active context) utilizing MPS. Any graphics applications (e.g. using OpenGL, DirectX) won't be listed by
+ * this function.
+ *
+ * To query the current number of running compute processes, call this function with *infoCount = 0. The
+ * return code will be NVML_ERROR_INSUFFICIENT_SIZE, or NVML_SUCCESS if none are running. For this call
+ * \a infos is allowed to be NULL.
+ *
+ * The usedGpuMemory field returned is all of the memory used by the application.
+ *
+ * Keep in mind that information returned by this call is dynamic and the number of elements might change in
+ * time. Allocate more space for \a infos table in case new compute processes are spawned.
+ * 
+ * @note In MIG mode, if device handle is provided, the API returns aggregate information, only if
+ *       the caller has appropriate privileges. Per-instance information can be queried by using
+ *       specific MIG device handles.
+ *       Querying per-instance information using MIG device handles is not supported if the device is in vGPU Host virtualization mode.
+ *
+ * @param device                               The device handle or MIG device handle
+ * @param infoCount                            Reference in which to provide the \a infos array size, and
+ *                                             to return the number of returned elements
+ * @param infos                                Reference in which to return the process information
+ *
+ * @return
+ *         - \ref NVML_SUCCESS                 if \a infoCount and \a infos have been populated
+ *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
+ *         - \ref NVML_ERROR_INSUFFICIENT_SIZE if \a infoCount indicates that the \a infos array is too small
+ *                                             \a infoCount will contain minimal amount of space necessary for
+ *                                             the call to complete
+ *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid, either of \a infoCount or \a infos is NULL
+ *         - \ref NVML_ERROR_GPU_IS_LOST       if the target GPU has fallen off the bus or is otherwise inaccessible
+ *         - \ref NVML_ERROR_NOT_SUPPORTED     if this query is not supported by \a device
+ *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
+ *
+ * @see \ref nvmlSystemGetProcessName
+ */
+nvmlReturn_t DECLDIR nvmlDeviceGetMPSComputeRunningProcesses_v3(nvmlDevice_t device, unsigned int *infoCount, nvmlProcessInfo_t *infos);
 
 /**
  * Check if the GPU devices are on the same physical board.
@@ -4410,7 +4862,7 @@ nvmlReturn_t DECLDIR nvmlDeviceOnSameBoard(nvmlDevice_t device1, nvmlDevice_t de
  *
  * @param device                               The identifier of the target device
  * @param apiType                              Target API type for this operation
- * @param isRestricted                         Reference in which to return the current restriction 
+ * @param isRestricted                         Reference in which to return the current restriction
  *                                             NVML_FEATURE_ENABLED indicates that the API is root-only
  *                                             NVML_FEATURE_DISABLED indicates that the API is accessible to all users
  *
@@ -4430,24 +4882,24 @@ nvmlReturn_t DECLDIR nvmlDeviceGetAPIRestriction(nvmlDevice_t device, nvmlRestri
 
 /**
  * Gets recent samples for the GPU.
- * 
+ *
  * For Kepler &tm; or newer fully supported devices.
- * 
- * Based on type, this method can be used to fetch the power, utilization or clock samples maintained in the buffer by 
+ *
+ * Based on type, this method can be used to fetch the power, utilization or clock samples maintained in the buffer by
  * the driver.
- * 
+ *
  * Power, Utilization and Clock samples are returned as type "unsigned int" for the union nvmlValue_t.
- * 
- * To get the size of samples that user needs to allocate, the method is invoked with samples set to NULL. 
- * The returned samplesCount will provide the number of samples that can be queried. The user needs to 
+ *
+ * To get the size of samples that user needs to allocate, the method is invoked with samples set to NULL.
+ * The returned samplesCount will provide the number of samples that can be queried. The user needs to
  * allocate the buffer with size as samplesCount * sizeof(nvmlSample_t).
- * 
- * lastSeenTimeStamp represents CPU timestamp in microseconds. Set it to 0 to fetch all the samples maintained by the 
- * underlying buffer. Set lastSeenTimeStamp to one of the timeStamps retrieved from the date of the previous query 
+ *
+ * lastSeenTimeStamp represents CPU timestamp in microseconds. Set it to 0 to fetch all the samples maintained by the
+ * underlying buffer. Set lastSeenTimeStamp to one of the timeStamps retrieved from the date of the previous query
  * to get more recent samples.
- * 
- * This method fetches the number of entries which can be accommodated in the provided samples array, and the 
- * reference samplesCount is updated to indicate how many samples were actually retrieved. The advantage of using this 
+ *
+ * This method fetches the number of entries which can be accommodated in the provided samples array, and the
+ * reference samplesCount is updated to indicate how many samples were actually retrieved. The advantage of using this
  * method for samples in contrast to polling via existing methods is to get get higher frequency data at lower polling cost.
  *
  * @note On MIG-enabled GPUs, querying the following sample types, NVML_GPU_UTILIZATION_SAMPLES, NVML_MEMORY_UTILIZATION_SAMPLES
@@ -4455,15 +4907,15 @@ nvmlReturn_t DECLDIR nvmlDeviceGetAPIRestriction(nvmlDevice_t device, nvmlRestri
  *
  * @param device                        The identifier for the target device
  * @param type                          Type of sampling event
- * @param lastSeenTimeStamp             Return only samples with timestamp greater than lastSeenTimeStamp. 
+ * @param lastSeenTimeStamp             Return only samples with timestamp greater than lastSeenTimeStamp.
  * @param sampleValType                 Output parameter to represent the type of sample value as described in nvmlSampleVal_t
  * @param sampleCount                   Reference to provide the number of elements which can be queried in samples array
  * @param samples                       Reference in which samples are returned
- 
- * @return 
+
+ * @return
  *         - \ref NVML_SUCCESS                 if samples are successfully retrieved
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
- *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid, \a samplesCount is NULL or 
+ *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid, \a samplesCount is NULL or
  *                                             reference to \a sampleCount is 0 for non null \a samples
  *         - \ref NVML_ERROR_NOT_SUPPORTED     if this query is not supported by the device
  *         - \ref NVML_ERROR_GPU_IS_LOST       if the target GPU has fallen off the bus or is otherwise inaccessible
@@ -4475,9 +4927,9 @@ nvmlReturn_t DECLDIR nvmlDeviceGetSamples(nvmlDevice_t device, nvmlSamplingType_
 
 /**
  * Gets Total, Available and Used size of BAR1 memory.
- * 
- * BAR1 is used to map the FB (device memory) so that it can be directly accessed by the CPU or by 3rd party 
- * devices (peer-to-peer on the PCIE bus). 
+ *
+ * BAR1 is used to map the FB (device memory) so that it can be directly accessed by the CPU or by 3rd party
+ * devices (peer-to-peer on the PCIE bus).
  *
  * @note In MIG mode, if device handle is provided, the API returns aggregate
  *       information, only if the caller has appropriate privileges. Per-instance
@@ -4501,20 +4953,20 @@ nvmlReturn_t DECLDIR nvmlDeviceGetSamples(nvmlDevice_t device, nvmlSamplingType_
 nvmlReturn_t DECLDIR nvmlDeviceGetBAR1MemoryInfo(nvmlDevice_t device, nvmlBAR1Memory_t *bar1Memory);
 
 /**
- * Gets the duration of time during which the device was throttled (lower than requested clocks) due to power 
+ * Gets the duration of time during which the device was throttled (lower than requested clocks) due to power
  * or thermal constraints.
  *
  * The method is important to users who are tying to understand if their GPUs throttle at any point during their applications. The
- * difference in violation times at two different reference times gives the indication of GPU throttling event. 
+ * difference in violation times at two different reference times gives the indication of GPU throttling event.
  *
  * Violation for thermal capping is not supported at this time.
- * 
+ *
  * For Kepler &tm; or newer fully supported devices.
  *
  * @param device                               The identifier of the target device
  * @param perfPolicyType                       Represents Performance policy which can trigger GPU throttling
- * @param violTime                             Reference to which violation time related information is returned 
- *                                         
+ * @param violTime                             Reference to which violation time related information is returned
+ *
  *
  * @return
  *         - \ref NVML_SUCCESS                 if violation time is successfully retrieved
@@ -4525,6 +4977,117 @@ nvmlReturn_t DECLDIR nvmlDeviceGetBAR1MemoryInfo(nvmlDevice_t device, nvmlBAR1Me
  *
  */
 nvmlReturn_t DECLDIR nvmlDeviceGetViolationStatus(nvmlDevice_t device, nvmlPerfPolicyType_t perfPolicyType, nvmlViolationTime_t *violTime);
+
+/**
+ * Gets the device's interrupt number
+ *
+ * @param device                               The identifier of the target device
+ * @param irqNum                               The interrupt number associated with the specified device
+ *
+ * @return
+ *         - \ref NVML_SUCCESS                 if irq number is successfully retrieved
+ *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
+ *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid, or \a irqNum is NULL
+ *         - \ref NVML_ERROR_NOT_SUPPORTED     if this query is not supported by the device
+ *         - \ref NVML_ERROR_GPU_IS_LOST       if the target GPU has fallen off the bus or is otherwise inaccessible
+ *
+ */
+nvmlReturn_t DECLDIR nvmlDeviceGetIrqNum(nvmlDevice_t device, unsigned int *irqNum);
+
+/**
+ * Gets the device's core count
+ *
+ * @param device                               The identifier of the target device
+ * @param numCores                             The number of cores for the specified device
+ *
+ * @return
+ *         - \ref NVML_SUCCESS                 if Gpu core count is successfully retrieved
+ *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
+ *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid, or \a numCores is NULL
+ *         - \ref NVML_ERROR_NOT_SUPPORTED     if this query is not supported by the device
+ *         - \ref NVML_ERROR_GPU_IS_LOST       if the target GPU has fallen off the bus or is otherwise inaccessible
+ *
+ */
+nvmlReturn_t DECLDIR nvmlDeviceGetNumGpuCores(nvmlDevice_t device, unsigned int *numCores);
+
+/**
+ * Gets the devices power source
+ *
+ * @param device                               The identifier of the target device
+ * @param powerSource                          The power source of the device
+ *
+ * @return
+ *         - \ref NVML_SUCCESS                 if the current power source was successfully retrieved
+ *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
+ *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid, or \a powerSource is NULL
+ *         - \ref NVML_ERROR_NOT_SUPPORTED     if this query is not supported by the device
+ *         - \ref NVML_ERROR_GPU_IS_LOST       if the target GPU has fallen off the bus or is otherwise inaccessible
+ *
+ */
+nvmlReturn_t DECLDIR nvmlDeviceGetPowerSource(nvmlDevice_t device, nvmlPowerSource_t *powerSource);
+
+/**
+ * Gets the device's memory bus width
+ *
+ * @param device                               The identifier of the target device
+ * @param maxSpeed                             The devices's memory bus width
+ *
+ * @return
+ *         - \ref NVML_SUCCESS                 if the memory bus width is successfully retrieved
+ *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
+ *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid, or \a busWidth is NULL
+ *         - \ref NVML_ERROR_NOT_SUPPORTED     if this query is not supported by the device
+ *         - \ref NVML_ERROR_GPU_IS_LOST       if the target GPU has fallen off the bus or is otherwise inaccessible
+ *
+ */
+nvmlReturn_t DECLDIR nvmlDeviceGetMemoryBusWidth(nvmlDevice_t device, unsigned int *busWidth);
+
+/**
+ * Gets the device's PCIE Max Link speed in MBPS
+ *
+ * @param device                               The identifier of the target device
+ * @param maxSpeed                             The devices's PCIE Max Link speed in MBPS
+ *
+ * @return
+ *         - \ref NVML_SUCCESS                 if Pcie Max Link Speed is successfully retrieved
+ *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
+ *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid, or \a maxSpeed is NULL
+ *         - \ref NVML_ERROR_NOT_SUPPORTED     if this query is not supported by the device
+ *         - \ref NVML_ERROR_GPU_IS_LOST       if the target GPU has fallen off the bus or is otherwise inaccessible
+ *
+ */
+nvmlReturn_t DECLDIR nvmlDeviceGetPcieLinkMaxSpeed(nvmlDevice_t device, unsigned int *maxSpeed);
+
+/**
+ * Gets the device's PCIe Link speed in Mbps
+ *
+ * @param device                               The identifier of the target device
+ * @param pcieSpeed                            The devices's PCIe Max Link speed in Mbps
+ *
+ * @return
+ *         - \ref NVML_SUCCESS                 if \a pcieSpeed has been retrieved
+ *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
+ *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid or \a pcieSpeed is NULL
+ *         - \ref NVML_ERROR_NOT_SUPPORTED     if the device does not support PCIe speed getting
+ *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
+ */
+nvmlReturn_t DECLDIR nvmlDeviceGetPcieSpeed(nvmlDevice_t device, unsigned int *pcieSpeed);
+
+/**
+ * Gets the device's Adaptive Clock status
+ *
+ * @param device                               The identifier of the target device
+ * @param adaptiveClockStatus                  The current adaptive clocking status
+ *
+ * @return
+ *         - \ref NVML_SUCCESS                 if the current adaptive clocking status is successfully retrieved
+ *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
+ *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid, or \a adaptiveClockStatus is NULL
+ *         - \ref NVML_ERROR_NOT_SUPPORTED     if this query is not supported by the device
+ *         - \ref NVML_ERROR_GPU_IS_LOST       if the target GPU has fallen off the bus or is otherwise inaccessible
+ *
+ */
+nvmlReturn_t DECLDIR nvmlDeviceGetAdaptiveClockInfoStatus(nvmlDevice_t device, unsigned int *adaptiveClockStatus);
 
 /**
  * @}
@@ -4545,8 +5108,8 @@ nvmlReturn_t DECLDIR nvmlDeviceGetViolationStatus(nvmlDevice_t device, nvmlPerfP
  * @param device                               The identifier of the target device
  * @param mode                                 Reference in which to return the current accounting mode
  *
- * @return 
- *         - \ref NVML_SUCCESS                 if the mode has been successfully retrieved 
+ * @return
+ *         - \ref NVML_SUCCESS                 if the mode has been successfully retrieved
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid or \a mode are NULL
  *         - \ref NVML_ERROR_NOT_SUPPORTED     if the device doesn't support this feature
@@ -4558,10 +5121,10 @@ nvmlReturn_t DECLDIR nvmlDeviceGetAccountingMode(nvmlDevice_t device, nvmlEnable
  * Queries process's accounting stats.
  *
  * For Kepler &tm; or newer fully supported devices.
- * 
+ *
  * Accounting stats capture GPU utilization and other statistics across the lifetime of a process.
  * Accounting stats can be queried during life time of the process and after its termination.
- * The time field in \ref nvmlAccountingStats_t is reported as 0 during the lifetime of the process and 
+ * The time field in \ref nvmlAccountingStats_t is reported as 0 during the lifetime of the process and
  * updated to actual running time after its termination.
  * Accounting stats are kept in a circular buffer, newly created processes overwrite information about old
  * processes.
@@ -4575,12 +5138,12 @@ nvmlReturn_t DECLDIR nvmlDeviceGetAccountingMode(nvmlDevice_t device, nvmlEnable
  * @note In case of pid collision stats of only the latest process (that terminated last) will be reported
  *
  * @warning On Kepler devices per process statistics are accurate only if there's one process running on a GPU.
- * 
+ *
  * @param device                               The identifier of the target device
  * @param pid                                  Process Id of the target process to query stats for
  * @param stats                                Reference in which to return the process's accounting stats
  *
- * @return 
+ * @return
  *         - \ref NVML_SUCCESS                 if stats have been successfully retrieved
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid or \a stats are NULL
@@ -4594,14 +5157,14 @@ nvmlReturn_t DECLDIR nvmlDeviceGetAccountingMode(nvmlDevice_t device, nvmlEnable
 nvmlReturn_t DECLDIR nvmlDeviceGetAccountingStats(nvmlDevice_t device, unsigned int pid, nvmlAccountingStats_t *stats);
 
 /**
- * Queries list of processes that can be queried for accounting stats. The list of processes returned 
+ * Queries list of processes that can be queried for accounting stats. The list of processes returned
  * can be in running or terminated state.
  *
  * For Kepler &tm; or newer fully supported devices.
  *
  * To just query the number of processes ready to be queried, call this function with *count = 0 and
  * pids=NULL. The return code will be NVML_ERROR_INSUFFICIENT_SIZE, or NVML_SUCCESS if list is empty.
- * 
+ *
  * For more details see \ref nvmlDeviceGetAccountingStats.
  *
  * @note In case of PID collision some processes might not be accessible before the circular buffer is full.
@@ -4610,8 +5173,8 @@ nvmlReturn_t DECLDIR nvmlDeviceGetAccountingStats(nvmlDevice_t device, unsigned 
  * @param count                                Reference in which to provide the \a pids array size, and
  *                                               to return the number of elements ready to be queried
  * @param pids                                 Reference in which to return list of process ids
- * 
- * @return 
+ *
+ * @return
  *         - \ref NVML_SUCCESS                 if pids were successfully retrieved
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid or \a count is NULL
@@ -4636,14 +5199,14 @@ nvmlReturn_t DECLDIR nvmlDeviceGetAccountingPids(nvmlDevice_t device, unsigned i
  * @param device                               The identifier of the target device
  * @param bufferSize                           Reference in which to provide the size (in number of elements)
  *                                               of the circular buffer for accounting stats.
- * 
- * @return 
+ *
+ * @return
  *         - \ref NVML_SUCCESS                 if buffer size was successfully retrieved
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid or \a bufferSize is NULL
  *         - \ref NVML_ERROR_NOT_SUPPORTED     if the device doesn't support this feature or accounting mode is disabled
  *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
- * 
+ *
  * @see nvmlDeviceGetAccountingStats
  * @see nvmlDeviceGetAccountingPids
  */
@@ -4659,7 +5222,7 @@ nvmlReturn_t DECLDIR nvmlDeviceGetAccountingBufferSize(nvmlDevice_t device, unsi
  * Returns the list of retired pages by source, including pages that are pending retirement
  * The address information provided from this API is the hardware address of the page that was retired.  Note
  * that this does not match the virtual address used in CUDA, but will match the address information in XID 63
- * 
+ *
  * For Kepler &tm; or newer fully supported devices.
  *
  * @param device                            The identifier of the target device
@@ -4668,13 +5231,13 @@ nvmlReturn_t DECLDIR nvmlDeviceGetAccountingBufferSize(nvmlDevice_t device, unsi
  *                                          to return the number of retired pages that match \a cause
  *                                          Set to 0 to query the size without allocating an \a addresses buffer
  * @param addresses                         Buffer to write the page addresses into
- * 
+ *
  * @return
  *         - \ref NVML_SUCCESS                 if \a pageCount was populated and \a addresses was filled
  *         - \ref NVML_ERROR_INSUFFICIENT_SIZE if \a pageCount indicates the buffer is not large enough to store all the
  *                                             matching page addresses.  \a pageCount is set to the needed size.
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
- *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid, \a pageCount is NULL, \a cause is invalid, or 
+ *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid, \a pageCount is NULL, \a cause is invalid, or
  *                                             \a addresses is NULL
  *         - \ref NVML_ERROR_NOT_SUPPORTED     if the device doesn't support this feature
  *         - \ref NVML_ERROR_GPU_IS_LOST       if the target GPU has fallen off the bus or is otherwise inaccessible
@@ -4690,7 +5253,7 @@ nvmlReturn_t DECLDIR nvmlDeviceGetRetiredPages(nvmlDevice_t device, nvmlPageReti
  *
  * \note nvmlDeviceGetRetiredPages_v2 adds an additional timestamps paramter to return the time of each page's
  *       retirement.
- * 
+ *
  * For Kepler &tm; or newer fully supported devices.
  *
  * @param device                            The identifier of the target device
@@ -4700,13 +5263,13 @@ nvmlReturn_t DECLDIR nvmlDeviceGetRetiredPages(nvmlDevice_t device, nvmlPageReti
  *                                          Set to 0 to query the size without allocating an \a addresses buffer
  * @param addresses                         Buffer to write the page addresses into
  * @param timestamps                        Buffer to write the timestamps of page retirement, additional for _v2
- * 
+ *
  * @return
  *         - \ref NVML_SUCCESS                 if \a pageCount was populated and \a addresses was filled
  *         - \ref NVML_ERROR_INSUFFICIENT_SIZE if \a pageCount indicates the buffer is not large enough to store all the
  *                                             matching page addresses.  \a pageCount is set to the needed size.
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
- *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid, \a pageCount is NULL, \a cause is invalid, or 
+ *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid, \a pageCount is NULL, \a cause is invalid, or
  *                                             \a addresses is NULL
  *         - \ref NVML_ERROR_NOT_SUPPORTED     if the device doesn't support this feature
  *         - \ref NVML_ERROR_GPU_IS_LOST       if the target GPU has fallen off the bus or is otherwise inaccessible
@@ -4722,7 +5285,7 @@ nvmlReturn_t DECLDIR nvmlDeviceGetRetiredPages_v2(nvmlDevice_t device, nvmlPageR
  *
  * @param device                            The identifier of the target device
  * @param isPending                         Reference in which to return the pending status
- * 
+ *
  * @return
  *         - \ref NVML_SUCCESS                 if \a isPending was populated
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
@@ -4806,24 +5369,24 @@ nvmlReturn_t DECLDIR nvmlDeviceGetArchitecture(nvmlDevice_t device, nvmlDeviceAr
  * Requires root/admin permissions.
  *
  * This operation takes effect immediately.
- * 
  *
- * <b>Current S-Class products don't provide unique LEDs for each unit. As such, both front 
+ *
+ * <b>Current S-Class products don't provide unique LEDs for each unit. As such, both front
  * and back LEDs will be toggled in unison regardless of which unit is specified with this command.</b>
  *
  * See \ref nvmlLedColor_t for available colors.
  *
  * @param unit                                 The identifier of the target unit
  * @param color                                The target LED color
- * 
- * @return 
+ *
+ * @return
  *         - \ref NVML_SUCCESS                 if the LED color has been set
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a unit or \a color is invalid
  *         - \ref NVML_ERROR_NOT_SUPPORTED     if this is not an S-class product
  *         - \ref NVML_ERROR_NO_PERMISSION     if the user doesn't have permission to perform this operation
  *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
- * 
+ *
  * @see nvmlUnitGetLedState()
  */
 nvmlReturn_t DECLDIR nvmlUnitSetLedState(nvmlUnit_t unit, nvmlLedColor_t color);
@@ -4862,8 +5425,8 @@ nvmlReturn_t DECLDIR nvmlUnitSetLedState(nvmlUnit_t unit, nvmlLedColor_t color);
  *
  * @param device                               The identifier of the target device
  * @param mode                                 The target persistence mode
- * 
- * @return 
+ *
+ * @return
  *         - \ref NVML_SUCCESS                 if the persistence mode was set
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid or \a mode is invalid
@@ -4896,8 +5459,8 @@ nvmlReturn_t DECLDIR nvmlDeviceSetPersistenceMode(nvmlDevice_t device, nvmlEnabl
  *
  * @param device                               The identifier of the target device
  * @param mode                                 The target compute mode
- * 
- * @return 
+ *
+ * @return
  *         - \ref NVML_SUCCESS                 if the compute mode was set
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid or \a mode is invalid
@@ -4926,8 +5489,8 @@ nvmlReturn_t DECLDIR nvmlDeviceSetComputeMode(nvmlDevice_t device, nvmlComputeMo
  *
  * @param device                               The identifier of the target device
  * @param ecc                                  The target ECC mode
- * 
- * @return 
+ *
+ * @return
  *         - \ref NVML_SUCCESS                 if the ECC mode was set
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid or \a ecc is invalid
@@ -4938,7 +5501,7 @@ nvmlReturn_t DECLDIR nvmlDeviceSetComputeMode(nvmlDevice_t device, nvmlComputeMo
  *
  * @see nvmlDeviceGetEccMode()
  */
-nvmlReturn_t DECLDIR nvmlDeviceSetEccMode(nvmlDevice_t device, nvmlEnableState_t ecc);  
+nvmlReturn_t DECLDIR nvmlDeviceSetEccMode(nvmlDevice_t device, nvmlEnableState_t ecc);
 
 /**
  * Clear the ECC error and other memory error counts for the device.
@@ -4958,8 +5521,8 @@ nvmlReturn_t DECLDIR nvmlDeviceSetEccMode(nvmlDevice_t device, nvmlEnableState_t
  *
  * @param device                               The identifier of the target device
  * @param counterType                          Flag that indicates which type of errors should be cleared.
- * 
- * @return 
+ *
+ * @return
  *         - \ref NVML_SUCCESS                 if the error counts were cleared
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid or \a counterType is invalid
@@ -4968,7 +5531,7 @@ nvmlReturn_t DECLDIR nvmlDeviceSetEccMode(nvmlDevice_t device, nvmlEnableState_t
  *         - \ref NVML_ERROR_GPU_IS_LOST       if the target GPU has fallen off the bus or is otherwise inaccessible
  *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
  *
- * @see 
+ * @see
  *      - nvmlDeviceGetDetailedEccErrors()
  *      - nvmlDeviceGetTotalEccErrors()
  */
@@ -4982,17 +5545,17 @@ nvmlReturn_t DECLDIR nvmlDeviceClearEccErrorCounts(nvmlDevice_t device, nvmlEccC
  * Requires root/admin permissions.
  *
  * On Windows platforms the device driver can run in either WDDM or WDM (TCC) mode. If a display is attached
- * to the device it must run in WDDM mode.  
+ * to the device it must run in WDDM mode.
  *
  * It is possible to force the change to WDM (TCC) while the display is still attached with a force flag (nvmlFlagForce).
  * This should only be done if the host is subsequently powered down and the display is detached from the device
- * before the next reboot. 
+ * before the next reboot.
  *
  * This operation takes effect after the next reboot.
- * 
+ *
  * Windows driver model may only be set to WDDM when running in DEFAULT compute mode.
  *
- * Change driver model to WDDM is not supported when GPU doesn't support graphics acceleration or 
+ * Change driver model to WDDM is not supported when GPU doesn't support graphics acceleration or
  * will not support it after reboot. See \ref nvmlDeviceSetGpuOperationMode.
  *
  * See \ref nvmlDriverModel_t for details on available driver models.
@@ -5001,8 +5564,8 @@ nvmlReturn_t DECLDIR nvmlDeviceClearEccErrorCounts(nvmlDevice_t device, nvmlEccC
  * @param device                               The identifier of the target device
  * @param driverModel                          The target driver model
  * @param flags                                Flags that change the default behavior
- * 
- * @return 
+ *
+ * @return
  *         - \ref NVML_SUCCESS                 if the driver model has been set
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid or \a driverModel is invalid
@@ -5010,7 +5573,7 @@ nvmlReturn_t DECLDIR nvmlDeviceClearEccErrorCounts(nvmlDevice_t device, nvmlEccC
  *         - \ref NVML_ERROR_NO_PERMISSION     if the user doesn't have permission to perform this operation
  *         - \ref NVML_ERROR_GPU_IS_LOST       if the target GPU has fallen off the bus or is otherwise inaccessible
  *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
- * 
+ *
  * @see nvmlDeviceGetDriverModel()
  */
 nvmlReturn_t DECLDIR nvmlDeviceSetDriverModel(nvmlDevice_t device, nvmlDriverModel_t driverModel, unsigned int flags);
@@ -5184,8 +5747,31 @@ nvmlReturn_t DECLDIR nvmlDeviceResetMemoryLockedClocks(nvmlDevice_t device);
 nvmlReturn_t DECLDIR nvmlDeviceSetApplicationsClocks(nvmlDevice_t device, unsigned int memClockMHz, unsigned int graphicsClockMHz);
 
 /**
- * Set new power limit of this device.
+ * Retrieves the frequency monitor fault status for the device.
+ *
+ * For Ampere &tm; or newer fully supported devices.
+ * Requires root user.
+ *
+ * See \ref nvmlClkMonStatus_t for details on decoding the status output.
+ *
+ * @param device                               The identifier of the target device
+ * @param status                               Reference in which to return the clkmon fault status
  * 
+ * @return 
+ *         - \ref NVML_SUCCESS                 if \a status has been set
+ *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
+ *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid or \a status is NULL
+ *         - \ref NVML_ERROR_NOT_SUPPORTED     if the device does not support this feature
+ *         - \ref NVML_ERROR_GPU_IS_LOST       if the target GPU has fallen off the bus or is otherwise inaccessible
+ *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
+ *
+ * @see nvmlDeviceGetClkMonStatus()
+ */
+nvmlReturn_t DECLDIR nvmlDeviceGetClkMonStatus(nvmlDevice_t device, nvmlClkMonStatus_t *status);
+
+/**
+ * Set new power limit of this device.
+ *
  * For Kepler &tm; or newer fully supported devices.
  * Requires root/admin permissions.
  *
@@ -5196,8 +5782,8 @@ nvmlReturn_t DECLDIR nvmlDeviceSetApplicationsClocks(nvmlDevice_t device, unsign
  *
  * @param device                               The identifier of the target device
  * @param limit                                Power management limit in milliwatts to set
- * 
- * @return 
+ *
+ * @return
  *         - \ref NVML_SUCCESS                 if \a limit has been set
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid or \a defaultLimit is out of range
@@ -5217,17 +5803,17 @@ nvmlReturn_t DECLDIR nvmlDeviceSetPowerManagementLimit(nvmlDevice_t device, unsi
  * Modes \ref NVML_GOM_LOW_DP and \ref NVML_GOM_ALL_ON are supported on fully supported GeForce products.
  * Not supported on Quadro &reg; and Tesla &tm; C-class products.
  * Requires root/admin permissions.
- * 
- * Changing GOMs requires a reboot. 
+ *
+ * Changing GOMs requires a reboot.
  * The reboot requirement might be removed in the future.
  *
  * Compute only GOMs don't support graphics acceleration. Under windows switching to these GOMs when
  * pending driver model is WDDM is not supported. See \ref nvmlDeviceSetDriverModel.
- * 
+ *
  * @param device                               The identifier of the target device
  * @param mode                                 Target GOM
- * 
- * @return 
+ *
+ * @return
  *         - \ref NVML_SUCCESS                 if \a mode has been set
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid or \a mode incorrect
@@ -5246,7 +5832,7 @@ nvmlReturn_t DECLDIR nvmlDeviceSetGpuOperationMode(nvmlDevice_t device, nvmlGpuO
  * This method can be used by a root/admin user to give non-root/admin access to certain otherwise-restricted APIs.
  * The new setting lasts for the lifetime of the NVIDIA driver; it is not persistent. See \a nvmlDeviceGetAPIRestriction
  * to query the current restriction settings.
- * 
+ *
  * For Kepler &tm; or newer fully supported devices.
  * Requires root/admin permissions.
  *
@@ -5259,7 +5845,7 @@ nvmlReturn_t DECLDIR nvmlDeviceSetGpuOperationMode(nvmlDevice_t device, nvmlGpuO
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid or \a apiType incorrect
  *         - \ref NVML_ERROR_NOT_SUPPORTED     if the device does not support changing API restrictions or the device does not support
- *                                                 the feature that api restrictions are being set for (E.G. Enabling/disabling auto 
+ *                                                 the feature that api restrictions are being set for (E.G. Enabling/disabling auto
  *                                                 boosted clocks is not supported by the device)
  *         - \ref NVML_ERROR_NO_PERMISSION     if the user doesn't have permission to perform this operation
  *         - \ref NVML_ERROR_GPU_IS_LOST       if the target GPU has fallen off the bus or is otherwise inaccessible
@@ -5272,7 +5858,7 @@ nvmlReturn_t DECLDIR nvmlDeviceSetAPIRestriction(nvmlDevice_t device, nvmlRestri
 /**
  * @}
  */
- 
+
 /** @addtogroup nvmlAccountingStats
  *  @{
  */
@@ -5285,7 +5871,7 @@ nvmlReturn_t DECLDIR nvmlDeviceSetAPIRestriction(nvmlDevice_t device, nvmlRestri
  *
  * @note This setting is not persistent and will default to disabled after driver unloads.
  *       Enable persistence mode to be sure the setting doesn't switch off to disabled.
- * 
+ *
  * @note Enabling accounting mode has no negative impact on the GPU performance.
  *
  * @note Disabling accounting clears all accounting pids information.
@@ -5299,7 +5885,7 @@ nvmlReturn_t DECLDIR nvmlDeviceSetAPIRestriction(nvmlDevice_t device, nvmlRestri
  * @param device                               The identifier of the target device
  * @param mode                                 The target accounting mode
  *
- * @return 
+ * @return
  *         - \ref NVML_SUCCESS                 if the new mode has been set
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device or \a mode are invalid
@@ -5321,8 +5907,8 @@ nvmlReturn_t DECLDIR nvmlDeviceSetAccountingMode(nvmlDevice_t device, nvmlEnable
  *
  * @param device                               The identifier of the target device
  *
- * @return 
- *         - \ref NVML_SUCCESS                 if accounting information has been cleared 
+ * @return
+ *         - \ref NVML_SUCCESS                 if accounting information has been cleared
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device are invalid
  *         - \ref NVML_ERROR_NOT_SUPPORTED     if the device doesn't support this feature
@@ -5348,10 +5934,10 @@ nvmlReturn_t DECLDIR nvmlDeviceClearAccountingPids(nvmlDevice_t device);
  * @param device                               The identifier of the target device
  * @param link                                 Specifies the NvLink link to be queried
  * @param isActive                             \a nvmlEnableState_t where NVML_FEATURE_ENABLED indicates that
- *                                             the link is active and NVML_FEATURE_DISABLED indicates it 
+ *                                             the link is active and NVML_FEATURE_DISABLED indicates it
  *                                             is inactive
  *
- * @return 
+ * @return
  *         - \ref NVML_SUCCESS                 if \a isActive has been set
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device or \a link is invalid or \a isActive is NULL
@@ -5369,7 +5955,7 @@ nvmlReturn_t DECLDIR nvmlDeviceGetNvLinkState(nvmlDevice_t device, unsigned int 
  * @param link                                 Specifies the NvLink link to be queried
  * @param version                              Requested NvLink version
  *
- * @return 
+ * @return
  *         - \ref NVML_SUCCESS                 if \a version has been set
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device or \a link is invalid or \a version is NULL
@@ -5390,7 +5976,7 @@ nvmlReturn_t DECLDIR nvmlDeviceGetNvLinkVersion(nvmlDevice_t device, unsigned in
  * @param capability                           Specifies the \a nvmlNvLinkCapability_t to be queried
  * @param capResult                            A boolean for the queried capability indicating that feature is available
  *
- * @return 
+ * @return
  *         - \ref NVML_SUCCESS                 if \a capResult has been set
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device, \a link, or \a capability is invalid or \a capResult is NULL
@@ -5398,19 +5984,19 @@ nvmlReturn_t DECLDIR nvmlDeviceGetNvLinkVersion(nvmlDevice_t device, unsigned in
  *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
  */
 nvmlReturn_t DECLDIR nvmlDeviceGetNvLinkCapability(nvmlDevice_t device, unsigned int link,
-                                                   nvmlNvLinkCapability_t capability, unsigned int *capResult); 
+                                                   nvmlNvLinkCapability_t capability, unsigned int *capResult);
 
 /**
- * Retrieves the PCI information for the remote node on a NvLink link 
+ * Retrieves the PCI information for the remote node on a NvLink link
  * Note: pciSubSystemId is not filled in this function and is indeterminate
  *
  * For Pascal &tm; or newer fully supported devices.
  *
  * @param device                               The identifier of the target device
  * @param link                                 Specifies the NvLink link to be queried
- * @param pci                                  \a nvmlPciInfo_t of the remote node for the specified link                            
+ * @param pci                                  \a nvmlPciInfo_t of the remote node for the specified link
  *
- * @return 
+ * @return
  *         - \ref NVML_SUCCESS                 if \a pci has been set
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device or \a link is invalid or \a pci is NULL
@@ -5430,7 +6016,7 @@ nvmlReturn_t DECLDIR nvmlDeviceGetNvLinkRemotePciInfo_v2(nvmlDevice_t device, un
  * @param counter                              Specifies the NvLink counter to be queried
  * @param counterValue                         Returned counter value
  *
- * @return 
+ * @return
  *         - \ref NVML_SUCCESS                 if \a counter has been set
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device, \a link, or \a counter is invalid or \a counterValue is NULL
@@ -5449,7 +6035,7 @@ nvmlReturn_t DECLDIR nvmlDeviceGetNvLinkErrorCounter(nvmlDevice_t device, unsign
  * @param device                               The identifier of the target device
  * @param link                                 Specifies the NvLink link to be queried
  *
- * @return 
+ * @return
  *         - \ref NVML_SUCCESS                 if the reset is successful
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device or \a link is invalid
@@ -5473,10 +6059,10 @@ nvmlReturn_t DECLDIR nvmlDeviceResetNvLinkErrorCounters(nvmlDevice_t device, uns
  * @param control                              A reference to the \a nvmlNvLinkUtilizationControl_t to set
  * @param reset                                Resets the counters on set if non-zero
  *
- * @return 
+ * @return
  *         - \ref NVML_SUCCESS                 if the control has been set successfully
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
- *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device, \a counter, \a link, or \a control is invalid 
+ *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device, \a counter, \a link, or \a control is invalid
  *         - \ref NVML_ERROR_NOT_SUPPORTED     if the device doesn't support this feature
  *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
  */
@@ -5496,10 +6082,10 @@ nvmlReturn_t DECLDIR nvmlDeviceSetNvLinkUtilizationControl(nvmlDevice_t device, 
  * @param link                                 Specifies the NvLink link to be queried
  * @param control                              A reference to the \a nvmlNvLinkUtilizationControl_t to place information
  *
- * @return 
+ * @return
  *         - \ref NVML_SUCCESS                 if the control has been set successfully
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
- *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device, \a counter, \a link, or \a control is invalid 
+ *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device, \a counter, \a link, or \a control is invalid
  *         - \ref NVML_ERROR_NOT_SUPPORTED     if the device doesn't support this feature
  *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
  */
@@ -5522,20 +6108,20 @@ nvmlReturn_t DECLDIR nvmlDeviceGetNvLinkUtilizationControl(nvmlDevice_t device, 
  * @param rxcounter                            Receive counter return value
  * @param txcounter                            Transmit counter return value
  *
- * @return 
+ * @return
  *         - \ref NVML_SUCCESS                 if \a rxcounter and \a txcounter have been successfully set
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device, \a counter, or \a link is invalid or \a rxcounter or \a txcounter are NULL
  *         - \ref NVML_ERROR_NOT_SUPPORTED     if the device doesn't support this feature
  *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
  */
-nvmlReturn_t DECLDIR nvmlDeviceGetNvLinkUtilizationCounter(nvmlDevice_t device, unsigned int link, unsigned int counter, 
+nvmlReturn_t DECLDIR nvmlDeviceGetNvLinkUtilizationCounter(nvmlDevice_t device, unsigned int link, unsigned int counter,
                                                            unsigned long long *rxcounter, unsigned long long *txcounter);
 
 /**
  * Deprecated: Freezing NVLINK utilization counters is no longer supported.
  *
- * Freeze the NVLINK utilization counters 
+ * Freeze the NVLINK utilization counters
  * Both the receive and transmit counters are operated on by this function
  *
  * For Pascal &tm; or newer fully supported devices.
@@ -5546,20 +6132,20 @@ nvmlReturn_t DECLDIR nvmlDeviceGetNvLinkUtilizationCounter(nvmlDevice_t device, 
  * @param freeze                               NVML_FEATURE_ENABLED = freeze the receive and transmit counters
  *                                             NVML_FEATURE_DISABLED = unfreeze the receive and transmit counters
  *
- * @return 
+ * @return
  *         - \ref NVML_SUCCESS                 if counters were successfully frozen or unfrozen
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device, \a link, \a counter, or \a freeze is invalid
  *         - \ref NVML_ERROR_NOT_SUPPORTED     if the device doesn't support this feature
  *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
  */
-nvmlReturn_t DECLDIR nvmlDeviceFreezeNvLinkUtilizationCounter (nvmlDevice_t device, unsigned int link, 
+nvmlReturn_t DECLDIR nvmlDeviceFreezeNvLinkUtilizationCounter (nvmlDevice_t device, unsigned int link,
                                             unsigned int counter, nvmlEnableState_t freeze);
 
 /**
  * Deprecated: Resetting NVLINK utilization counters is no longer supported.
  *
- * Reset the NVLINK utilization counters 
+ * Reset the NVLINK utilization counters
  * Both the receive and transmit counters are operated on by this function
  *
  * For Pascal &tm; or newer fully supported devices.
@@ -5568,7 +6154,7 @@ nvmlReturn_t DECLDIR nvmlDeviceFreezeNvLinkUtilizationCounter (nvmlDevice_t devi
  * @param link                                 Specifies the NvLink link to be reset
  * @param counter                              Specifies the counter that should be reset (0 or 1)
  *
- * @return 
+ * @return
  *         - \ref NVML_SUCCESS                 if counters were successfully reset
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device, \a link, or \a counter is invalid
@@ -5577,11 +6163,30 @@ nvmlReturn_t DECLDIR nvmlDeviceFreezeNvLinkUtilizationCounter (nvmlDevice_t devi
  */
 nvmlReturn_t DECLDIR nvmlDeviceResetNvLinkUtilizationCounter (nvmlDevice_t device, unsigned int link, unsigned int counter);
 
+/**
+* Get the NVLink device type of the remote device connected over the given link.
+*
+* @param device                                The device handle of the target GPU
+* @param link                                  The NVLink link index on the target GPU
+* @param pNvLinkDeviceType                     Pointer in which the output remote device type is returned
+*
+* @return
+*         - \ref NVML_SUCCESS                  if \a pNvLinkDeviceType has been set
+*         - \ref NVML_ERROR_UNINITIALIZED      if the library has not been successfully initialized
+*         - \ref NVML_ERROR_NOT_SUPPORTED      if NVLink is not supported
+*         - \ref NVML_ERROR_INVALID_ARGUMENT   if \a device or \a link is invalid, or
+*                                              \a pNvLinkDeviceType is NULL
+*         - \ref NVML_ERROR_GPU_IS_LOST        if the target GPU has fallen off the bus or is
+*                                              otherwise inaccessible
+*         - \ref NVML_ERROR_UNKNOWN            on any unexpected error
+*/
+nvmlReturn_t DECLDIR nvmlDeviceGetNvLinkRemoteDeviceType(nvmlDevice_t device, unsigned int link, nvmlIntNvLinkDeviceType_t *pNvLinkDeviceType);
+
 /** @} */
 
 /***************************************************************************************************/
 /** @defgroup nvmlEvents Event Handling Methods
- * This chapter describes methods that NVML can perform against each device to register and wait for 
+ * This chapter describes methods that NVML can perform against each device to register and wait for
  * some event to occur.
  *  @{
  */
@@ -5593,13 +6198,13 @@ nvmlReturn_t DECLDIR nvmlDeviceResetNvLinkUtilizationCounter (nvmlDevice_t devic
  *
  * For Fermi &tm; or newer fully supported devices.
  * @param set                                  Reference in which to return the event handle
- * 
- * @return 
+ *
+ * @return
  *         - \ref NVML_SUCCESS                 if the event has been set
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a set is NULL
  *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
- * 
+ *
  * @see nvmlEventSetFree
  */
 nvmlReturn_t DECLDIR nvmlEventSetCreate(nvmlEventSet_t *set);
@@ -5626,15 +6231,15 @@ nvmlReturn_t DECLDIR nvmlEventSetCreate(nvmlEventSet_t *set);
  * @param device                               The identifier of the target device
  * @param eventTypes                           Bitmask of \ref nvmlEventType to record
  * @param set                                  Set to which add new event types
- * 
- * @return 
+ *
+ * @return
  *         - \ref NVML_SUCCESS                 if the event has been set
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a eventTypes is invalid or \a set is NULL
  *         - \ref NVML_ERROR_NOT_SUPPORTED     if the platform does not support this feature or some of requested event types
  *         - \ref NVML_ERROR_GPU_IS_LOST       if the target GPU has fallen off the bus or is otherwise inaccessible
  *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
- * 
+ *
  * @see nvmlEventType
  * @see nvmlDeviceGetSupportedEventTypes
  * @see nvmlEventSetWait
@@ -5651,14 +6256,14 @@ nvmlReturn_t DECLDIR nvmlDeviceRegisterEvents(nvmlDevice_t device, unsigned long
  *
  * @param device                               The identifier of the target device
  * @param eventTypes                           Reference in which to return bitmask of supported events
- * 
- * @return 
+ *
+ * @return
  *         - \ref NVML_SUCCESS                 if the eventTypes has been set
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a eventType is NULL
  *         - \ref NVML_ERROR_GPU_IS_LOST       if the target GPU has fallen off the bus or is otherwise inaccessible
  *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
- * 
+ *
  * @see nvmlEventType
  * @see nvmlDeviceRegisterEvents
  */
@@ -5670,7 +6275,7 @@ nvmlReturn_t DECLDIR nvmlDeviceGetSupportedEventTypes(nvmlDevice_t device, unsig
  * For Fermi &tm; or newer fully supported devices.
  *
  * If some events are ready to be delivered at the time of the call, function returns immediately.
- * If there are no events ready to be delivered, function sleeps till event arrives 
+ * If there are no events ready to be delivered, function sleeps till event arrives
  * but not longer than specified timeout. This function in certain conditions can return before
  * specified timeout passes (e.g. when interrupt arrives)
  *
@@ -5689,15 +6294,15 @@ nvmlReturn_t DECLDIR nvmlDeviceGetSupportedEventTypes(nvmlDevice_t device, unsig
  * @param set                                  Reference to set of events to wait on
  * @param data                                 Reference in which to return event data
  * @param timeoutms                            Maximum amount of wait time in milliseconds for registered event
- * 
- * @return 
+ *
+ * @return
  *         - \ref NVML_SUCCESS                 if the data has been set
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a data is NULL
  *         - \ref NVML_ERROR_TIMEOUT           if no event arrived in specified timeout or interrupt arrived
  *         - \ref NVML_ERROR_GPU_IS_LOST       if a GPU has fallen off the bus or is otherwise inaccessible
  *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
- * 
+ *
  * @see nvmlEventType
  * @see nvmlDeviceRegisterEvents
  */
@@ -5708,13 +6313,13 @@ nvmlReturn_t DECLDIR nvmlEventSetWait_v2(nvmlEventSet_t set, nvmlEventData_t * d
  *
  * For Fermi &tm; or newer fully supported devices.
  *
- * @param set                                  Reference to events to be released 
- * 
- * @return 
+ * @param set                                  Reference to events to be released
+ *
+ * @return
  *         - \ref NVML_SUCCESS                 if the event has been successfully released
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
- * 
+ *
  * @see nvmlDeviceRegisterEvents
  */
 nvmlReturn_t DECLDIR nvmlEventSetFree(nvmlEventSet_t set);
@@ -5722,7 +6327,7 @@ nvmlReturn_t DECLDIR nvmlEventSetFree(nvmlEventSet_t set);
 /** @} */
 
 /***************************************************************************************************/
-/** @defgroup nvmlZPI Drain states 
+/** @defgroup nvmlZPI Drain states
  * This chapter describes methods that NVML can perform against each device to control their drain state
  * and recognition by NVML and NVIDIA kernel driver. These methods can be used with out-of-band tools to
  * power on/off GPUs, enable robust reset scenarios, etc.
@@ -5736,14 +6341,14 @@ nvmlReturn_t DECLDIR nvmlEventSetFree(nvmlEventSet_t set);
  * this call is made.
  * Must be called as administrator.
  * For Linux only.
- * 
+ *
  * For Pascal &tm; or newer fully supported devices.
  * Some Kepler devices supported.
  *
  * @param pciInfo                              The PCI address of the GPU drain state to be modified
  * @param newState                             The drain state that should be entered, see \ref nvmlEnableState_t
  *
- * @return 
+ * @return
  *         - \ref NVML_SUCCESS                 if counters were successfully reset
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a nvmlIndex or \a newState is invalid
@@ -5758,14 +6363,14 @@ nvmlReturn_t DECLDIR nvmlDeviceModifyDrainState (nvmlPciInfo_t *pciInfo, nvmlEna
  * Query the drain state of a GPU.  This method is used to check if a GPU is in a currently draining
  * state.
  * For Linux only.
- * 
+ *
  * For Pascal &tm; or newer fully supported devices.
  * Some Kepler devices supported.
  *
  * @param pciInfo                              The PCI address of the GPU drain state to be queried
  * @param currentState                         The current drain state for this GPU, see \ref nvmlEnableState_t
  *
- * @return 
+ * @return
  *         - \ref NVML_SUCCESS                 if counters were successfully reset
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a nvmlIndex or \a currentState is invalid
@@ -5779,14 +6384,14 @@ nvmlReturn_t DECLDIR nvmlDeviceQueryDrainState (nvmlPciInfo_t *pciInfo, nvmlEnab
  * as long as no other processes are attached. If other processes are attached, this call will return
  * NVML_ERROR_IN_USE and the GPU will be returned to its original "draining" state. Note: the
  * only situation where a process can still be attached after nvmlDeviceModifyDrainState() is called
- * to initiate the draining state is if that process was using, and is still using, a GPU before the 
+ * to initiate the draining state is if that process was using, and is still using, a GPU before the
  * call was made. Also note, persistence mode counts as an attachment to the GPU thus it must be disabled
  * prior to this call.
  *
  * For long-running NVML processes please note that this will change the enumeration of current GPUs.
  * For example, if there are four GPUs present and GPU1 is removed, the new enumeration will be 0-2.
  * Also, device handles after the removed GPU will not be valid and must be re-established.
- * Must be run as administrator. 
+ * Must be run as administrator.
  * For Linux only.
  *
  * For Pascal &tm; or newer fully supported devices.
@@ -5808,7 +6413,7 @@ nvmlReturn_t DECLDIR nvmlDeviceRemoveGpu_v2(nvmlPciInfo_t *pciInfo, nvmlDetachGp
 
 /**
  * Request the OS and the NVIDIA kernel driver to rediscover a portion of the PCI subsystem looking for GPUs that
- * were previously removed. The portion of the PCI tree can be narrowed by specifying a domain, bus, and device.  
+ * were previously removed. The portion of the PCI tree can be narrowed by specifying a domain, bus, and device.
  * If all are zeroes then the entire PCI tree will be searched.  Please note that for long-running NVML processes
  * the enumeration will change based on how many GPUs are discovered and where they are inserted in bus order.
  *
@@ -5817,14 +6422,14 @@ nvmlReturn_t DECLDIR nvmlDeviceRemoveGpu_v2(nvmlPciInfo_t *pciInfo, nvmlDetachGp
  *
  * Must be run as administrator.
  * For Linux only.
- * 
+ *
  * For Pascal &tm; or newer fully supported devices.
  * Some Kepler devices supported.
  *
  * @param pciInfo                              The PCI tree to be searched.  Only the domain, bus, and device
  *                                             fields are used in this call.
  *
- * @return 
+ * @return
  *         - \ref NVML_SUCCESS                 if counters were successfully reset
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a pciInfo is invalid
@@ -5886,8 +6491,8 @@ nvmlReturn_t DECLDIR nvmlDeviceGetFieldValues(nvmlDevice_t device, int valuesCou
  *
  * @param device                    Identifier of the target device
  * @param pVirtualMode              Reference to virtualization mode. One of NVML_GPU_VIRTUALIZATION_?
- * 
- * @return 
+ *
+ * @return
  *         - \ref NVML_SUCCESS                  if \a pVirtualMode is fetched
  *         - \ref NVML_ERROR_UNINITIALIZED      if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT   if \a device is invalid or \a pVirtualMode is NULL
@@ -5922,7 +6527,7 @@ nvmlReturn_t DECLDIR nvmlDeviceGetHostVgpuMode(nvmlDevice_t device, nvmlHostVgpu
  * @param device                    Identifier of the target device
  * @param virtualMode               virtualization mode. One of NVML_GPU_VIRTUALIZATION_?
  *
- * @return 
+ * @return
  *         - \ref NVML_SUCCESS                  if \a pVirtualMode is set
  *         - \ref NVML_ERROR_UNINITIALIZED      if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT   if \a device is invalid or \a pVirtualMode is NULL
@@ -5946,7 +6551,7 @@ nvmlReturn_t DECLDIR nvmlDeviceSetVirtualizationMode(nvmlDevice_t device, nvmlGp
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a pGridLicensableFeatures is NULL
  *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
  */
-nvmlReturn_t DECLDIR nvmlDeviceGetGridLicensableFeatures_v3(nvmlDevice_t device, nvmlGridLicensableFeatures_t *pGridLicensableFeatures);
+nvmlReturn_t DECLDIR nvmlDeviceGetGridLicensableFeatures_v4(nvmlDevice_t device, nvmlGridLicensableFeatures_t *pGridLicensableFeatures);
 
 /**
  * Retrieves the current utilization and process ID
@@ -5984,11 +6589,46 @@ nvmlReturn_t DECLDIR nvmlDeviceGetGridLicensableFeatures_v3(nvmlDevice_t device,
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid, \a utilization is NULL, or \a samplingPeriodUs is NULL
  *         - \ref NVML_ERROR_NOT_SUPPORTED     if the device does not support this feature
+ *         - \ref NVML_ERROR_NOT_FOUND         if sample entries are not found
  *         - \ref NVML_ERROR_GPU_IS_LOST       if the target GPU has fallen off the bus or is otherwise inaccessible
  *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
  */
 nvmlReturn_t DECLDIR nvmlDeviceGetProcessUtilization(nvmlDevice_t device, nvmlProcessUtilizationSample_t *utilization,
                                               unsigned int *processSamplesCount, unsigned long long lastSeenTimeStamp);
+
+/**
+ * Retrieve GSP firmware version.
+ *
+ * The caller passes in buffer via \a version and corresponding GSP firmware numbered version
+ * is returned with the same parameter in string format.
+ *
+ * @param device                               Device handle
+ * @param version                              The retrieved GSP firmware version
+ *
+ * @return
+ *         - \ref NVML_SUCCESS                 if GSP firmware version is sucessfully retrieved
+ *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid or GSP \a version pointer is NULL
+ *         - \ref NVML_ERROR_NOT_SUPPORTED     if GSP firmware is not enabled for GPU
+ *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
+ */
+nvmlReturn_t DECLDIR nvmlDeviceGetGspFirmwareVersion(nvmlDevice_t device, char *version);
+
+/**
+ * Retrieve GSP firmware mode.
+ *
+ * The caller passes in integer pointers. GSP firmware enablement and default mode information is returned with
+ * corresponding parameters. The return value in \a isEnabled and \a defaultMode should be treated as boolean.
+ *
+ * @param device                               Device handle
+ * @param isEnabled                            Pointer to specify if GSP firmware is enabled
+ * @param defaultMode                          Pointer to specify if GSP firmware is supported by default on \a device
+ *
+ * @return
+ *         - \ref NVML_SUCCESS                 if GSP firmware mode is sucessfully retrieved
+ *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid or any of \a isEnabled or \a defaultMode is NULL
+ *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
+ */
+nvmlReturn_t DECLDIR nvmlDeviceGetGspFirmwareMode(nvmlDevice_t device, unsigned int *isEnabled, unsigned int *defaultMode);
 
 /** @} */
 
@@ -6377,6 +7017,8 @@ nvmlReturn_t DECLDIR nvmlVgpuInstanceGetVmDriverVersion(nvmlVgpuInstance_t vgpuI
 nvmlReturn_t DECLDIR nvmlVgpuInstanceGetFbUsage(nvmlVgpuInstance_t vgpuInstance, unsigned long long *fbUsage);
 
 /**
+ * @deprecated Use \ref nvmlVgpuInstanceGetLicenseInfo_v2.
+ *
  * Retrieve the current licensing state of the vGPU instance.
  *
  * If the vGPU is currently licensed, \a licensed is set to 1, otherwise it is set to 0.
@@ -6602,6 +7244,45 @@ nvmlReturn_t DECLDIR nvmlVgpuInstanceGetFBCSessions(nvmlVgpuInstance_t vgpuInsta
 */
 nvmlReturn_t DECLDIR nvmlVgpuInstanceGetGpuInstanceId(nvmlVgpuInstance_t vgpuInstance, unsigned int *gpuInstanceId);
 
+/**
+* Retrieves the PCI Id of the given vGPU Instance i.e. the PCI Id of the GPU as seen inside the VM.
+*
+* The vGPU PCI id is returned as "00000000:00:00.0" if NVIDIA driver is not installed on the vGPU instance.
+*
+* @param vgpuInstance                         Identifier of the target vGPU instance
+* @param vgpuPciId                            Caller-supplied buffer to return vGPU PCI Id string
+* @param length                               Size of the vgpuPciId buffer
+*
+* @return
+*         - \ref NVML_SUCCESS                 if vGPU PCI Id is sucessfully retrieved
+*         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
+*         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a vgpuInstance is 0, or \a vgpuPciId is NULL
+*         - \ref NVML_ERROR_NOT_FOUND         if \a vgpuInstance does not match a valid active vGPU instance on the system
+*         - \ref NVML_ERROR_DRIVER_NOT_LOADED if NVIDIA driver is not running on the vGPU instance
+*         - \ref NVML_ERROR_INSUFFICIENT_SIZE if \a length is too small, \a length is set to required length
+*         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
+*/
+nvmlReturn_t DECLDIR nvmlVgpuInstanceGetGpuPciId(nvmlVgpuInstance_t vgpuInstance, char *vgpuPciId, unsigned int *length);
+
+/**
+* Retrieve the requested capability for a given vGPU type. Refer to the \a nvmlVgpuCapability_t structure
+* for the specific capabilities that can be queried. The return value in \a capResult should be treated as
+* a boolean, with a non-zero value indicating that the capability is supported.
+*
+* For Maxwell &tm; or newer fully supported devices.
+*
+* @param vgpuTypeId                           Handle to vGPU type
+* @param capability                           Specifies the \a nvmlVgpuCapability_t to be queried
+* @param capResult                            A boolean for the queried capability indicating that feature is supported
+*
+* @return
+*         - \ref NVML_SUCCESS                 successful completion
+*         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
+*         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a vgpuTypeId is invalid, or \a capability is invalid, or \a capResult is NULL
+*         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
+*/
+nvmlReturn_t DECLDIR nvmlVgpuTypeGetCapabilities(nvmlVgpuTypeId_t vgpuTypeId, nvmlVgpuCapability_t capability, unsigned int *capResult);
+
 /** @} */
 
 /***************************************************************************************************/
@@ -6661,7 +7342,7 @@ typedef enum nvmlVgpuVmCompatibility_enum
     NVML_VGPU_VM_COMPATIBILITY_COLD         = 0x1,    //!< vGPU is runnable from a cold / powered-off state (ACPI S5)
     NVML_VGPU_VM_COMPATIBILITY_HIBERNATE    = 0x2,    //!< vGPU is runnable from a hibernated state (ACPI S4)
     NVML_VGPU_VM_COMPATIBILITY_SLEEP        = 0x4,    //!< vGPU is runnable from a sleeped state (ACPI S3)
-    NVML_VGPU_VM_COMPATIBILITY_LIVE         = 0x8,    //!< vGPU is runnable from a live/paused (ACPI S0)
+    NVML_VGPU_VM_COMPATIBILITY_LIVE         = 0x8     //!< vGPU is runnable from a live/paused (ACPI S0)
 } nvmlVgpuVmCompatibility_t;
 
 /**
@@ -6673,7 +7354,7 @@ typedef enum nvmlVgpuPgpuCompatibilityLimitCode_enum
     NVML_VGPU_COMPATIBILITY_LIMIT_HOST_DRIVER   = 0x1,           //!< ompatibility is limited by host driver version.
     NVML_VGPU_COMPATIBILITY_LIMIT_GUEST_DRIVER  = 0x2,           //!< Compatibility is limited by guest driver version.
     NVML_VGPU_COMPATIBILITY_LIMIT_GPU           = 0x4,           //!< Compatibility is limited by GPU hardware.
-    NVML_VGPU_COMPATIBILITY_LIMIT_OTHER         = 0x80000000,    //!< Compatibility is limited by an undefined factor.
+    NVML_VGPU_COMPATIBILITY_LIMIT_OTHER         = 0x80000000     //!< Compatibility is limited by an undefined factor.
 } nvmlVgpuPgpuCompatibilityLimitCode_t;
 
 /**
@@ -6784,7 +7465,7 @@ nvmlReturn_t DECLDIR nvmlDeviceGetPgpuMetadataString(nvmlDevice_t device, char *
  * Virtual GPU (vGPU) version
  *
  * The NVIDIA vGPU Manager and the guest drivers are tagged with a range of supported vGPU versions. This determines the range of NVIDIA guest driver versions that
- * are compatible for vGPU feature support with a given NVIDIA vGPU Manager. For vGPU feature support, the range of supported versions for the NVIDIA vGPU Manager 
+ * are compatible for vGPU feature support with a given NVIDIA vGPU Manager. For vGPU feature support, the range of supported versions for the NVIDIA vGPU Manager
  * and the guest driver must overlap. Otherwise, the guest driver fails to load in the VM.
  *
  * When the NVIDIA guest driver loads, either when the VM is booted or when the driver is installed or upgraded, a negotiation occurs between the guest driver
@@ -6825,7 +7506,7 @@ nvmlReturn_t DECLDIR nvmlGetVgpuVersion(nvmlVgpuVersion_t *supported, nvmlVgpuVe
  *
  * @note 1. The range set by the administrator must be a subset of the preset range that the NVIDIA vGPU Manager supports. Otherwise, an error is returned.
  *       2. If the range of supported guest driver versions does not overlap the range set by the administrator, the guest driver fails to load.
- *       3. If the range of supported guest driver versions overlaps the range set by the administrator, the guest driver will load with a negotiated 
+ *       3. If the range of supported guest driver versions overlaps the range set by the administrator, the guest driver will load with a negotiated
  *          vGPU version that is the maximum value in the overlapping range.
  *       4. No VMs must be running on the host when this function is called. If a VM is running on the host, the call to this function fails.
  *
@@ -6842,7 +7523,7 @@ nvmlReturn_t DECLDIR nvmlSetVgpuVersion(nvmlVgpuVersion_t *vgpuVersion);
 /** @} */
 
 /***************************************************************************************************/
-/** @defgroup nvmlUtil vGPU Utilization and Accounting 
+/** @defgroup nvmlUtil vGPU Utilization and Accounting
  * This chapter describes operations that are associated with vGPU Utilization and Accounting.
  *  @{
  */
@@ -7049,6 +7730,23 @@ nvmlReturn_t DECLDIR nvmlVgpuInstanceGetAccountingStats(nvmlVgpuInstance_t vgpuI
  *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
  */
 nvmlReturn_t DECLDIR nvmlVgpuInstanceClearAccountingPids(nvmlVgpuInstance_t vgpuInstance);
+
+/**
+ * Query the license information of the vGPU instance.
+ *
+ * For Maxwell &tm; or newer fully supported devices.
+ *
+ * @param vgpuInstance              Identifier of the target vGPU instance
+ * @param licenseInfo               Pointer to vGPU license information structure
+ *
+ * @return
+ *         - \ref NVML_SUCCESS                 if information is successfully retrieved
+ *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a vgpuInstance is 0, or \a licenseInfo is NULL
+ *         - \ref NVML_ERROR_NOT_FOUND         if \a vgpuInstance does not match a valid active vGPU instance on the system
+ *         - \ref NVML_ERROR_DRIVER_NOT_LOADED if NVIDIA driver is not running on the vGPU instance
+ *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
+ */
+nvmlReturn_t DECLDIR nvmlVgpuInstanceGetLicenseInfo_v2(nvmlVgpuInstance_t vgpuInstance, nvmlVgpuLicenseInfo_t *licenseInfo);
 /** @} */
 
 /***************************************************************************************************/
@@ -7069,12 +7767,12 @@ typedef struct nvmlExcludedDeviceInfo_st
 
  /**
  * Retrieves the number of excluded GPU devices in the system.
- * 
+ *
  * For all products.
  *
  * @param deviceCount                          Reference in which to return the number of excluded devices
- * 
- * @return 
+ *
+ * @return
  *         - \ref NVML_SUCCESS                 if \a deviceCount has been set
  *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a deviceCount is NULL
  */
@@ -7082,17 +7780,17 @@ nvmlReturn_t DECLDIR nvmlGetExcludedDeviceCount(unsigned int *deviceCount);
 
 /**
  * Acquire the device information for an excluded GPU device, based on its index.
- * 
+ *
  * For all products.
  *
- * Valid indices are derived from the \a deviceCount returned by 
- *   \ref nvmlGetExcludedDeviceCount(). For example, if \a deviceCount is 2 the valid indices  
+ * Valid indices are derived from the \a deviceCount returned by
+ *   \ref nvmlGetExcludedDeviceCount(). For example, if \a deviceCount is 2 the valid indices
  *   are 0 and 1, corresponding to GPU 0 and GPU 1.
  *
  * @param index                                The index of the target GPU, >= 0 and < \a deviceCount
  * @param info                                 Reference in which to return the device information
- * 
- * @return 
+ *
+ * @return
  *         - \ref NVML_SUCCESS                  if \a device has been set
  *         - \ref NVML_ERROR_INVALID_ARGUMENT   if \a index is invalid or \a info is NULL
  *
@@ -7125,21 +7823,25 @@ nvmlReturn_t DECLDIR nvmlGetExcludedDeviceInfoByIndex(unsigned int index, nvmlEx
  * These macros should be passed to \ref nvmlDeviceGetGpuInstanceProfileInfo to retrieve the
  * detailed information about a GPU instance such as profile ID, engine counts.
  */
-#define NVML_GPU_INSTANCE_PROFILE_1_SLICE 0x0
-#define NVML_GPU_INSTANCE_PROFILE_2_SLICE 0x1
-#define NVML_GPU_INSTANCE_PROFILE_3_SLICE 0x2
-#define NVML_GPU_INSTANCE_PROFILE_4_SLICE 0x3
-#define NVML_GPU_INSTANCE_PROFILE_7_SLICE 0x4
-#define NVML_GPU_INSTANCE_PROFILE_8_SLICE 0x5
-#define NVML_GPU_INSTANCE_PROFILE_6_SLICE 0x6
-#define NVML_GPU_INSTANCE_PROFILE_COUNT   0x7
+#define NVML_GPU_INSTANCE_PROFILE_1_SLICE      0x0
+#define NVML_GPU_INSTANCE_PROFILE_2_SLICE      0x1
+#define NVML_GPU_INSTANCE_PROFILE_3_SLICE      0x2
+#define NVML_GPU_INSTANCE_PROFILE_4_SLICE      0x3
+#define NVML_GPU_INSTANCE_PROFILE_7_SLICE      0x4
+#define NVML_GPU_INSTANCE_PROFILE_8_SLICE      0x5
+#define NVML_GPU_INSTANCE_PROFILE_6_SLICE      0x6
+#define NVML_GPU_INSTANCE_PROFILE_1_SLICE_REV1 0x7
+#define NVML_GPU_INSTANCE_PROFILE_COUNT        0x8
 
 typedef struct nvmlGpuInstancePlacement_st
 {
-    unsigned int start;
-    unsigned int size;
+    unsigned int start;               //!< Index of first occupied memory slice
+    unsigned int size;                //!< Number of memory slices occupied
 } nvmlGpuInstancePlacement_t;
 
+/**
+ * GPU instance profile information.
+ */
 typedef struct nvmlGpuInstanceProfileInfo_st
 {
     unsigned int id;                  //!< Unique profile ID within the device
@@ -7154,6 +7856,36 @@ typedef struct nvmlGpuInstanceProfileInfo_st
     unsigned int ofaCount;            //!< OFA Engine count
     unsigned long long memorySizeMB;  //!< Memory size in MBytes
 } nvmlGpuInstanceProfileInfo_t;
+
+/**
+ * GPU instance profile information (v2).
+ * 
+ * Version 2 adds the \ref nvmlGpuInstanceProfileInfo_v2_t.version field
+ * to the start of the structure, and the \ref nvmlGpuInstanceProfileInfo_v2_t.name
+ * field to the end. This structure is not backwards-compatible with
+ * \ref nvmlGpuInstanceProfileInfo_t.
+ */
+typedef struct nvmlGpuInstanceProfileInfo_v2_st
+{
+    unsigned int version;                       //!< Structure version identifier (set to \ref nvmlGpuInstanceProfileInfo_v2)
+    unsigned int id;                            //!< Unique profile ID within the device
+    unsigned int isP2pSupported;                //!< Peer-to-Peer support
+    unsigned int sliceCount;                    //!< GPU Slice count
+    unsigned int instanceCount;                 //!< GPU instance count
+    unsigned int multiprocessorCount;           //!< Streaming Multiprocessor count
+    unsigned int copyEngineCount;               //!< Copy Engine count
+    unsigned int decoderCount;                  //!< Decoder Engine count
+    unsigned int encoderCount;                  //!< Encoder Engine count
+    unsigned int jpegCount;                     //!< JPEG Engine count
+    unsigned int ofaCount;                      //!< OFA Engine count
+    unsigned long long memorySizeMB;            //!< Memory size in MBytes
+    char name[NVML_DEVICE_NAME_V2_BUFFER_SIZE]; //!< Profile name
+} nvmlGpuInstanceProfileInfo_v2_t;
+
+/**
+ * Version identifier value for \ref nvmlGpuInstanceProfileInfo_v2_t.version.
+ */
+#define nvmlGpuInstanceProfileInfo_v2 NVML_STRUCT_VERSION(GpuInstanceProfileInfo, 2)
 
 typedef struct nvmlGpuInstanceInfo_st
 {
@@ -7185,10 +7917,13 @@ typedef struct nvmlGpuInstance_st* nvmlGpuInstance_t;
 
 typedef struct nvmlComputeInstancePlacement_st
 {
-    unsigned int start;
-    unsigned int size;
+    unsigned int start;                 //!< Index of first occupied compute slice
+    unsigned int size;                  //!< Number of compute slices occupied
 } nvmlComputeInstancePlacement_t;
 
+/**
+ * Compute instance profile information.
+ */
 typedef struct nvmlComputeInstanceProfileInfo_st
 {
     unsigned int id;                    //!< Unique profile ID within the GPU instance
@@ -7202,13 +7937,41 @@ typedef struct nvmlComputeInstanceProfileInfo_st
     unsigned int sharedOfaCount;        //!< Shared OFA Engine count
 } nvmlComputeInstanceProfileInfo_t;
 
+/**
+ * Compute instance profile information (v2).
+ * 
+ * Version 2 adds the \ref nvmlComputeInstanceProfileInfo_v2_t.version field
+ * to the start of the structure, and the \ref nvmlComputeInstanceProfileInfo_v2_t.name
+ * field to the end. This structure is not backwards-compatible with
+ * \ref nvmlComputeInstanceProfileInfo_t.
+ */
+typedef struct nvmlComputeInstanceProfileInfo_v2_st
+{
+    unsigned int version;                       //!< Structure version identifier (set to \ref nvmlComputeInstanceProfileInfo_v2)
+    unsigned int id;                            //!< Unique profile ID within the GPU instance
+    unsigned int sliceCount;                    //!< GPU Slice count
+    unsigned int instanceCount;                 //!< Compute instance count
+    unsigned int multiprocessorCount;           //!< Streaming Multiprocessor count
+    unsigned int sharedCopyEngineCount;         //!< Shared Copy Engine count
+    unsigned int sharedDecoderCount;            //!< Shared Decoder Engine count
+    unsigned int sharedEncoderCount;            //!< Shared Encoder Engine count
+    unsigned int sharedJpegCount;               //!< Shared JPEG Engine count
+    unsigned int sharedOfaCount;                //!< Shared OFA Engine count
+    char name[NVML_DEVICE_NAME_V2_BUFFER_SIZE]; //!< Profile name
+} nvmlComputeInstanceProfileInfo_v2_t;
+
+/**
+ * Version identifier value for \ref nvmlComputeInstanceProfileInfo_v2_t.version.
+ */
+#define nvmlComputeInstanceProfileInfo_v2 NVML_STRUCT_VERSION(ComputeInstanceProfileInfo, 2)
+
 typedef struct nvmlComputeInstanceInfo_st
 {
     nvmlDevice_t device;                      //!< Parent device
     nvmlGpuInstance_t gpuInstance;            //!< Parent GPU instance
     unsigned int id;                          //!< Unique instance ID within the GPU instance
     unsigned int profileId;                   //!< Unique profile ID within the GPU instance
-    nvmlComputeInstancePlacement_t placement; //!< Placement for this instance within the GPU instance's slice range {0, sliceCount}
+    nvmlComputeInstancePlacement_t placement; //!< Placement for this instance within the GPU instance's compute slice range {0, sliceCount}
 } nvmlComputeInstanceInfo_t;
 
 typedef struct nvmlComputeInstance_st* nvmlComputeInstance_t;
@@ -7277,7 +8040,6 @@ nvmlReturn_t DECLDIR nvmlDeviceGetMigMode(nvmlDevice_t device, unsigned int *cur
  *
  * For Ampere &tm; or newer fully supported devices.
  * Supported on Linux only.
- * Requires privileged user.
  *
  * @param device                               The identifier of the target device
  * @param profile                              One of the NVML_GPU_INSTANCE_PROFILE_*
@@ -7294,10 +8056,43 @@ nvmlReturn_t DECLDIR nvmlDeviceGetGpuInstanceProfileInfo(nvmlDevice_t device, un
                                                          nvmlGpuInstanceProfileInfo_t *info);
 
 /**
+ * Versioned wrapper around \ref nvmlDeviceGetGpuInstanceProfileInfo that accepts a versioned
+ * \ref nvmlGpuInstanceProfileInfo_v2_t or later output structure.
+ * 
+ * @note The caller must set the \ref nvmlGpuInstanceProfileInfo_v2_t.version field to the
+ * appropriate version prior to calling this function. For example:
+ * \code
+ *     nvmlGpuInstanceProfileInfo_v2_t profileInfo =
+ *         { .version = nvmlGpuInstanceProfileInfo_v2 };
+ *     nvmlReturn_t result = nvmlDeviceGetGpuInstanceProfileInfoV(device,
+ *                                                                profile,
+ *                                                                &profileInfo);
+ * \endcode
+ *
+ * For Ampere &tm; or newer fully supported devices.
+ * Supported on Linux only.
+ *
+ * @param device                               The identifier of the target device
+ * @param profile                              One of the NVML_GPU_INSTANCE_PROFILE_*
+ * @param info                                 Returns detailed profile information
+ *
+ * @return
+ *         - \ref NVML_SUCCESS                 Upon success
+ *         - \ref NVML_ERROR_UNINITIALIZED     If library has not been successfully initialized
+ *         - \ref NVML_ERROR_INVALID_ARGUMENT  If \a device, \a profile, \a info, or \a info->version are invalid
+ *         - \ref NVML_ERROR_NOT_SUPPORTED     If \a device doesn't have MIG mode enabled or \a profile isn't supported
+ *         - \ref NVML_ERROR_NO_PERMISSION     If user doesn't have permission to perform the operation
+ */
+nvmlReturn_t DECLDIR nvmlDeviceGetGpuInstanceProfileInfoV(nvmlDevice_t device, unsigned int profile,
+                                                          nvmlGpuInstanceProfileInfo_v2_t *info);
+
+/**
  * Get GPU instance placements.
  *
  * A placement represents the location of a GPU instance within a device. This API only returns all the possible
  * placements for the given profile.
+ * A created GPU instance occupies memory slices described by its placement. Creation of new GPU instance will
+ * fail if there is overlap with the already occupied memory slices.
  *
  * For Ampere &tm; or newer fully supported devices.
  * Supported on Linux only.
@@ -7305,21 +8100,21 @@ nvmlReturn_t DECLDIR nvmlDeviceGetGpuInstanceProfileInfo(nvmlDevice_t device, un
  *
  * @param device                               The identifier of the target device
  * @param profileId                            The GPU instance profile ID. See \ref nvmlDeviceGetGpuInstanceProfileInfo
- * @param placements                           Returns placements, the buffer must be large enough to accommodate
- *                                             the instances supported by the profile.
- *                                             See \ref nvmlDeviceGetGpuInstanceProfileInfo
- * @param count                                The count of returned placements
+ * @param placements                           Returns placements allowed for the profile. Can be NULL to discover number
+ *                                             of allowed placements for this profile. If non-NULL must be large enough
+ *                                             to accommodate the placements supported by the profile.
+ * @param count                                Returns number of allowed placemenets for the profile.
  *
  * @return
  *         - \ref NVML_SUCCESS                 Upon success
  *         - \ref NVML_ERROR_UNINITIALIZED     If library has not been successfully initialized
- *         - \ref NVML_ERROR_INVALID_ARGUMENT  If \a device, \a profileId, \a placements or \a count are invalid
+ *         - \ref NVML_ERROR_INVALID_ARGUMENT  If \a device, \a profileId or \a count are invalid
  *         - \ref NVML_ERROR_NOT_SUPPORTED     If \a device doesn't have MIG mode enabled or \a profileId isn't supported
  *         - \ref NVML_ERROR_NO_PERMISSION     If user doesn't have permission to perform the operation
  */
-nvmlReturn_t DECLDIR nvmlDeviceGetGpuInstancePossiblePlacements(nvmlDevice_t device, unsigned int profileId,
-                                                                nvmlGpuInstancePlacement_t *placements,
-                                                                unsigned int *count);
+nvmlReturn_t DECLDIR nvmlDeviceGetGpuInstancePossiblePlacements_v2(nvmlDevice_t device, unsigned int profileId,
+                                                                   nvmlGpuInstancePlacement_t *placements,
+                                                                   unsigned int *count);
 
 /**
  * Get GPU instance profile capacity.
@@ -7379,7 +8174,7 @@ nvmlReturn_t DECLDIR nvmlDeviceCreateGpuInstance(nvmlDevice_t device, unsigned i
  *
  * @param device                               The identifier of the target device
  * @param profileId                            The GPU instance profile ID. See \ref nvmlDeviceGetGpuInstanceProfileInfo
- * @param placement                            The requested placement. See \ref nvmlDeviceGetGpuInstancePossiblePlacements
+ * @param placement                            The requested placement. See \ref nvmlDeviceGetGpuInstancePossiblePlacements_v2
  * @param gpuInstance                          Returns the GPU instance handle
  *
  * @return
@@ -7484,7 +8279,6 @@ nvmlReturn_t DECLDIR nvmlGpuInstanceGetInfo(nvmlGpuInstance_t gpuInstance, nvmlG
  *
  * For Ampere &tm; or newer fully supported devices.
  * Supported on Linux only.
- * Requires privileged user.
  *
  * @param gpuInstance                          The identifier of the target GPU instance
  * @param profile                              One of the NVML_COMPUTE_INSTANCE_PROFILE_*
@@ -7501,6 +8295,40 @@ nvmlReturn_t DECLDIR nvmlGpuInstanceGetInfo(nvmlGpuInstance_t gpuInstance, nvmlG
 nvmlReturn_t DECLDIR nvmlGpuInstanceGetComputeInstanceProfileInfo(nvmlGpuInstance_t gpuInstance, unsigned int profile,
                                                                   unsigned int engProfile,
                                                                   nvmlComputeInstanceProfileInfo_t *info);
+
+/**
+ * Versioned wrapper around \ref nvmlGpuInstanceGetComputeInstanceProfileInfo that accepts a versioned
+ * \ref nvmlComputeInstanceProfileInfo_v2_t or later output structure.
+ *
+ * @note The caller must set the \ref nvmlGpuInstanceProfileInfo_v2_t.version field to the
+ * appropriate version prior to calling this function. For example:
+ * \code
+ *     nvmlComputeInstanceProfileInfo_v2_t profileInfo =
+ *         { .version = nvmlComputeInstanceProfileInfo_v2 };
+ *     nvmlReturn_t result = nvmlGpuInstanceGetComputeInstanceProfileInfoV(gpuInstance,
+ *                                                                         profile,
+ *                                                                         engProfile,
+ *                                                                         &profileInfo);
+ * \endcode
+ *
+ * For Ampere &tm; or newer fully supported devices.
+ * Supported on Linux only.
+ *
+ * @param gpuInstance                          The identifier of the target GPU instance
+ * @param profile                              One of the NVML_COMPUTE_INSTANCE_PROFILE_*
+ * @param engProfile                           One of the NVML_COMPUTE_INSTANCE_ENGINE_PROFILE_*
+ * @param info                                 Returns detailed profile information
+ *
+ * @return
+ *         - \ref NVML_SUCCESS                 Upon success
+ *         - \ref NVML_ERROR_UNINITIALIZED     If library has not been successfully initialized
+ *         - \ref NVML_ERROR_INVALID_ARGUMENT  If \a gpuInstance, \a profile, \a engProfile, \a info, or \a info->version are invalid
+ *         - \ref NVML_ERROR_NOT_SUPPORTED     If \a profile isn't supported
+ *         - \ref NVML_ERROR_NO_PERMISSION     If user doesn't have permission to perform the operation
+ */
+nvmlReturn_t DECLDIR nvmlGpuInstanceGetComputeInstanceProfileInfoV(nvmlGpuInstance_t gpuInstance, unsigned int profile,
+                                                                   unsigned int engProfile,
+                                                                   nvmlComputeInstanceProfileInfo_v2_t *info);
 
 /**
  * Get compute instance profile capacity.
@@ -7763,6 +8591,134 @@ nvmlReturn_t DECLDIR nvmlDeviceGetMigDeviceHandleByIndex(nvmlDevice_t device, un
  */
 nvmlReturn_t DECLDIR nvmlDeviceGetDeviceHandleFromMigDeviceHandle(nvmlDevice_t migDevice, nvmlDevice_t *device);
 
+/**
+ * Get the type of the GPU Bus (PCIe, PCI, ...)
+ *
+ * @param device                               The identifier of the target device
+ * @param type                                 The PCI Bus type
+ *
+ * return
+ *         - \ref NVML_SUCCESS                 if the bus \a type is successfully retreived
+ *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
+ *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \device is invalid or \type is NULL
+ *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
+ */
+nvmlReturn_t DECLDIR nvmlDeviceGetBusType(nvmlDevice_t device, nvmlBusType_t *type);
+
+/**
+ * Retrieve performance monitor samples from the associated subdevice.
+ *
+ * @param device
+ * @param pDynamicPstatesInfo
+ *
+ * @return
+ *         - \ref NVML_SUCCESS                 if \a pDynamicPstatesInfo has been set
+ *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
+ *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid or \a pDynamicPstatesInfo is NULL
+ *         - \ref NVML_ERROR_NOT_SUPPORTED     if the device does not support this feature
+ *         - \ref NVML_ERROR_GPU_IS_LOST       if the target GPU has fallen off the bus or is otherwise inaccessible
+ *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
+ */
+nvmlReturn_t DECLDIR nvmlDeviceGetDynamicPstatesInfo(nvmlDevice_t device, nvmlGpuDynamicPstatesInfo_t *pDynamicPstatesInfo);
+
+/**
+ * Sets the speed of a specified fan.
+ *
+ * WARNING: This function changes the fan control policy to manual. It means that YOU have to monitor
+ *          the temperature and adjust the fan speed accordingly.
+ *          If you set the fan speed too low you can burn your GPU!
+ *          Use nvmlDeviceSetDefaultFanSpeed_v2 to restore default control policy.
+ *
+ * For all cuda-capable discrete products with fans that are Maxwell or Newer.
+ *
+ * device                                The identifier of the target device
+ * fan                                   The index of the fan, starting at zero
+ * speed                                 The target speed of the fan [0-100] in % of max speed
+ *
+ * return
+ *        NVML_SUCCESS                   if the fan speed has been set
+ *        NVML_ERROR_UNINITIALIZED       if the library has not been successfully initialized
+ *        NVML_ERROR_INVALID_ARGUMENT    if the device is not valid, or the speed is outside acceptable ranges,
+ *                                              or if the fan index doesn't reference an actual fan.
+ *        NVML_ERROR_NOT_SUPPORTED       if the device is older than Maxwell.
+ *        NVML_ERROR_UNKNOWN             if there was an unexpected error.
+ */
+nvmlReturn_t DECLDIR nvmlDeviceSetFanSpeed_v2(nvmlDevice_t device, unsigned int fan, unsigned int speed);
+
+/**
+ * Retrieve the GPCCLK VF offset value
+ * @param[in]   device                         The identifier of the target device
+ * @param[out]  offset                         The retrieved GPCCLK VF offset value
+ *
+ * @return
+ *         - \ref NVML_SUCCESS                 if \a offset has been successfully queried
+ *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
+ *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid or \a offset is NULL
+ *         - \ref NVML_ERROR_NOT_SUPPORTED     if the device does not support this feature
+ *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
+ */
+nvmlReturn_t DECLDIR nvmlDeviceGetGpcClkVfOffset(nvmlDevice_t device, int *offset);
+
+/**
+ * Set the GPCCLK VF offset value
+ * @param[in]   device                         The identifier of the target device
+ * @param[in]   offset                         The GPCCLK VF offset value to set
+ *
+ * @return
+ *         - \ref NVML_SUCCESS                 if \a offset has been set
+ *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
+ *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid or \a offset is NULL
+ *         - \ref NVML_ERROR_NOT_SUPPORTED     if the device does not support this feature
+ *         - \ref NVML_ERROR_GPU_IS_LOST       if the target GPU has fallen off the bus or is otherwise inaccessible
+ *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
+ */
+nvmlReturn_t DECLDIR nvmlDeviceSetGpcClkVfOffset(nvmlDevice_t device, int offset);
+
+/**
+ * Retrieve min and max clocks of some clock domain for a given PState
+ *
+ * @param device                               The identifier of the target device
+ * @param type                                 Clock domain
+ * @param pstate                               PState to query
+ * @param minClockMHz                          Reference in which to return min clock frequency
+ * @param maxClockMHz                          Reference in which to return max clock frequency
+ *
+ * @return
+ *         - \ref NVML_SUCCESS                 if everything worked
+ *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
+ *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device, \a type or \a pstate are invalid or both
+ *                                                  \a minClockMHz and \a maxClockMHz are NULL
+ *         - \ref NVML_ERROR_NOT_SUPPORTED     if the device does not support this feature
+ */
+nvmlReturn_t DECLDIR nvmlDeviceGetMinMaxClockOfPState(nvmlDevice_t device, nvmlClockType_t type, nvmlPstates_t pstate,
+                                                      unsigned int * minClockMHz, unsigned int * maxClockMHz);
+
+/**
+ * Get all supported Performance States (P-States) for the device.
+ *
+ * The returned array would contain a contiguous list of valid P-States supported by
+ * the device. If the number of supported P-States is fewer than the size of the array
+ * supplied missing elements would contain \a NVML_PSTATE_UNKNOWN.
+ *
+ * The number of elements in the returned list will never exceed \a NVML_MAX_GPU_PERF_PSTATES.
+ *
+ * @param device                               The identifier of the target device
+ * @param pstates                              Container to return the list of performance states
+ *                                             supported by device
+ * @param size                                 Size of the supplied \a pstates array in bytes
+ *
+ * @return
+ *         - \ref NVML_SUCCESS                 if \a pstates array has been retrieved
+ *         - \ref NVML_ERROR_INSUFFICIENT_SIZE if the the container supplied was not large enough to
+ *                                             hold the resulting list
+ *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
+ *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device or \a pstates is invalid
+ *         - \ref NVML_ERROR_NOT_SUPPORTED     if the device does not support performance state readings
+ *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
+ */
+nvmlReturn_t DECLDIR nvmlDeviceGetSupportedPerformanceStates(nvmlDevice_t device,
+                                                             nvmlPstates_t *pstates, unsigned int size);
+
 /** @} */
 
 /**
@@ -7779,12 +8735,19 @@ nvmlReturn_t DECLDIR nvmlDeviceGetPciInfo_v2(nvmlDevice_t device, nvmlPciInfo_t 
 nvmlReturn_t DECLDIR nvmlDeviceGetNvLinkRemotePciInfo(nvmlDevice_t device, unsigned int link, nvmlPciInfo_t *pci);
 nvmlReturn_t DECLDIR nvmlDeviceGetGridLicensableFeatures(nvmlDevice_t device, nvmlGridLicensableFeatures_t *pGridLicensableFeatures);
 nvmlReturn_t DECLDIR nvmlDeviceGetGridLicensableFeatures_v2(nvmlDevice_t device, nvmlGridLicensableFeatures_t *pGridLicensableFeatures);
+nvmlReturn_t DECLDIR nvmlDeviceGetGridLicensableFeatures_v3(nvmlDevice_t device, nvmlGridLicensableFeatures_t *pGridLicensableFeatures);
 nvmlReturn_t DECLDIR nvmlDeviceRemoveGpu(nvmlPciInfo_t *pciInfo);
 nvmlReturn_t DECLDIR nvmlEventSetWait(nvmlEventSet_t set, nvmlEventData_t * data, unsigned int timeoutms);
 nvmlReturn_t DECLDIR nvmlDeviceGetAttributes(nvmlDevice_t device, nvmlDeviceAttributes_t *attributes);
 nvmlReturn_t DECLDIR nvmlComputeInstanceGetInfo(nvmlComputeInstance_t computeInstance, nvmlComputeInstanceInfo_t *info);
-nvmlReturn_t DECLDIR nvmlDeviceGetComputeRunningProcesses(nvmlDevice_t device, unsigned int *infoCount, nvmlProcessInfo_t *infos);
-nvmlReturn_t DECLDIR nvmlDeviceGetGraphicsRunningProcesses(nvmlDevice_t device, unsigned int *infoCount, nvmlProcessInfo_t *infos);
+nvmlReturn_t DECLDIR nvmlDeviceGetComputeRunningProcesses(nvmlDevice_t device, unsigned int *infoCount, nvmlProcessInfo_v1_t *infos);
+nvmlReturn_t DECLDIR nvmlDeviceGetComputeRunningProcesses_v2(nvmlDevice_t device, unsigned int *infoCount, nvmlProcessInfo_v2_t *infos);
+nvmlReturn_t DECLDIR nvmlDeviceGetGraphicsRunningProcesses(nvmlDevice_t device, unsigned int *infoCount, nvmlProcessInfo_v1_t *infos);
+nvmlReturn_t DECLDIR nvmlDeviceGetGraphicsRunningProcesses_v2(nvmlDevice_t device, unsigned int *infoCount, nvmlProcessInfo_v2_t *infos);
+nvmlReturn_t DECLDIR nvmlDeviceGetMPSComputeRunningProcesses(nvmlDevice_t device, unsigned int *infoCount, nvmlProcessInfo_v1_t *infos);
+nvmlReturn_t DECLDIR nvmlDeviceGetMPSComputeRunningProcesses_v2(nvmlDevice_t device, unsigned int *infoCount, nvmlProcessInfo_v2_t *infos);
+nvmlReturn_t DECLDIR nvmlDeviceGetGpuInstancePossiblePlacements(nvmlDevice_t device, unsigned int profileId, nvmlGpuInstancePlacement_t *placements, unsigned int *count);
+nvmlReturn_t DECLDIR nvmlVgpuInstanceGetLicenseInfo(nvmlVgpuInstance_t vgpuInstance, nvmlVgpuLicenseInfo_t *licenseInfo);
 #endif // #ifdef NVML_NO_UNVERSIONED_FUNC_DEFS
 
 #if defined(NVML_NO_UNVERSIONED_FUNC_DEFS)
@@ -7793,6 +8756,7 @@ nvmlReturn_t DECLDIR nvmlDeviceGetGraphicsRunningProcesses(nvmlDevice_t device, 
 #elif defined(__NVML_API_VERSION_INTERNAL)
 #undef nvmlDeviceGetGraphicsRunningProcesses
 #undef nvmlDeviceGetComputeRunningProcesses
+#undef nvmlDeviceGetMPSComputeRunningProcesses
 #undef nvmlDeviceGetAttributes
 #undef nvmlComputeInstanceGetInfo
 #undef nvmlEventSetWait
@@ -7807,6 +8771,8 @@ nvmlReturn_t DECLDIR nvmlDeviceGetGraphicsRunningProcesses(nvmlDevice_t device, 
 #undef nvmlBlacklistDeviceInfo_t
 #undef nvmlGetBlacklistDeviceCount
 #undef nvmlGetBlacklistDeviceInfoByIndex
+#undef nvmlDeviceGetGpuInstancePossiblePlacements
+#undef nvmlVgpuInstanceGetLicenseInfo
 #endif
 
 #ifdef __cplusplus

--- a/src/nvapi_gpu.cpp
+++ b/src/nvapi_gpu.cpp
@@ -115,6 +115,32 @@ extern "C" {
         if (!nvapiAdapterRegistry->IsAdapter(adapter))
             return ExpectedPhysicalGpuHandle(n);
 
+        if (adapter->HasNvmlDevice()) {
+            nvmlBusType_t busType;
+            auto result = adapter->GetNvmlDeviceBusType(&busType);
+            if (result == NVML_SUCCESS) {
+                switch (busType) {
+                    case NVML_BUS_TYPE_PCI:
+                        *pBusType = NVAPI_GPU_BUS_TYPE_PCI;
+                        break;
+                    case NVML_BUS_TYPE_PCIE:
+                        *pBusType = NVAPI_GPU_BUS_TYPE_PCI_EXPRESS;
+                        break;
+                    case NVML_BUS_TYPE_FPCI:
+                        *pBusType = NVAPI_GPU_BUS_TYPE_FPCI;
+                        break;
+                    case NVML_BUS_TYPE_AGP:
+                        *pBusType = NVAPI_GPU_BUS_TYPE_AGP;
+                        break;
+                    default:
+                        *pBusType = NVAPI_GPU_BUS_TYPE_UNDEFINED;
+                        break;
+                }
+
+                return Ok(n);
+            }
+        }
+
         if (adapter->GetArchitectureId() >= NV_GPU_ARCHITECTURE_GM200)
             *pBusType = NVAPI_GPU_BUS_TYPE_PCI_EXPRESS; // Assume PCIe on Maxwell like generation and newer
         else

--- a/src/nvapi_gpu.cpp
+++ b/src/nvapi_gpu.cpp
@@ -433,6 +433,63 @@ extern "C" {
         }
     }
 
+    static NV_THERMAL_TARGET MapThermalTarget(nvmlThermalTarget_t target) {
+        static_assert(static_cast<int>(NVML_THERMAL_TARGET_NONE) == static_cast<int>(NVAPI_THERMAL_TARGET_NONE));
+        static_assert(static_cast<int>(NVML_THERMAL_TARGET_GPU) == static_cast<int>(NVAPI_THERMAL_TARGET_GPU));
+        static_assert(static_cast<int>(NVML_THERMAL_TARGET_MEMORY) == static_cast<int>(NVAPI_THERMAL_TARGET_MEMORY));
+        static_assert(static_cast<int>(NVML_THERMAL_TARGET_POWER_SUPPLY) == static_cast<int>(NVAPI_THERMAL_TARGET_POWER_SUPPLY));
+        static_assert(static_cast<int>(NVML_THERMAL_TARGET_BOARD) == static_cast<int>(NVAPI_THERMAL_TARGET_BOARD));
+        static_assert(static_cast<int>(NVML_THERMAL_TARGET_VCD_BOARD) == static_cast<int>(NVAPI_THERMAL_TARGET_VCD_BOARD));
+        static_assert(static_cast<int>(NVML_THERMAL_TARGET_VCD_INLET) == static_cast<int>(NVAPI_THERMAL_TARGET_VCD_INLET));
+        static_assert(static_cast<int>(NVML_THERMAL_TARGET_VCD_OUTLET) == static_cast<int>(NVAPI_THERMAL_TARGET_VCD_OUTLET));
+        static_assert(static_cast<int>(NVML_THERMAL_TARGET_ALL) == static_cast<int>(NVAPI_THERMAL_TARGET_ALL));
+        static_assert(static_cast<int>(NVML_THERMAL_TARGET_UNKNOWN) == static_cast<int>(NVAPI_THERMAL_TARGET_UNKNOWN));
+        return static_cast<NV_THERMAL_TARGET>(target);
+    }
+
+    static NV_THERMAL_CONTROLLER MapThermalController(nvmlThermalController_t controller) {
+        switch (controller) {
+            case NVML_THERMAL_CONTROLLER_NONE:
+                return NVAPI_THERMAL_CONTROLLER_NONE;
+            case NVML_THERMAL_CONTROLLER_GPU_INTERNAL:
+                return NVAPI_THERMAL_CONTROLLER_GPU_INTERNAL;
+            case NVML_THERMAL_CONTROLLER_ADM1032:
+                return NVAPI_THERMAL_CONTROLLER_ADM1032;
+            // case NVML_THERMAL_CONTROLLER_ADT7461:
+            //     return NVAPI_THERMAL_CONTROLLER_ADT7461;
+            case NVML_THERMAL_CONTROLLER_MAX6649:
+                return NVAPI_THERMAL_CONTROLLER_MAX6649;
+            case NVML_THERMAL_CONTROLLER_MAX1617:
+                return NVAPI_THERMAL_CONTROLLER_MAX1617;
+            case NVML_THERMAL_CONTROLLER_LM99:
+                return NVAPI_THERMAL_CONTROLLER_LM99;
+            case NVML_THERMAL_CONTROLLER_LM89:
+                return NVAPI_THERMAL_CONTROLLER_LM89;
+            case NVML_THERMAL_CONTROLLER_LM64:
+                return NVAPI_THERMAL_CONTROLLER_LM64;
+            // case NVML_THERMAL_CONTROLLER_G781:
+            //     return NVAPI_THERMAL_CONTROLLER_G781;
+            case NVML_THERMAL_CONTROLLER_ADT7473:
+                return NVAPI_THERMAL_CONTROLLER_ADT7473;
+            case NVML_THERMAL_CONTROLLER_SBMAX6649:
+                return NVAPI_THERMAL_CONTROLLER_SBMAX6649;
+            case NVML_THERMAL_CONTROLLER_VBIOSEVT:
+                return NVAPI_THERMAL_CONTROLLER_VBIOSEVT;
+            case NVML_THERMAL_CONTROLLER_OS:
+                return NVAPI_THERMAL_CONTROLLER_OS;
+            // case NVML_THERMAL_CONTROLLER_NVSYSCON_CANOAS:
+            //     return NVAPI_THERMAL_CONTROLLER_NVSYSCON_CANOAS;
+            // case NVML_THERMAL_CONTROLLER_NVSYSCON_E551:
+            //     return NVAPI_THERMAL_CONTROLLER_NVSYSCON_E551;
+            // case NVML_THERMAL_CONTROLLER_MAX6649R:
+            //     return NVAPI_THERMAL_CONTROLLER_MAX6649R;
+            // case NVML_THERMAL_CONTROLLER_ADT7473S:
+            //     return NVAPI_THERMAL_CONTROLLER_ADT7473S;
+            default:
+                return NVAPI_THERMAL_CONTROLLER_UNKNOWN;
+        }
+    }
+
     NvAPI_Status __cdecl NvAPI_GPU_GetThermalSettings(NvPhysicalGpuHandle hPhysicalGpu, NvU32 sensorIndex, NV_GPU_THERMAL_SETTINGS* pThermalSettings) {
         constexpr auto n = __func__;
         static bool alreadyLoggedNoNvml = false;
@@ -452,7 +509,7 @@ extern "C" {
         if (!nvapiAdapterRegistry->IsAdapter(adapter))
             return ExpectedPhysicalGpuHandle(n);
 
-        if (sensorIndex != 0 && sensorIndex != NVAPI_THERMAL_TARGET_ALL) {
+        if (!adapter->HasNvmlDevice() && sensorIndex != 0 && sensorIndex != NVAPI_THERMAL_TARGET_ALL) {
             pThermalSettings->count = 0;
             return Ok(n, alreadyLoggedOk);
         }
@@ -463,8 +520,70 @@ extern "C" {
         if (!adapter->HasNvmlDevice())
             return HandleInvalidated(str::format(n, ": NVML available but current adapter is not NVML compatible"), alreadyLoggedHandleInvalidated);
 
+        nvmlGpuThermalSettings_t thermalSettings;
+        auto result = adapter->GetNvmlDeviceThermalSettings(sensorIndex, &thermalSettings);
+        switch (result) {
+            case NVML_SUCCESS:
+                switch (pThermalSettings->version) {
+                    case NV_GPU_THERMAL_SETTINGS_VER_1: {
+                        auto pThermalSettingsV1 = reinterpret_cast<NV_GPU_THERMAL_SETTINGS_V1*>(pThermalSettings);
+                        pThermalSettingsV1->count = thermalSettings.count;
+                        for (auto i = 0U; i < thermalSettings.count; i++) {
+                            pThermalSettingsV1->sensor[i].controller = MapThermalController(thermalSettings.sensor[i].controller);
+                            pThermalSettingsV1->sensor[i].target = MapThermalTarget(thermalSettings.sensor[i].target);
+                            pThermalSettingsV1->sensor[i].currentTemp = thermalSettings.sensor[i].currentTemp;
+                            pThermalSettingsV1->sensor[i].defaultMaxTemp = thermalSettings.sensor[i].defaultMaxTemp;
+                            pThermalSettingsV1->sensor[i].defaultMinTemp = thermalSettings.sensor[i].defaultMinTemp;
+                        }
+                        break;
+                    }
+                    case NV_GPU_THERMAL_SETTINGS_VER_2:
+                        pThermalSettings->count = thermalSettings.count;
+                        for (auto i = 0U; i < thermalSettings.count; i++) {
+                            pThermalSettings->sensor[i].controller = MapThermalController(thermalSettings.sensor[i].controller);
+                            pThermalSettings->sensor[i].target = MapThermalTarget(thermalSettings.sensor[i].target);
+                            pThermalSettings->sensor[i].currentTemp = static_cast<NvS32>(thermalSettings.sensor[i].currentTemp);
+                            pThermalSettings->sensor[i].defaultMaxTemp = static_cast<NvS32>(thermalSettings.sensor[i].defaultMaxTemp);
+                            pThermalSettings->sensor[i].defaultMinTemp = static_cast<NvS32>(thermalSettings.sensor[i].defaultMinTemp);
+                        }
+                        break;
+                    default:
+                        return Error(n); // Unreachable, but just to be sure
+                }
+                return Ok(n, alreadyLoggedOk);
+            case NVML_ERROR_FUNCTION_NOT_FOUND:
+                // probably an older version of NVML that doesn't support nvmlDeviceGetThermalSettings yet
+                // retry with nvmlDeviceGetTemperature before giving up
+                break;
+            case NVML_ERROR_INVALID_ARGUMENT:
+                return InvalidArgument(n);
+            case NVML_ERROR_NOT_SUPPORTED:
+                switch (pThermalSettings->version) {
+                    case NV_GPU_THERMAL_SETTINGS_VER_1: {
+                        auto pThermalSettingsV1 = reinterpret_cast<NV_GPU_THERMAL_SETTINGS_V1*>(pThermalSettings);
+                        pThermalSettingsV1->count = 0;
+                        break;
+                    }
+                    case NV_GPU_THERMAL_SETTINGS_VER_2:
+                        pThermalSettings->count = 0;
+                        break;
+                    default:
+                        return Error(n); // Unreachable, but just to be sure
+                }
+                return NotSupported(n);
+            case NVML_ERROR_GPU_IS_LOST:
+                return HandleInvalidated(n);
+            default:
+                return Error(str::format(n, ": ", adapter->GetNvmlErrorString(result)));
+        }
+
+        if (sensorIndex != 0 && sensorIndex != NVAPI_THERMAL_TARGET_ALL) {
+            pThermalSettings->count = 0;
+            return Ok(n, alreadyLoggedOk);
+        }
+
         unsigned int temp;
-        auto result = adapter->GetNvmlDeviceTemperature(NVML_TEMPERATURE_GPU, &temp);
+        result = adapter->GetNvmlDeviceTemperature(NVML_TEMPERATURE_GPU, &temp);
         switch (result) {
             case NVML_SUCCESS:
                 switch (pThermalSettings->version) {

--- a/src/nvapi_gpu.cpp
+++ b/src/nvapi_gpu.cpp
@@ -479,7 +479,7 @@ extern "C" {
             return HandleInvalidated(str::format(n, ": NVML available but current adapter is not NVML compatible"), alreadyLoggedHandleInvalidated);
 
         nvmlPstates_t pState;
-        auto result = adapter->GetNvmlPerformanceState(&pState);
+        auto result = adapter->GetNvmlDevicePerformanceState(&pState);
         switch (result) {
             case NVML_SUCCESS:
                 *pCurrentPstate = static_cast<NV_GPU_PERF_PSTATE_ID>(pState);

--- a/src/nvapi_gpu.cpp
+++ b/src/nvapi_gpu.cpp
@@ -307,6 +307,9 @@ extern "C" {
             case NVML_SUCCESS:
                 str::tonvss(szBiosRevision, version);
                 return Ok(n);
+            case NVML_ERROR_FUNCTION_NOT_FOUND:
+                str::tonvss(szBiosRevision, "N/A");
+                return Ok(n);
             case NVML_ERROR_NOT_SUPPORTED:
                 return NotSupported(n);
             case NVML_ERROR_GPU_IS_LOST:
@@ -358,6 +361,8 @@ extern "C" {
                     pDynamicPstatesInfoEx->utilization[i].bIsPresent = 0;
 
                 return Ok(n, alreadyLoggedOk);
+            case NVML_ERROR_FUNCTION_NOT_FOUND:
+                return NoImplementation(n, alreadyLoggedNoNvml);
             case NVML_ERROR_NOT_SUPPORTED:
                 pDynamicPstatesInfoEx->flags = 0;
                 for (auto& util : pDynamicPstatesInfoEx->utilization)
@@ -428,6 +433,8 @@ extern "C" {
                         return Error(n); // Unreachable, but just to be sure
                 }
                 return Ok(n, alreadyLoggedOk);
+            case NVML_ERROR_FUNCTION_NOT_FOUND:
+                return NoImplementation(n, alreadyLoggedNoNvml);
             case NVML_ERROR_NOT_SUPPORTED:
                 switch (pThermalSettings->version) {
                     case NV_GPU_THERMAL_SETTINGS_VER_1: {
@@ -477,6 +484,8 @@ extern "C" {
             case NVML_SUCCESS:
                 *pCurrentPstate = static_cast<NV_GPU_PERF_PSTATE_ID>(pState);
                 return Ok(n, alreadyLoggedOk);
+            case NVML_ERROR_FUNCTION_NOT_FOUND:
+                return NoImplementation(n, alreadyLoggedNoNvml);
             case NVML_ERROR_NOT_SUPPORTED:
                 return NotSupported(n);
             case NVML_ERROR_GPU_IS_LOST:
@@ -545,6 +554,8 @@ extern "C" {
                         return Error(n); // Unreachable, but just to be sure
                 }
                 break;
+            case NVML_ERROR_FUNCTION_NOT_FOUND:
+                return NoImplementation(n, alreadyLoggedNoNvml);
             case NVML_ERROR_NOT_SUPPORTED:
                 break;
             case NVML_ERROR_GPU_IS_LOST:

--- a/src/sysinfo/nvapi_adapter.cpp
+++ b/src/sysinfo/nvapi_adapter.cpp
@@ -258,6 +258,10 @@ namespace dxvk {
         return m_nvml.DeviceGetTemperature(m_nvmlDevice, sensorType, temp);
     }
 
+    nvmlReturn_t NvapiAdapter::GetNvmlDeviceThermalSettings(unsigned int sensorIndex, nvmlGpuThermalSettings_t* pThermalSettings) const {
+        return m_nvml.DeviceGetThermalSettings(m_nvmlDevice, sensorIndex, pThermalSettings);
+    }
+
     nvmlReturn_t NvapiAdapter::GetNvmlDevicePerformanceState(nvmlPstates_t* pState) const {
         return m_nvml.DeviceGetPerformanceState(m_nvmlDevice, pState);
     }

--- a/src/sysinfo/nvapi_adapter.cpp
+++ b/src/sysinfo/nvapi_adapter.cpp
@@ -262,7 +262,7 @@ namespace dxvk {
         return m_nvml.DeviceGetVbiosVersion(m_nvmlDevice, version, length);
     }
 
-    nvmlReturn_t NvapiAdapter::GetNvmlPerformanceState(nvmlPstates_t* pState) const {
+    nvmlReturn_t NvapiAdapter::GetNvmlDevicePerformanceState(nvmlPstates_t* pState) const {
         return m_nvml.DeviceGetPerformanceState(m_nvmlDevice, pState);
     }
 

--- a/src/sysinfo/nvapi_adapter.cpp
+++ b/src/sysinfo/nvapi_adapter.cpp
@@ -269,4 +269,12 @@ namespace dxvk {
     nvmlReturn_t NvapiAdapter::GetNvmlDeviceClockInfo(nvmlClockType_t type, unsigned int* clock) const {
         return m_nvml.DeviceGetClockInfo(m_nvmlDevice, type, clock);
     }
+
+    nvmlReturn_t NvapiAdapter::GetNvmlDeviceBusType(nvmlBusType_t* type) const {
+        return m_nvml.DeviceGetBusType(m_nvmlDevice, type);
+    }
+
+    nvmlReturn_t NvapiAdapter::GetNvmlDeviceDynamicPstatesInfo(nvmlGpuDynamicPstatesInfo_t* pDynamicPstatesInfo) const {
+        return m_nvml.DeviceGetDynamicPstatesInfo(m_nvmlDevice, pDynamicPstatesInfo);
+    }
 }

--- a/src/sysinfo/nvapi_adapter.cpp
+++ b/src/sysinfo/nvapi_adapter.cpp
@@ -250,8 +250,16 @@ namespace dxvk {
         return {m_nvml.ErrorString(result)};
     }
 
+    nvmlReturn_t NvapiAdapter::GetNvmlDeviceClockInfo(nvmlClockType_t type, unsigned int* clock) const {
+        return m_nvml.DeviceGetClockInfo(m_nvmlDevice, type, clock);
+    }
+
     nvmlReturn_t NvapiAdapter::GetNvmlDeviceTemperature(nvmlTemperatureSensors_t sensorType, unsigned int* temp) const {
         return m_nvml.DeviceGetTemperature(m_nvmlDevice, sensorType, temp);
+    }
+
+    nvmlReturn_t NvapiAdapter::GetNvmlDevicePerformanceState(nvmlPstates_t* pState) const {
+        return m_nvml.DeviceGetPerformanceState(m_nvmlDevice, pState);
     }
 
     nvmlReturn_t NvapiAdapter::GetNvmlDeviceUtilizationRates(nvmlUtilization_t* utilization) const {
@@ -260,14 +268,6 @@ namespace dxvk {
 
     nvmlReturn_t NvapiAdapter::GetNvmlDeviceVbiosVersion(char* version, unsigned int length) const {
         return m_nvml.DeviceGetVbiosVersion(m_nvmlDevice, version, length);
-    }
-
-    nvmlReturn_t NvapiAdapter::GetNvmlDevicePerformanceState(nvmlPstates_t* pState) const {
-        return m_nvml.DeviceGetPerformanceState(m_nvmlDevice, pState);
-    }
-
-    nvmlReturn_t NvapiAdapter::GetNvmlDeviceClockInfo(nvmlClockType_t type, unsigned int* clock) const {
-        return m_nvml.DeviceGetClockInfo(m_nvmlDevice, type, clock);
     }
 
     nvmlReturn_t NvapiAdapter::GetNvmlDeviceBusType(nvmlBusType_t* type) const {

--- a/src/sysinfo/nvapi_adapter.h
+++ b/src/sysinfo/nvapi_adapter.h
@@ -31,11 +31,11 @@ namespace dxvk {
         [[nodiscard]] bool HasNvml() const;
         [[nodiscard]] bool HasNvmlDevice() const;
         [[nodiscard]] std::string GetNvmlErrorString(nvmlReturn_t result) const;
+        [[nodiscard]] nvmlReturn_t GetNvmlDeviceClockInfo(nvmlClockType_t type, unsigned int* clock) const;
         [[nodiscard]] nvmlReturn_t GetNvmlDeviceTemperature(nvmlTemperatureSensors_t sensorType, unsigned int* temp) const;
+        [[nodiscard]] nvmlReturn_t GetNvmlDevicePerformanceState(nvmlPstates_t* pState) const;
         [[nodiscard]] nvmlReturn_t GetNvmlDeviceUtilizationRates(nvmlUtilization_t* utilization) const;
         [[nodiscard]] nvmlReturn_t GetNvmlDeviceVbiosVersion(char* version, unsigned int length) const;
-        [[nodiscard]] nvmlReturn_t GetNvmlDevicePerformanceState(nvmlPstates_t* pState) const;
-        [[nodiscard]] nvmlReturn_t GetNvmlDeviceClockInfo(nvmlClockType_t type, unsigned int* clock) const;
         [[nodiscard]] nvmlReturn_t GetNvmlDeviceBusType(nvmlBusType_t* type) const;
         [[nodiscard]] nvmlReturn_t GetNvmlDeviceDynamicPstatesInfo(nvmlGpuDynamicPstatesInfo_t* pDynamicPstatesInfo) const;
 

--- a/src/sysinfo/nvapi_adapter.h
+++ b/src/sysinfo/nvapi_adapter.h
@@ -36,6 +36,8 @@ namespace dxvk {
         [[nodiscard]] nvmlReturn_t GetNvmlDeviceVbiosVersion(char* version, unsigned int length) const;
         [[nodiscard]] nvmlReturn_t GetNvmlDevicePerformanceState(nvmlPstates_t* pState) const;
         [[nodiscard]] nvmlReturn_t GetNvmlDeviceClockInfo(nvmlClockType_t type, unsigned int* clock) const;
+        [[nodiscard]] nvmlReturn_t GetNvmlDeviceBusType(nvmlBusType_t* type) const;
+        [[nodiscard]] nvmlReturn_t GetNvmlDeviceDynamicPstatesInfo(nvmlGpuDynamicPstatesInfo_t* pDynamicPstatesInfo) const;
 
       private:
         Vulkan& m_vulkan;

--- a/src/sysinfo/nvapi_adapter.h
+++ b/src/sysinfo/nvapi_adapter.h
@@ -33,6 +33,7 @@ namespace dxvk {
         [[nodiscard]] std::string GetNvmlErrorString(nvmlReturn_t result) const;
         [[nodiscard]] nvmlReturn_t GetNvmlDeviceClockInfo(nvmlClockType_t type, unsigned int* clock) const;
         [[nodiscard]] nvmlReturn_t GetNvmlDeviceTemperature(nvmlTemperatureSensors_t sensorType, unsigned int* temp) const;
+        [[nodiscard]] nvmlReturn_t GetNvmlDeviceThermalSettings(unsigned int sensorIndex, nvmlGpuThermalSettings_t* pThermalSettings) const;
         [[nodiscard]] nvmlReturn_t GetNvmlDevicePerformanceState(nvmlPstates_t* pState) const;
         [[nodiscard]] nvmlReturn_t GetNvmlDeviceUtilizationRates(nvmlUtilization_t* utilization) const;
         [[nodiscard]] nvmlReturn_t GetNvmlDeviceVbiosVersion(char* version, unsigned int length) const;

--- a/src/sysinfo/nvapi_adapter.h
+++ b/src/sysinfo/nvapi_adapter.h
@@ -34,7 +34,7 @@ namespace dxvk {
         [[nodiscard]] nvmlReturn_t GetNvmlDeviceTemperature(nvmlTemperatureSensors_t sensorType, unsigned int* temp) const;
         [[nodiscard]] nvmlReturn_t GetNvmlDeviceUtilizationRates(nvmlUtilization_t* utilization) const;
         [[nodiscard]] nvmlReturn_t GetNvmlDeviceVbiosVersion(char* version, unsigned int length) const;
-        [[nodiscard]] nvmlReturn_t GetNvmlPerformanceState(nvmlPstates_t* pState) const;
+        [[nodiscard]] nvmlReturn_t GetNvmlDevicePerformanceState(nvmlPstates_t* pState) const;
         [[nodiscard]] nvmlReturn_t GetNvmlDeviceClockInfo(nvmlClockType_t type, unsigned int* clock) const;
 
       private:

--- a/src/sysinfo/nvml.cpp
+++ b/src/sysinfo/nvml.cpp
@@ -26,6 +26,8 @@ namespace dxvk {
         GETPROCADDR(nvmlDeviceGetVbiosVersion);
         GETPROCADDR(nvmlDeviceGetPerformanceState);
         GETPROCADDR(nvmlDeviceGetClockInfo);
+        GETPROCADDR(nvmlDeviceGetBusType);
+        GETPROCADDR(nvmlDeviceGetDynamicPstatesInfo);
 
 #undef GETPROCADDR
 
@@ -100,6 +102,18 @@ namespace dxvk {
     nvmlReturn_t Nvml::DeviceGetClockInfo(nvmlDevice_t device, nvmlClockType_t type, unsigned int* clock) const {
         return m_nvmlDeviceGetClockInfo
             ? m_nvmlDeviceGetClockInfo(device, type, clock)
+            : NVML_ERROR_FUNCTION_NOT_FOUND;
+    }
+
+    nvmlReturn_t Nvml::DeviceGetBusType(nvmlDevice_t device, nvmlBusType_t* type) const {
+        return m_nvmlDeviceGetBusType
+            ? m_nvmlDeviceGetBusType(device, type)
+            : NVML_ERROR_FUNCTION_NOT_FOUND;
+    }
+
+    nvmlReturn_t Nvml::DeviceGetDynamicPstatesInfo(nvmlDevice_t device, nvmlGpuDynamicPstatesInfo_t* pDynamicPstatesInfo) const {
+        return m_nvmlDeviceGetDynamicPstatesInfo
+            ? m_nvmlDeviceGetDynamicPstatesInfo(device, pDynamicPstatesInfo)
             : NVML_ERROR_FUNCTION_NOT_FOUND;
     }
 

--- a/src/sysinfo/nvml.cpp
+++ b/src/sysinfo/nvml.cpp
@@ -21,11 +21,11 @@ namespace dxvk {
         GETPROCADDR(nvmlErrorString);
         GETPROCADDR(nvmlDeviceGetHandleByPciBusId_v2);
         GETPROCADDR(nvmlDeviceGetPciInfo_v3);
+        GETPROCADDR(nvmlDeviceGetClockInfo);
         GETPROCADDR(nvmlDeviceGetTemperature);
+        GETPROCADDR(nvmlDeviceGetPerformanceState);
         GETPROCADDR(nvmlDeviceGetUtilizationRates);
         GETPROCADDR(nvmlDeviceGetVbiosVersion);
-        GETPROCADDR(nvmlDeviceGetPerformanceState);
-        GETPROCADDR(nvmlDeviceGetClockInfo);
         GETPROCADDR(nvmlDeviceGetBusType);
         GETPROCADDR(nvmlDeviceGetDynamicPstatesInfo);
 
@@ -75,9 +75,21 @@ namespace dxvk {
             : NVML_ERROR_FUNCTION_NOT_FOUND;
     }
 
+    nvmlReturn_t Nvml::DeviceGetClockInfo(nvmlDevice_t device, nvmlClockType_t type, unsigned int* clock) const {
+        return m_nvmlDeviceGetClockInfo
+            ? m_nvmlDeviceGetClockInfo(device, type, clock)
+            : NVML_ERROR_FUNCTION_NOT_FOUND;
+    }
+
     nvmlReturn_t Nvml::DeviceGetTemperature(nvmlDevice_t device, nvmlTemperatureSensors_t sensorType, unsigned int* temp) const {
         return m_nvmlDeviceGetTemperature
             ? m_nvmlDeviceGetTemperature(device, sensorType, temp)
+            : NVML_ERROR_FUNCTION_NOT_FOUND;
+    }
+
+    nvmlReturn_t Nvml::DeviceGetPerformanceState(nvmlDevice_t device, nvmlPstates_t* pState) const {
+        return m_nvmlDeviceGetPerformanceState
+            ? m_nvmlDeviceGetPerformanceState(device, pState)
             : NVML_ERROR_FUNCTION_NOT_FOUND;
     }
 
@@ -90,18 +102,6 @@ namespace dxvk {
     nvmlReturn_t Nvml::DeviceGetVbiosVersion(nvmlDevice_t device, char* version, unsigned int length) const {
         return m_nvmlDeviceGetVbiosVersion
             ? m_nvmlDeviceGetVbiosVersion(device, version, length)
-            : NVML_ERROR_FUNCTION_NOT_FOUND;
-    }
-
-    nvmlReturn_t Nvml::DeviceGetPerformanceState(nvmlDevice_t device, nvmlPstates_t* pState) const {
-        return m_nvmlDeviceGetPerformanceState
-            ? m_nvmlDeviceGetPerformanceState(device, pState)
-            : NVML_ERROR_FUNCTION_NOT_FOUND;
-    }
-
-    nvmlReturn_t Nvml::DeviceGetClockInfo(nvmlDevice_t device, nvmlClockType_t type, unsigned int* clock) const {
-        return m_nvmlDeviceGetClockInfo
-            ? m_nvmlDeviceGetClockInfo(device, type, clock)
             : NVML_ERROR_FUNCTION_NOT_FOUND;
     }
 

--- a/src/sysinfo/nvml.cpp
+++ b/src/sysinfo/nvml.cpp
@@ -14,16 +14,20 @@ namespace dxvk {
             return;
         }
 
-        m_nvmlInit_v2 = GetProcAddress<PFN_nvmlInit_v2>("nvmlInit_v2");
-        m_nvmlShutdown = GetProcAddress<PFN_nvmlShutdown>("nvmlShutdown");
-        m_nvmlErrorString = GetProcAddress<PFN_nvmlErrorString>("nvmlErrorString");
-        m_nvmlDeviceGetHandleByPciBusId_v2 = GetProcAddress<PFN_nvmlDeviceGetHandleByPciBusId_v2>("nvmlDeviceGetHandleByPciBusId_v2");
-        m_nvmlDeviceGetPciInfo_v3 = GetProcAddress<PFN_nvmlDeviceGetPciInfo_v3>("nvmlDeviceGetPciInfo_v3");
-        m_nvmlDeviceGetTemperature = GetProcAddress<PFN_nvmlDeviceGetTemperature>("nvmlDeviceGetTemperature");
-        m_nvmlDeviceGetUtilizationRates = GetProcAddress<PFN_nvmlDeviceGetUtilizationRates>("nvmlDeviceGetUtilizationRates");
-        m_nvmlDeviceGetVbiosVersion = GetProcAddress<PFN_nvmlDeviceGetVbiosVersion>("nvmlDeviceGetVbiosVersion");
-        m_nvmlDeviceGetPerformanceState = GetProcAddress<PFN_nvmlDeviceGetPerformanceState>("nvmlDeviceGetPerformanceState");
-        m_nvmlDeviceGetClockInfo = GetProcAddress<PFN_nvmlDeviceGetClockInfo>("nvmlDeviceGetClockInfo");
+#define GETPROCADDR(x) m_##x = GetProcAddress<PFN_##x>(#x)
+
+        GETPROCADDR(nvmlInit_v2);
+        GETPROCADDR(nvmlShutdown);
+        GETPROCADDR(nvmlErrorString);
+        GETPROCADDR(nvmlDeviceGetHandleByPciBusId_v2);
+        GETPROCADDR(nvmlDeviceGetPciInfo_v3);
+        GETPROCADDR(nvmlDeviceGetTemperature);
+        GETPROCADDR(nvmlDeviceGetUtilizationRates);
+        GETPROCADDR(nvmlDeviceGetVbiosVersion);
+        GETPROCADDR(nvmlDeviceGetPerformanceState);
+        GETPROCADDR(nvmlDeviceGetClockInfo);
+
+#undef GETPROCADDR
 
         if (m_nvmlInit_v2 == nullptr
             || m_nvmlShutdown == nullptr

--- a/src/sysinfo/nvml.cpp
+++ b/src/sysinfo/nvml.cpp
@@ -124,6 +124,83 @@ namespace dxvk {
             : NVML_ERROR_FUNCTION_NOT_FOUND;
     }
 
+    NV_THERMAL_TARGET Nvml::ToNvThermalTarget(nvmlThermalTarget_t target) {
+        static_assert(static_cast<int>(NVML_THERMAL_TARGET_NONE) == static_cast<int>(NVAPI_THERMAL_TARGET_NONE));
+        static_assert(static_cast<int>(NVML_THERMAL_TARGET_GPU) == static_cast<int>(NVAPI_THERMAL_TARGET_GPU));
+        static_assert(static_cast<int>(NVML_THERMAL_TARGET_MEMORY) == static_cast<int>(NVAPI_THERMAL_TARGET_MEMORY));
+        static_assert(static_cast<int>(NVML_THERMAL_TARGET_POWER_SUPPLY) == static_cast<int>(NVAPI_THERMAL_TARGET_POWER_SUPPLY));
+        static_assert(static_cast<int>(NVML_THERMAL_TARGET_BOARD) == static_cast<int>(NVAPI_THERMAL_TARGET_BOARD));
+        static_assert(static_cast<int>(NVML_THERMAL_TARGET_VCD_BOARD) == static_cast<int>(NVAPI_THERMAL_TARGET_VCD_BOARD));
+        static_assert(static_cast<int>(NVML_THERMAL_TARGET_VCD_INLET) == static_cast<int>(NVAPI_THERMAL_TARGET_VCD_INLET));
+        static_assert(static_cast<int>(NVML_THERMAL_TARGET_VCD_OUTLET) == static_cast<int>(NVAPI_THERMAL_TARGET_VCD_OUTLET));
+        static_assert(static_cast<int>(NVML_THERMAL_TARGET_ALL) == static_cast<int>(NVAPI_THERMAL_TARGET_ALL));
+        static_assert(static_cast<int>(NVML_THERMAL_TARGET_UNKNOWN) == static_cast<int>(NVAPI_THERMAL_TARGET_UNKNOWN));
+        return static_cast<NV_THERMAL_TARGET>(target);
+    }
+
+    NV_THERMAL_CONTROLLER Nvml::ToNvThermalController(nvmlThermalController_t controller) {
+        switch (controller) {
+            case NVML_THERMAL_CONTROLLER_NONE:
+                return NVAPI_THERMAL_CONTROLLER_NONE;
+            case NVML_THERMAL_CONTROLLER_GPU_INTERNAL:
+                return NVAPI_THERMAL_CONTROLLER_GPU_INTERNAL;
+            case NVML_THERMAL_CONTROLLER_ADM1032:
+                return NVAPI_THERMAL_CONTROLLER_ADM1032;
+            // case NVML_THERMAL_CONTROLLER_ADT7461:
+            //     return NVAPI_THERMAL_CONTROLLER_ADT7461;
+            case NVML_THERMAL_CONTROLLER_MAX6649:
+                return NVAPI_THERMAL_CONTROLLER_MAX6649;
+            case NVML_THERMAL_CONTROLLER_MAX1617:
+                return NVAPI_THERMAL_CONTROLLER_MAX1617;
+            case NVML_THERMAL_CONTROLLER_LM99:
+                return NVAPI_THERMAL_CONTROLLER_LM99;
+            case NVML_THERMAL_CONTROLLER_LM89:
+                return NVAPI_THERMAL_CONTROLLER_LM89;
+            case NVML_THERMAL_CONTROLLER_LM64:
+                return NVAPI_THERMAL_CONTROLLER_LM64;
+            // case NVML_THERMAL_CONTROLLER_G781:
+            //     return NVAPI_THERMAL_CONTROLLER_G781;
+            case NVML_THERMAL_CONTROLLER_ADT7473:
+                return NVAPI_THERMAL_CONTROLLER_ADT7473;
+            case NVML_THERMAL_CONTROLLER_SBMAX6649:
+                return NVAPI_THERMAL_CONTROLLER_SBMAX6649;
+            case NVML_THERMAL_CONTROLLER_VBIOSEVT:
+                return NVAPI_THERMAL_CONTROLLER_VBIOSEVT;
+            case NVML_THERMAL_CONTROLLER_OS:
+                return NVAPI_THERMAL_CONTROLLER_OS;
+            // case NVML_THERMAL_CONTROLLER_NVSYSCON_CANOAS:
+            //     return NVAPI_THERMAL_CONTROLLER_NVSYSCON_CANOAS;
+            // case NVML_THERMAL_CONTROLLER_NVSYSCON_E551:
+            //     return NVAPI_THERMAL_CONTROLLER_NVSYSCON_E551;
+            // case NVML_THERMAL_CONTROLLER_MAX6649R:
+            //     return NVAPI_THERMAL_CONTROLLER_MAX6649R;
+            // case NVML_THERMAL_CONTROLLER_ADT7473S:
+            //     return NVAPI_THERMAL_CONTROLLER_ADT7473S;
+            default:
+                return NVAPI_THERMAL_CONTROLLER_UNKNOWN;
+        }
+    }
+
+    NV_GPU_BUS_TYPE Nvml::ToNvGpuBusType(nvmlBusType_t type) {
+        switch (type) {
+            case NVML_BUS_TYPE_PCI:
+                return NVAPI_GPU_BUS_TYPE_PCI;
+                break;
+            case NVML_BUS_TYPE_PCIE:
+                return NVAPI_GPU_BUS_TYPE_PCI_EXPRESS;
+                break;
+            case NVML_BUS_TYPE_FPCI:
+                return NVAPI_GPU_BUS_TYPE_FPCI;
+                break;
+            case NVML_BUS_TYPE_AGP:
+                return NVAPI_GPU_BUS_TYPE_AGP;
+                break;
+            default:
+                return NVAPI_GPU_BUS_TYPE_UNDEFINED;
+                break;
+        }
+    }
+
     template <typename T>
     T Nvml::GetProcAddress(const char* name) {
         return reinterpret_cast<T>(reinterpret_cast<void*>(::GetProcAddress(m_nvmlModule, name)));

--- a/src/sysinfo/nvml.cpp
+++ b/src/sysinfo/nvml.cpp
@@ -23,6 +23,7 @@ namespace dxvk {
         GETPROCADDR(nvmlDeviceGetPciInfo_v3);
         GETPROCADDR(nvmlDeviceGetClockInfo);
         GETPROCADDR(nvmlDeviceGetTemperature);
+        GETPROCADDR(nvmlDeviceGetThermalSettings);
         GETPROCADDR(nvmlDeviceGetPerformanceState);
         GETPROCADDR(nvmlDeviceGetUtilizationRates);
         GETPROCADDR(nvmlDeviceGetVbiosVersion);
@@ -84,6 +85,12 @@ namespace dxvk {
     nvmlReturn_t Nvml::DeviceGetTemperature(nvmlDevice_t device, nvmlTemperatureSensors_t sensorType, unsigned int* temp) const {
         return m_nvmlDeviceGetTemperature
             ? m_nvmlDeviceGetTemperature(device, sensorType, temp)
+            : NVML_ERROR_FUNCTION_NOT_FOUND;
+    }
+
+    nvmlReturn_t Nvml::DeviceGetThermalSettings(nvmlDevice_t device, unsigned int sensorIndex, nvmlGpuThermalSettings_t* pThermalSettings) const {
+        return m_nvmlDeviceGetThermalSettings
+            ? m_nvmlDeviceGetThermalSettings(device, sensorIndex, pThermalSettings)
             : NVML_ERROR_FUNCTION_NOT_FOUND;
     }
 

--- a/src/sysinfo/nvml.cpp
+++ b/src/sysinfo/nvml.cpp
@@ -32,13 +32,7 @@ namespace dxvk {
         if (m_nvmlInit_v2 == nullptr
             || m_nvmlShutdown == nullptr
             || m_nvmlErrorString == nullptr
-            || m_nvmlDeviceGetHandleByPciBusId_v2 == nullptr
-            || m_nvmlDeviceGetPciInfo_v3 == nullptr
-            || m_nvmlDeviceGetTemperature == nullptr
-            || m_nvmlDeviceGetUtilizationRates == nullptr
-            || m_nvmlDeviceGetVbiosVersion == nullptr
-            || m_nvmlDeviceGetPerformanceState == nullptr
-            || m_nvmlDeviceGetClockInfo == nullptr)
+            || m_nvmlDeviceGetHandleByPciBusId_v2 == nullptr)
             log::write(str::format("NVML loaded but initialization failed"));
         else {
             auto result = m_nvmlInit_v2();
@@ -74,27 +68,39 @@ namespace dxvk {
     }
 
     nvmlReturn_t Nvml::DeviceGetPciInfo_v3(nvmlDevice_t device, nvmlPciInfo_t* pci) const {
-        return m_nvmlDeviceGetPciInfo_v3(device, pci);
+        return m_nvmlDeviceGetPciInfo_v3
+            ? m_nvmlDeviceGetPciInfo_v3(device, pci)
+            : NVML_ERROR_FUNCTION_NOT_FOUND;
     }
 
     nvmlReturn_t Nvml::DeviceGetTemperature(nvmlDevice_t device, nvmlTemperatureSensors_t sensorType, unsigned int* temp) const {
-        return m_nvmlDeviceGetTemperature(device, sensorType, temp);
+        return m_nvmlDeviceGetTemperature
+            ? m_nvmlDeviceGetTemperature(device, sensorType, temp)
+            : NVML_ERROR_FUNCTION_NOT_FOUND;
     }
 
     nvmlReturn_t Nvml::DeviceGetUtilizationRates(nvmlDevice_t device, nvmlUtilization_t* utilization) const {
-        return m_nvmlDeviceGetUtilizationRates(device, utilization);
+        return m_nvmlDeviceGetUtilizationRates
+            ? m_nvmlDeviceGetUtilizationRates(device, utilization)
+            : NVML_ERROR_FUNCTION_NOT_FOUND;
     }
 
     nvmlReturn_t Nvml::DeviceGetVbiosVersion(nvmlDevice_t device, char* version, unsigned int length) const {
-        return m_nvmlDeviceGetVbiosVersion(device, version, length);
+        return m_nvmlDeviceGetVbiosVersion
+            ? m_nvmlDeviceGetVbiosVersion(device, version, length)
+            : NVML_ERROR_FUNCTION_NOT_FOUND;
     }
 
     nvmlReturn_t Nvml::DeviceGetPerformanceState(nvmlDevice_t device, nvmlPstates_t* pState) const {
-        return m_nvmlDeviceGetPerformanceState(device, pState);
+        return m_nvmlDeviceGetPerformanceState
+            ? m_nvmlDeviceGetPerformanceState(device, pState)
+            : NVML_ERROR_FUNCTION_NOT_FOUND;
     }
 
     nvmlReturn_t Nvml::DeviceGetClockInfo(nvmlDevice_t device, nvmlClockType_t type, unsigned int* clock) const {
-        return m_nvmlDeviceGetClockInfo(device, type, clock);
+        return m_nvmlDeviceGetClockInfo
+            ? m_nvmlDeviceGetClockInfo(device, type, clock)
+            : NVML_ERROR_FUNCTION_NOT_FOUND;
     }
 
     template <typename T>

--- a/src/sysinfo/nvml.h
+++ b/src/sysinfo/nvml.h
@@ -13,11 +13,11 @@ namespace dxvk {
         [[nodiscard]] virtual const char* ErrorString(nvmlReturn_t result) const;
         [[nodiscard]] virtual nvmlReturn_t DeviceGetHandleByPciBusId_v2(const char* pciBusId, nvmlDevice_t* device) const;
         [[nodiscard]] virtual nvmlReturn_t DeviceGetPciInfo_v3(nvmlDevice_t device, nvmlPciInfo_t* pci) const;
+        [[nodiscard]] virtual nvmlReturn_t DeviceGetClockInfo(nvmlDevice_t device, nvmlClockType_t type, unsigned int* clock) const;
         [[nodiscard]] virtual nvmlReturn_t DeviceGetTemperature(nvmlDevice_t device, nvmlTemperatureSensors_t sensorType, unsigned int* temp) const;
+        [[nodiscard]] virtual nvmlReturn_t DeviceGetPerformanceState(nvmlDevice_t device, nvmlPstates_t* pState) const;
         [[nodiscard]] virtual nvmlReturn_t DeviceGetUtilizationRates(nvmlDevice_t device, nvmlUtilization_t* utilization) const;
         [[nodiscard]] virtual nvmlReturn_t DeviceGetVbiosVersion(nvmlDevice_t device, char* version, unsigned int length) const;
-        [[nodiscard]] virtual nvmlReturn_t DeviceGetPerformanceState(nvmlDevice_t device, nvmlPstates_t* pState) const;
-        [[nodiscard]] virtual nvmlReturn_t DeviceGetClockInfo(nvmlDevice_t device, nvmlClockType_t type, unsigned int* clock) const;
         [[nodiscard]] virtual nvmlReturn_t DeviceGetBusType(nvmlDevice_t device, nvmlBusType_t* type) const;
         [[nodiscard]] virtual nvmlReturn_t DeviceGetDynamicPstatesInfo(nvmlDevice_t device, nvmlGpuDynamicPstatesInfo_t* pDynamicPstatesInfo) const;
 
@@ -27,11 +27,11 @@ namespace dxvk {
         typedef decltype(&nvmlErrorString) PFN_nvmlErrorString;
         typedef decltype(&nvmlDeviceGetHandleByPciBusId_v2) PFN_nvmlDeviceGetHandleByPciBusId_v2;
         typedef decltype(&nvmlDeviceGetPciInfo_v3) PFN_nvmlDeviceGetPciInfo_v3;
+        typedef decltype(&nvmlDeviceGetClockInfo) PFN_nvmlDeviceGetClockInfo;
         typedef decltype(&nvmlDeviceGetTemperature) PFN_nvmlDeviceGetTemperature;
+        typedef decltype(&nvmlDeviceGetPerformanceState) PFN_nvmlDeviceGetPerformanceState;
         typedef decltype(&nvmlDeviceGetUtilizationRates) PFN_nvmlDeviceGetUtilizationRates;
         typedef decltype(&nvmlDeviceGetVbiosVersion) PFN_nvmlDeviceGetVbiosVersion;
-        typedef decltype(&nvmlDeviceGetPerformanceState) PFN_nvmlDeviceGetPerformanceState;
-        typedef decltype(&nvmlDeviceGetClockInfo) PFN_nvmlDeviceGetClockInfo;
         typedef decltype(&nvmlDeviceGetBusType) PFN_nvmlDeviceGetBusType;
         typedef decltype(&nvmlDeviceGetDynamicPstatesInfo) PFN_nvmlDeviceGetDynamicPstatesInfo;
 
@@ -41,11 +41,11 @@ namespace dxvk {
         PFN_nvmlErrorString m_nvmlErrorString{};
         PFN_nvmlDeviceGetHandleByPciBusId_v2 m_nvmlDeviceGetHandleByPciBusId_v2{};
         PFN_nvmlDeviceGetPciInfo_v3 m_nvmlDeviceGetPciInfo_v3{};
+        PFN_nvmlDeviceGetClockInfo m_nvmlDeviceGetClockInfo{};
         PFN_nvmlDeviceGetTemperature m_nvmlDeviceGetTemperature{};
+        PFN_nvmlDeviceGetPerformanceState m_nvmlDeviceGetPerformanceState{};
         PFN_nvmlDeviceGetUtilizationRates m_nvmlDeviceGetUtilizationRates{};
         PFN_nvmlDeviceGetVbiosVersion m_nvmlDeviceGetVbiosVersion{};
-        PFN_nvmlDeviceGetPerformanceState m_nvmlDeviceGetPerformanceState{};
-        PFN_nvmlDeviceGetClockInfo m_nvmlDeviceGetClockInfo{};
         PFN_nvmlDeviceGetBusType m_nvmlDeviceGetBusType{};
         PFN_nvmlDeviceGetDynamicPstatesInfo m_nvmlDeviceGetDynamicPstatesInfo{};
 

--- a/src/sysinfo/nvml.h
+++ b/src/sysinfo/nvml.h
@@ -22,6 +22,10 @@ namespace dxvk {
         [[nodiscard]] virtual nvmlReturn_t DeviceGetBusType(nvmlDevice_t device, nvmlBusType_t* type) const;
         [[nodiscard]] virtual nvmlReturn_t DeviceGetDynamicPstatesInfo(nvmlDevice_t device, nvmlGpuDynamicPstatesInfo_t* pDynamicPstatesInfo) const;
 
+        [[nodiscard]] static NV_THERMAL_TARGET ToNvThermalTarget(nvmlThermalTarget_t target);
+        [[nodiscard]] static NV_THERMAL_CONTROLLER ToNvThermalController(nvmlThermalController_t controller);
+        [[nodiscard]] static NV_GPU_BUS_TYPE ToNvGpuBusType(nvmlBusType_t type);
+
       private:
         typedef decltype(&nvmlInit_v2) PFN_nvmlInit_v2;
         typedef decltype(&nvmlShutdown) PFN_nvmlShutdown;

--- a/src/sysinfo/nvml.h
+++ b/src/sysinfo/nvml.h
@@ -15,6 +15,7 @@ namespace dxvk {
         [[nodiscard]] virtual nvmlReturn_t DeviceGetPciInfo_v3(nvmlDevice_t device, nvmlPciInfo_t* pci) const;
         [[nodiscard]] virtual nvmlReturn_t DeviceGetClockInfo(nvmlDevice_t device, nvmlClockType_t type, unsigned int* clock) const;
         [[nodiscard]] virtual nvmlReturn_t DeviceGetTemperature(nvmlDevice_t device, nvmlTemperatureSensors_t sensorType, unsigned int* temp) const;
+        [[nodiscard]] virtual nvmlReturn_t DeviceGetThermalSettings(nvmlDevice_t device, unsigned int sensorIndex, nvmlGpuThermalSettings_t* pThermalSettings) const;
         [[nodiscard]] virtual nvmlReturn_t DeviceGetPerformanceState(nvmlDevice_t device, nvmlPstates_t* pState) const;
         [[nodiscard]] virtual nvmlReturn_t DeviceGetUtilizationRates(nvmlDevice_t device, nvmlUtilization_t* utilization) const;
         [[nodiscard]] virtual nvmlReturn_t DeviceGetVbiosVersion(nvmlDevice_t device, char* version, unsigned int length) const;
@@ -29,6 +30,7 @@ namespace dxvk {
         typedef decltype(&nvmlDeviceGetPciInfo_v3) PFN_nvmlDeviceGetPciInfo_v3;
         typedef decltype(&nvmlDeviceGetClockInfo) PFN_nvmlDeviceGetClockInfo;
         typedef decltype(&nvmlDeviceGetTemperature) PFN_nvmlDeviceGetTemperature;
+        typedef decltype(&nvmlDeviceGetThermalSettings) PFN_nvmlDeviceGetThermalSettings;
         typedef decltype(&nvmlDeviceGetPerformanceState) PFN_nvmlDeviceGetPerformanceState;
         typedef decltype(&nvmlDeviceGetUtilizationRates) PFN_nvmlDeviceGetUtilizationRates;
         typedef decltype(&nvmlDeviceGetVbiosVersion) PFN_nvmlDeviceGetVbiosVersion;
@@ -43,6 +45,7 @@ namespace dxvk {
         PFN_nvmlDeviceGetPciInfo_v3 m_nvmlDeviceGetPciInfo_v3{};
         PFN_nvmlDeviceGetClockInfo m_nvmlDeviceGetClockInfo{};
         PFN_nvmlDeviceGetTemperature m_nvmlDeviceGetTemperature{};
+        PFN_nvmlDeviceGetThermalSettings m_nvmlDeviceGetThermalSettings{};
         PFN_nvmlDeviceGetPerformanceState m_nvmlDeviceGetPerformanceState{};
         PFN_nvmlDeviceGetUtilizationRates m_nvmlDeviceGetUtilizationRates{};
         PFN_nvmlDeviceGetVbiosVersion m_nvmlDeviceGetVbiosVersion{};

--- a/src/sysinfo/nvml.h
+++ b/src/sysinfo/nvml.h
@@ -18,6 +18,8 @@ namespace dxvk {
         [[nodiscard]] virtual nvmlReturn_t DeviceGetVbiosVersion(nvmlDevice_t device, char* version, unsigned int length) const;
         [[nodiscard]] virtual nvmlReturn_t DeviceGetPerformanceState(nvmlDevice_t device, nvmlPstates_t* pState) const;
         [[nodiscard]] virtual nvmlReturn_t DeviceGetClockInfo(nvmlDevice_t device, nvmlClockType_t type, unsigned int* clock) const;
+        [[nodiscard]] virtual nvmlReturn_t DeviceGetBusType(nvmlDevice_t device, nvmlBusType_t* type) const;
+        [[nodiscard]] virtual nvmlReturn_t DeviceGetDynamicPstatesInfo(nvmlDevice_t device, nvmlGpuDynamicPstatesInfo_t* pDynamicPstatesInfo) const;
 
       private:
         typedef decltype(&nvmlInit_v2) PFN_nvmlInit_v2;
@@ -30,6 +32,8 @@ namespace dxvk {
         typedef decltype(&nvmlDeviceGetVbiosVersion) PFN_nvmlDeviceGetVbiosVersion;
         typedef decltype(&nvmlDeviceGetPerformanceState) PFN_nvmlDeviceGetPerformanceState;
         typedef decltype(&nvmlDeviceGetClockInfo) PFN_nvmlDeviceGetClockInfo;
+        typedef decltype(&nvmlDeviceGetBusType) PFN_nvmlDeviceGetBusType;
+        typedef decltype(&nvmlDeviceGetDynamicPstatesInfo) PFN_nvmlDeviceGetDynamicPstatesInfo;
 
         HMODULE m_nvmlModule{};
         PFN_nvmlInit_v2 m_nvmlInit_v2{};
@@ -42,6 +46,8 @@ namespace dxvk {
         PFN_nvmlDeviceGetVbiosVersion m_nvmlDeviceGetVbiosVersion{};
         PFN_nvmlDeviceGetPerformanceState m_nvmlDeviceGetPerformanceState{};
         PFN_nvmlDeviceGetClockInfo m_nvmlDeviceGetClockInfo{};
+        PFN_nvmlDeviceGetBusType m_nvmlDeviceGetBusType{};
+        PFN_nvmlDeviceGetDynamicPstatesInfo m_nvmlDeviceGetDynamicPstatesInfo{};
 
         template <typename T>
         T GetProcAddress(const char* name);

--- a/tests/nvapi_sysinfo_mocks.h
+++ b/tests/nvapi_sysinfo_mocks.h
@@ -73,9 +73,12 @@ class NvmlMock : public trompeloeil::mock_interface<dxvk::Nvml> {
     IMPLEMENT_CONST_MOCK1(ErrorString);
     IMPLEMENT_CONST_MOCK2(DeviceGetHandleByPciBusId_v2);
     IMPLEMENT_CONST_MOCK2(DeviceGetPciInfo_v3);
+    IMPLEMENT_CONST_MOCK3(DeviceGetClockInfo);
     IMPLEMENT_CONST_MOCK3(DeviceGetTemperature);
+    IMPLEMENT_CONST_MOCK3(DeviceGetThermalSettings);
+    IMPLEMENT_CONST_MOCK2(DeviceGetPerformanceState);
     IMPLEMENT_CONST_MOCK2(DeviceGetUtilizationRates);
     IMPLEMENT_CONST_MOCK3(DeviceGetVbiosVersion);
-    IMPLEMENT_CONST_MOCK2(DeviceGetPerformanceState);
-    IMPLEMENT_CONST_MOCK3(DeviceGetClockInfo);
+    IMPLEMENT_CONST_MOCK2(DeviceGetBusType);
+    IMPLEMENT_CONST_MOCK2(DeviceGetDynamicPstatesInfo);
 };


### PR DESCRIPTION
An attempt to reimplement a few NVAPI functions using better NVML counterparts from newer API versions. Not tested yet because the only Windows machine I have at hand is a very small VM I set up on my laptop and doing GPU passthrough is annoying so I wanted to gather some feedback and ensure you're willing to accept a PR like this before actually getting my hands dirty :sweat_smile:

Some notes:
* I still need to fix/update tests
* we no longer require all NVML function to be present in the loaded library
* old implementations are kept as a fallback in case new functions are not available
* `nvmlDeviceGetDynamicPstatesInfo` and `nvmlDeviceGetThermalSettings` seem to be almost direct "ports" of `NvAPI_GPU_GetDynamicPstatesInfoEx` and `NvAPI_GPU_GetThermalSettings` respectively, but apparently they are not exactly the same (pending some testing):
  * `nvmlDeviceGetDynamicPstatesInfo` has `flags` which are "reserved for future use", while `NvAPI_GPU_GetDynamicPstatesInfoEx` has one already documented flag
  * thermal controller enums have known values ordered differently and NVML knows about a few more than NVAPI
  * it's undocumented/unknown whether `nvmlDeviceGetThermalSettings` accepts `NVAPI_THERMAL_TARGET_ALL` for `sensorIndex` to retrieve info for all sensors like `NvAPI_GPU_GetThermalSettings` does
  * returned temperature values are unsigned, making `nvmlDeviceGetThermalSettings` closer to V1 version of `NvAPI_GPU_GetThermalSettings`, fortunately we should be able to safely cast values from expected range to signed integers for V2 and just never report negative values this way
* there are a few more low hanging fruits which can be implemented using new functions:
  * `NvAPI_GPU_GetCurrentPCIEDownstreamWidth` using `nvmlDeviceGetCurrPcieLinkWidth` (wasn't this previously stubbed out?)
  * `NvAPI_GPU_GetIRQ` using `nvmlDeviceGetIrqNum`
  * `NvAPI_GPU_GetGpuCoreCount` using `nvmlDeviceGetNumGpuCores`

In the meantime, I'm working on the [next version of `wine-nvml`](https://github.com/Saancreed/wine-nvml/pull/6) that uses Wine's unixlib syscall interface and automatically generates code from NVIDIA's API header, which in theory should make adding support for new functions as they get released much easier in the future.