### PR TITLE
nvapi-adapter: Report vram size based on DXGI adapter

### DIFF
--- a/src/sysinfo/nvapi_adapter.h
+++ b/src/sysinfo/nvapi_adapter.h
@@ -51,10 +51,10 @@ namespace dxvk {
         VkPhysicalDeviceProperties m_deviceProperties{};
         VkPhysicalDeviceIDProperties m_deviceIdProperties{};
         VkPhysicalDevicePCIBusInfoPropertiesEXT m_devicePciBusProperties{};
-        VkPhysicalDeviceMemoryProperties m_memoryProperties{};
         VkPhysicalDeviceDriverPropertiesKHR m_deviceDriverProperties{};
         VkPhysicalDeviceFragmentShadingRatePropertiesKHR m_deviceFragmentShadingRateProperties{};
         uint32_t m_vkDriverVersion{};
+        uint32_t m_dedicatedVideoMemory{};
 
         nvmlDevice_t m_nvmlDevice{};
 

--- a/src/sysinfo/vulkan.cpp
+++ b/src/sysinfo/vulkan.cpp
@@ -41,14 +41,6 @@ namespace dxvk {
         vkGetPhysicalDeviceProperties2(vkDevice, deviceProperties2);
     }
 
-    void Vulkan::GetPhysicalDeviceMemoryProperties2(VkInstance vkInstance, VkPhysicalDevice vkDevice, VkPhysicalDeviceMemoryProperties2* memoryProperties2) const {
-        auto vkGetPhysicalDeviceMemoryProperties2 =
-            GetInstanceProcAddress<PFN_vkGetPhysicalDeviceMemoryProperties2>(
-                vkInstance, "vkGetPhysicalDeviceMemoryProperties2");
-
-        vkGetPhysicalDeviceMemoryProperties2(vkDevice, memoryProperties2);
-    }
-
     NV_GPU_TYPE Vulkan::ToNvGpuType(VkPhysicalDeviceType vkDeviceType) {
         // Assert enum value equality between Vulkan and NVAPI at compile time
         static_assert(static_cast<int>(VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU) == static_cast<int>(NV_SYSTEM_TYPE_DGPU));

--- a/src/sysinfo/vulkan.h
+++ b/src/sysinfo/vulkan.h
@@ -14,7 +14,6 @@ namespace dxvk {
         [[nodiscard]] virtual bool IsAvailable() const;
         [[nodiscard]] virtual std::set<std::string> GetDeviceExtensions(VkInstance vkInstance, VkPhysicalDevice vkDevice) const;
         virtual void GetPhysicalDeviceProperties2(VkInstance vkInstance, VkPhysicalDevice vkDevice, VkPhysicalDeviceProperties2* deviceProperties2) const;
-        virtual void GetPhysicalDeviceMemoryProperties2(VkInstance vkInstance, VkPhysicalDevice vkDevice, VkPhysicalDeviceMemoryProperties2* memoryProperties2) const;
 
         [[nodiscard]] static NV_GPU_TYPE ToNvGpuType(VkPhysicalDeviceType vkDeviceType);
 

--- a/tests/nvapi_sysinfo.cpp
+++ b/tests/nvapi_sysinfo.cpp
@@ -410,12 +410,11 @@ TEST_CASE("Sysinfo methods succeed", "[.sysinfo]") {
     }
 
     SECTION("GetPhysicalFrameBufferSize returns OK") {
-        ALLOW_CALL(*vulkan, GetPhysicalDeviceMemoryProperties2(_, _, _)) // NOLINT(bugprone-use-after-move)
-            .SIDE_EFFECT({
-                _3->memoryProperties.memoryHeapCount = 1;
-                _3->memoryProperties.memoryHeaps[0].flags = VK_MEMORY_HEAP_DEVICE_LOCAL_BIT;
-                _3->memoryProperties.memoryHeaps[0].size = 8191 * 1024;
-            });
+        DXGI_ADAPTER_DESC1 desc{};
+        desc.DedicatedVideoMemory = 8191 * 1024;
+        ALLOW_CALL(adapter, GetDesc1(_))
+            .LR_SIDE_EFFECT(*_1 = desc)
+            .RETURN(S_OK);
 
         SetupResourceFactory(std::move(dxgiFactory), std::move(vulkan), std::move(nvml), std::move(lfx));
         REQUIRE(NvAPI_Initialize() == NVAPI_OK);

--- a/tests/nvapi_sysinfo_mocks.h
+++ b/tests/nvapi_sysinfo_mocks.h
@@ -75,7 +75,6 @@ class VulkanMock : public trompeloeil::mock_interface<dxvk::Vulkan> {
     IMPLEMENT_CONST_MOCK0(IsAvailable);
     IMPLEMENT_CONST_MOCK2(GetDeviceExtensions);
     IMPLEMENT_CONST_MOCK3(GetPhysicalDeviceProperties2);
-    IMPLEMENT_CONST_MOCK3(GetPhysicalDeviceMemoryProperties2);
 };
 
 class NvmlMock : public trompeloeil::mock_interface<dxvk::Nvml> {

--- a/tests/resource_factory_util.cpp
+++ b/tests/resource_factory_util.cpp
@@ -13,7 +13,7 @@ void SetupResourceFactory(
     initializationCount = 0ULL;
 }
 
-[[nodiscard]] std::array<std::unique_ptr<expectation>, 18> ConfigureDefaultTestEnvironment(
+[[nodiscard]] std::array<std::unique_ptr<expectation>, 19> ConfigureDefaultTestEnvironment(
     DXGIFactory1Mock& dxgiFactory,
     VulkanMock& vulkan,
     NvmlMock& nvml,
@@ -36,6 +36,8 @@ void SetupResourceFactory(
             .RETURN(S_OK),
         NAMED_ALLOW_CALL(adapter, Release())
             .RETURN(0),
+        NAMED_ALLOW_CALL(adapter, GetDesc1(_))
+            .RETURN(E_FAIL),
         NAMED_ALLOW_CALL(adapter, EnumOutputs(0U, _))
             .LR_SIDE_EFFECT(*_2 = static_cast<IDXGIOutput*>(&output))
             .RETURN(S_OK),
@@ -71,7 +73,7 @@ void SetupResourceFactory(
             .RETURN(false)};
 }
 
-[[nodiscard]] std::array<std::unique_ptr<expectation>, 32> ConfigureExtendedTestEnvironment(
+[[nodiscard]] std::array<std::unique_ptr<expectation>, 34> ConfigureExtendedTestEnvironment(
     DXGIFactory1Mock& dxgiFactory,
     VulkanMock& vulkan,
     NvmlMock& nvml,
@@ -100,6 +102,8 @@ void SetupResourceFactory(
             .RETURN(S_OK),
         NAMED_ALLOW_CALL(adapter1, Release())
             .RETURN(0),
+        NAMED_ALLOW_CALL(adapter1, GetDesc1(_))
+            .RETURN(E_FAIL),
         NAMED_ALLOW_CALL(adapter1, EnumOutputs(0U, _))
             .LR_SIDE_EFFECT(*_2 = static_cast<IDXGIOutput*>(&output1))
             .RETURN(S_OK),
@@ -116,6 +120,8 @@ void SetupResourceFactory(
             .RETURN(S_OK),
         NAMED_ALLOW_CALL(adapter2, Release())
             .RETURN(0),
+        NAMED_ALLOW_CALL(adapter2, GetDesc1(_))
+            .RETURN(E_FAIL),
         NAMED_ALLOW_CALL(adapter2, EnumOutputs(0U, _))
             .LR_SIDE_EFFECT(*_2 = static_cast<IDXGIOutput*>(&output3))
             .RETURN(S_OK),
@@ -176,7 +182,7 @@ void SetupResourceFactory(
             .RETURN(false)};
 }
 
-[[nodiscard]] std::array<std::unique_ptr<expectation>, 25> ConfigureIntegratedAndDiscreteGpuTestEnvironment(
+[[nodiscard]] std::array<std::unique_ptr<expectation>, 27> ConfigureIntegratedAndDiscreteGpuTestEnvironment(
     DXGIFactory1Mock& dxgiFactory,
     VulkanMock& vulkan,
     NvmlMock& nvml,
@@ -203,6 +209,8 @@ void SetupResourceFactory(
             .RETURN(S_OK),
         NAMED_ALLOW_CALL(adapter1, Release())
             .RETURN(0),
+        NAMED_ALLOW_CALL(adapter1, GetDesc1(_))
+            .RETURN(E_FAIL),
         NAMED_ALLOW_CALL(adapter1, EnumOutputs(0U, _))
             .LR_SIDE_EFFECT(*_2 = static_cast<IDXGIOutput*>(&output1))
             .RETURN(S_OK),
@@ -216,6 +224,8 @@ void SetupResourceFactory(
             .RETURN(S_OK),
         NAMED_ALLOW_CALL(adapter2, Release())
             .RETURN(0),
+        NAMED_ALLOW_CALL(adapter2, GetDesc1(_))
+            .RETURN(E_FAIL),
         NAMED_ALLOW_CALL(adapter2, EnumOutputs(0U, _))
             .LR_SIDE_EFFECT(*_2 = static_cast<IDXGIOutput*>(&output1))
             .RETURN(S_OK),

--- a/tests/resource_factory_util.cpp
+++ b/tests/resource_factory_util.cpp
@@ -13,7 +13,7 @@ void SetupResourceFactory(
     initializationCount = 0ULL;
 }
 
-[[nodiscard]] std::array<std::unique_ptr<expectation>, 19> ConfigureDefaultTestEnvironment(
+[[nodiscard]] std::array<std::unique_ptr<expectation>, 18> ConfigureDefaultTestEnvironment(
     DXGIFactory1Mock& dxgiFactory,
     VulkanMock& vulkan,
     NvmlMock& nvml,
@@ -65,7 +65,6 @@ void SetupResourceFactory(
                         props->deviceType = VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU;
                         driverProps->driverID = VK_DRIVER_ID_NVIDIA_PROPRIETARY;
                     })),
-        NAMED_ALLOW_CALL(vulkan, GetPhysicalDeviceMemoryProperties2(_, _, _)),
 
         NAMED_ALLOW_CALL(nvml, IsAvailable())
             .RETURN(false),
@@ -73,7 +72,7 @@ void SetupResourceFactory(
             .RETURN(false)};
 }
 
-[[nodiscard]] std::array<std::unique_ptr<expectation>, 34> ConfigureExtendedTestEnvironment(
+[[nodiscard]] std::array<std::unique_ptr<expectation>, 33> ConfigureExtendedTestEnvironment(
     DXGIFactory1Mock& dxgiFactory,
     VulkanMock& vulkan,
     NvmlMock& nvml,
@@ -174,7 +173,6 @@ void SetupResourceFactory(
                         props->deviceType = VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU;
                         driverProps->driverID = VK_DRIVER_ID_NVIDIA_PROPRIETARY;
                     })),
-        NAMED_ALLOW_CALL(vulkan, GetPhysicalDeviceMemoryProperties2(_, _, _)),
 
         NAMED_ALLOW_CALL(nvml, IsAvailable())
             .RETURN(false),
@@ -182,7 +180,7 @@ void SetupResourceFactory(
             .RETURN(false)};
 }
 
-[[nodiscard]] std::array<std::unique_ptr<expectation>, 27> ConfigureIntegratedAndDiscreteGpuTestEnvironment(
+[[nodiscard]] std::array<std::unique_ptr<expectation>, 26> ConfigureIntegratedAndDiscreteGpuTestEnvironment(
     DXGIFactory1Mock& dxgiFactory,
     VulkanMock& vulkan,
     NvmlMock& nvml,
@@ -262,7 +260,6 @@ void SetupResourceFactory(
                         props->deviceType = VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU;
                         driverProps->driverID = VK_DRIVER_ID_NVIDIA_PROPRIETARY;
                     })),
-        NAMED_ALLOW_CALL(vulkan, GetPhysicalDeviceMemoryProperties2(_, _, _)),
 
         NAMED_ALLOW_CALL(nvml, IsAvailable())
             .RETURN(false),

--- a/tests/resource_factory_util.h
+++ b/tests/resource_factory_util.h
@@ -11,7 +11,7 @@ void SetupResourceFactory(
     std::unique_ptr<dxvk::Nvml> nvml,
     std::unique_ptr<dxvk::Lfx> lfx);
 
-[[nodiscard]] std::array<std::unique_ptr<trompeloeil::expectation>, 18> ConfigureDefaultTestEnvironment(
+[[nodiscard]] std::array<std::unique_ptr<trompeloeil::expectation>, 19> ConfigureDefaultTestEnvironment(
     DXGIFactory1Mock& dxgiFactory,
     VulkanMock& vulkan,
     NvmlMock& nvml,
@@ -19,7 +19,7 @@ void SetupResourceFactory(
     DXGIDxvkAdapterMock& adapter,
     DXGIOutput6Mock& output);
 
-[[nodiscard]] std::array<std::unique_ptr<trompeloeil::expectation>, 32> ConfigureExtendedTestEnvironment(
+[[nodiscard]] std::array<std::unique_ptr<trompeloeil::expectation>, 34> ConfigureExtendedTestEnvironment(
     DXGIFactory1Mock& dxgiFactory,
     VulkanMock& vulkan,
     NvmlMock& nvml,
@@ -30,7 +30,7 @@ void SetupResourceFactory(
     DXGIOutput6Mock& output2,
     DXGIOutput6Mock& output3);
 
-[[nodiscard]] std::array<std::unique_ptr<trompeloeil::expectation>, 25> ConfigureIntegratedAndDiscreteGpuTestEnvironment(
+[[nodiscard]] std::array<std::unique_ptr<trompeloeil::expectation>, 27> ConfigureIntegratedAndDiscreteGpuTestEnvironment(
     DXGIFactory1Mock& dxgiFactory,
     VulkanMock& vulkan,
     NvmlMock& nvml,

--- a/tests/resource_factory_util.h
+++ b/tests/resource_factory_util.h
@@ -11,7 +11,7 @@ void SetupResourceFactory(
     std::unique_ptr<dxvk::Nvml> nvml,
     std::unique_ptr<dxvk::Lfx> lfx);
 
-[[nodiscard]] std::array<std::unique_ptr<trompeloeil::expectation>, 19> ConfigureDefaultTestEnvironment(
+[[nodiscard]] std::array<std::unique_ptr<trompeloeil::expectation>, 18> ConfigureDefaultTestEnvironment(
     DXGIFactory1Mock& dxgiFactory,
     VulkanMock& vulkan,
     NvmlMock& nvml,
@@ -19,7 +19,7 @@ void SetupResourceFactory(
     DXGIDxvkAdapterMock& adapter,
     DXGIOutput6Mock& output);
 
-[[nodiscard]] std::array<std::unique_ptr<trompeloeil::expectation>, 34> ConfigureExtendedTestEnvironment(
+[[nodiscard]] std::array<std::unique_ptr<trompeloeil::expectation>, 33> ConfigureExtendedTestEnvironment(
     DXGIFactory1Mock& dxgiFactory,
     VulkanMock& vulkan,
     NvmlMock& nvml,
@@ -30,7 +30,7 @@ void SetupResourceFactory(
     DXGIOutput6Mock& output2,
     DXGIOutput6Mock& output3);
 
-[[nodiscard]] std::array<std::unique_ptr<trompeloeil::expectation>, 27> ConfigureIntegratedAndDiscreteGpuTestEnvironment(
+[[nodiscard]] std::array<std::unique_ptr<trompeloeil::expectation>, 26> ConfigureIntegratedAndDiscreteGpuTestEnvironment(
     DXGIFactory1Mock& dxgiFactory,
     VulkanMock& vulkan,
     NvmlMock& nvml,


### PR DESCRIPTION
This way we honor DXVK memory overrides from DXVK configuration.