### PR TITLE
nvapi-adapter: Free Vulkan after adapter initialization

### DIFF
--- a/src/resource_factory.cpp
+++ b/src/resource_factory.cpp
@@ -18,13 +18,7 @@ namespace dxvk {
         return dxgiFactory;
     }
 
-    std::unique_ptr<Vulkan> ResourceFactory::CreateVulkan() {
-        Com<IDXGIFactory1> dxgiFactory;
-        if (FAILED(::CreateDXGIFactory1(__uuidof(IDXGIFactory1), (void**)&dxgiFactory))) {
-            log::write("Creating DXGI Factory (IDXGIFactory1) failed, please ensure that DXVK's dxgi.dll is present");
-            return nullptr;
-        }
-
+    std::unique_ptr<Vulkan> ResourceFactory::CreateVulkan(Com<IDXGIFactory1>& dxgiFactory) {
         Com<IDXGIVkInteropFactory> dxgiVkFactory;
         if (FAILED(dxgiFactory->QueryInterface(IID_PPV_ARGS(&dxgiVkFactory)))) {
             log::write("Querying Vulkan entry point from DXGI factory failed, please ensure that DXVK's dxgi.dll (version 2.1 or newer) is present");

--- a/src/resource_factory.h
+++ b/src/resource_factory.h
@@ -14,7 +14,7 @@ namespace dxvk {
         virtual ~ResourceFactory();
 
         virtual Com<IDXGIFactory1> CreateDXGIFactory1();
-        virtual std::unique_ptr<Vulkan> CreateVulkan();
+        virtual std::unique_ptr<Vulkan> CreateVulkan(Com<IDXGIFactory1>& dxgiFactory);
         virtual std::unique_ptr<Nvml> CreateNvml();
         virtual std::unique_ptr<Lfx> CreateLfx();
     };

--- a/src/sysinfo/nvapi_adapter.cpp
+++ b/src/sysinfo/nvapi_adapter.cpp
@@ -5,12 +5,12 @@
 #include "../util/util_log.h"
 
 namespace dxvk {
-    NvapiAdapter::NvapiAdapter(Vulkan& vulkan, Nvml& nvml)
-        : m_vulkan(vulkan), m_nvml(nvml) {}
+    NvapiAdapter::NvapiAdapter(Nvml& nvml)
+        : m_nvml(nvml) {}
 
     NvapiAdapter::~NvapiAdapter() = default;
 
-    bool NvapiAdapter::Initialize(Com<IDXGIAdapter1>& dxgiAdapter, uint32_t index, std::vector<NvapiOutput*>& outputs) {
+    bool NvapiAdapter::Initialize(Com<IDXGIAdapter1>& dxgiAdapter, uint32_t index, Vulkan& vulkan, std::vector<NvapiOutput*>& outputs) {
         constexpr auto driverVersionEnvName = "DXVK_NVAPI_DRIVER_VERSION";
         constexpr auto allowOtherDriversEnvName = "DXVK_NVAPI_ALLOW_OTHER_DRIVERS";
 
@@ -30,7 +30,7 @@ namespace dxvk {
         VkPhysicalDevice vkDevice = VK_NULL_HANDLE;
         dxgiVkInteropAdapter->GetVulkanHandles(&vkInstance, &vkDevice);
 
-        m_deviceExtensions = m_vulkan.GetDeviceExtensions(vkInstance, vkDevice);
+        m_deviceExtensions = vulkan.GetDeviceExtensions(vkInstance, vkDevice);
         if (m_deviceExtensions.empty())
             return false;
 
@@ -64,7 +64,7 @@ namespace dxvk {
         m_deviceIdProperties.pNext = deviceProperties2.pNext;
         deviceProperties2.pNext = &m_deviceIdProperties;
 
-        m_vulkan.GetPhysicalDeviceProperties2(vkInstance, vkDevice, &deviceProperties2);
+        vulkan.GetPhysicalDeviceProperties2(vkInstance, vkDevice, &deviceProperties2);
         m_deviceProperties = deviceProperties2.properties;
 
         auto allowOtherDrivers = env::getEnvVariable(allowOtherDriversEnvName);

--- a/src/sysinfo/nvapi_adapter.h
+++ b/src/sysinfo/nvapi_adapter.h
@@ -10,10 +10,10 @@ namespace dxvk {
     class NvapiAdapter {
 
       public:
-        NvapiAdapter(Vulkan& vulkan, Nvml& nvml);
+        explicit NvapiAdapter(Nvml& nvml);
         ~NvapiAdapter();
 
-        bool Initialize(Com<IDXGIAdapter1>& dxgiAdapter, uint32_t index, std::vector<NvapiOutput*>& outputs);
+        bool Initialize(Com<IDXGIAdapter1>& dxgiAdapter, uint32_t index, Vulkan& vulkan, std::vector<NvapiOutput*>& outputs);
         [[nodiscard]] std::string GetDeviceName() const;
         [[nodiscard]] bool HasNvProprietaryDriver() const;
         [[nodiscard]] uint32_t GetDriverVersion() const;
@@ -44,7 +44,6 @@ namespace dxvk {
         [[nodiscard]] nvmlReturn_t GetNvmlDeviceDynamicPstatesInfo(nvmlGpuDynamicPstatesInfo_t* pDynamicPstatesInfo) const;
 
       private:
-        Vulkan& m_vulkan;
         Nvml& m_nvml;
 
         std::set<std::string> m_deviceExtensions;

--- a/src/sysinfo/nvapi_adapter_registry.cpp
+++ b/src/sysinfo/nvapi_adapter_registry.cpp
@@ -22,8 +22,8 @@ namespace dxvk {
         if (dxgiFactory == nullptr)
             return false;
 
-        m_vulkan = m_resourceFactory.CreateVulkan();
-        if (m_vulkan == nullptr || !m_vulkan->IsAvailable())
+        auto vulkan = m_resourceFactory.CreateVulkan(dxgiFactory);
+        if (vulkan == nullptr || !vulkan->IsAvailable())
             return false;
 
         m_nvml = m_resourceFactory.CreateNvml();
@@ -33,8 +33,8 @@ namespace dxvk {
         // Query all D3D11 adapter from DXVK to honor any DXVK device filtering
         Com<IDXGIAdapter1> dxgiAdapter;
         for (auto i = 0U; dxgiFactory->EnumAdapters1(i, &dxgiAdapter) != DXGI_ERROR_NOT_FOUND; i++) {
-            auto nvapiAdapter = new NvapiAdapter(*m_vulkan, *m_nvml);
-            if (nvapiAdapter->Initialize(dxgiAdapter, i, m_nvapiOutputs))
+            auto nvapiAdapter = new NvapiAdapter(*m_nvml);
+            if (nvapiAdapter->Initialize(dxgiAdapter, i, *vulkan, m_nvapiOutputs))
                 m_nvapiAdapters.push_back(nvapiAdapter);
             else
                 delete nvapiAdapter;

--- a/src/sysinfo/nvapi_adapter_registry.h
+++ b/src/sysinfo/nvapi_adapter_registry.h
@@ -32,7 +32,6 @@ namespace dxvk {
 
       private:
         ResourceFactory& m_resourceFactory;
-        std::unique_ptr<Vulkan> m_vulkan;
         std::unique_ptr<Nvml> m_nvml;
         std::vector<NvapiAdapter*> m_nvapiAdapters;
         std::vector<NvapiOutput*> m_nvapiOutputs;

--- a/tests/mock_factory.h
+++ b/tests/mock_factory.h
@@ -16,7 +16,7 @@ class MockFactory : public dxvk::ResourceFactory {
         return dxgiFactory;
     };
 
-    std::unique_ptr<dxvk::Vulkan> CreateVulkan() override {
+    std::unique_ptr<dxvk::Vulkan> CreateVulkan(dxvk::Com<IDXGIFactory1>& dxgiFactory) override {
         return std::move(m_vulkanMock);
     }
 


### PR DESCRIPTION
Just free the resources, including the DXGIFactory, once we have all the info we need. Also use the existing DXGIFactory to obtain the Vulkan entry points.

@Saancreed  Any thoughts on this? In my opinion it is less clean, but freeing the resources once we don't need them anymore feels good too.