### PR TITLE
Prevent CudaEnumComputeCapableGpus V2 crash

### DIFF
--- a/src/nvapi.cpp
+++ b/src/nvapi.cpp
@@ -89,9 +89,6 @@ extern "C" {
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);
 
-        if (hPhysicalGpu == nullptr)
-            return InvalidArgument(n);
-
         NvapiAdapter* adapter = nullptr;
         for (auto i = 0U; i < nvapiAdapterRegistry->GetAdapterCount(); i++)
             if (nvapiAdapterRegistry->GetAdapter(i)->GetBoardId() == gpuId)

--- a/src/nvapi_gpu.cpp
+++ b/src/nvapi_gpu.cpp
@@ -454,11 +454,8 @@ extern "C" {
         if (pComputeTopo == nullptr)
             return InvalidArgument(n);
 
-        if (pComputeTopo->version != NV_COMPUTE_GPU_TOPOLOGY_VER1 && pComputeTopo->version != NV_COMPUTE_GPU_TOPOLOGY_VER)
+        if (pComputeTopo->version != NV_COMPUTE_GPU_TOPOLOGY_VER1)
             return IncompatibleStructVersion(n);
-
-        if (pComputeTopo->version == NV_COMPUTE_GPU_TOPOLOGY_VER && pComputeTopo->computeGpus == nullptr)
-            return InvalidArgument(n);
 
         auto cudaCapableGpus = std::vector<NvPhysicalGpuHandle>(0);
         for (auto i = 0U; i < nvapiAdapterRegistry->GetAdapterCount(); i++) {
@@ -482,13 +479,6 @@ extern "C" {
                 }
                 break;
             }
-            case NV_COMPUTE_GPU_TOPOLOGY_VER:
-                pComputeTopo->gpuCount = cudaCapableGpus.size();
-                for (auto i = 0U; i < cudaCapableGpus.size(); i++) {
-                    pComputeTopo->computeGpus[i].hPhysicalGpu = cudaCapableGpus[i];
-                    pComputeTopo->computeGpus[i].flags = flags;
-                }
-                break;
             default:
                 return Error(n); // Unreachable, but just to be sure
         }

--- a/tests/nvapi_sysinfo.cpp
+++ b/tests/nvapi_sysinfo.cpp
@@ -260,23 +260,10 @@ TEST_CASE("Sysinfo methods succeed", "[.sysinfo]") {
             }
         }
 
-        SECTION("CudaEnumComputeCapableGpus (V2) returns OK") {
+        SECTION("CudaEnumComputeCapableGpus (V2) returns incompatible-struct-version") {
             NV_COMPUTE_GPU_TOPOLOGY_V2 gpuTopology;
             gpuTopology.version = NV_COMPUTE_GPU_TOPOLOGY_VER;
-            gpuTopology.computeGpus = new NV_COMPUTE_GPU[1];
-            REQUIRE(NvAPI_GPU_CudaEnumComputeCapableGpus(&gpuTopology) == NVAPI_OK);
-            REQUIRE(gpuTopology.gpuCount == args.cudaGpuCount);
-            if (gpuTopology.gpuCount == 1) {
-                REQUIRE(gpuTopology.computeGpus[0].hPhysicalGpu == handle);
-                REQUIRE(gpuTopology.computeGpus[0].flags == 0x0b);
-            }
-            delete gpuTopology.computeGpus;
-        }
-
-        SECTION("CudaEnumComputeCapableGpus (V2) without set compute-gpus returns invalid-argument") {
-            NV_COMPUTE_GPU_TOPOLOGY_V2 gpuTopology{};
-            gpuTopology.version = NV_COMPUTE_GPU_TOPOLOGY_VER;
-            REQUIRE(NvAPI_GPU_CudaEnumComputeCapableGpus(&gpuTopology) == NVAPI_INVALID_ARGUMENT);
+            REQUIRE(NvAPI_GPU_CudaEnumComputeCapableGpus(&gpuTopology) == NVAPI_INCOMPATIBLE_STRUCT_VERSION);
         }
 
         ::SetEnvironmentVariableA("DXVK_NVAPI_ALLOW_OTHER_DRIVERS", "");


### PR DESCRIPTION
It doesn't allow hardware PhysX in https://github.com/jp7677/dxvk-nvapi/issues/127, but at least it doesn't crash anymore.

The header says:

```c
typedef struct _NV_COMPUTE_GPU_TOPOLOGY_V2
{
    NvU32 version;                 //!< Structure version
    NvU32 gpuCount;                //!< Size of array
    NV_COMPUTE_GPU *computeGpus;   //!< Array of compute-capable physical GPUs (allocate memory of size of Physical gpuCount of system).

} NV_COMPUTE_GPU_TOPOLOGY_V2;
```

I would interpret it that this has to be done on the consumer side, but here we are... 