### PR TITLE
Add resource details to fine .dll file

### DIFF
--- a/build-win32.txt
+++ b/build-win32.txt
@@ -2,6 +2,7 @@
 cpp = 'i686-w64-mingw32-g++'
 strip = 'i686-w64-mingw32-strip'
 ar = 'i686-w64-mingw32-ar'
+windres = 'i686-w64-mingw32-windres'
 
 [built-in options]
 cpp_args=['-msse', '-msse2']

--- a/build-win64.txt
+++ b/build-win64.txt
@@ -2,6 +2,7 @@
 cpp = 'x86_64-w64-mingw32-g++'
 strip = 'x86_64-w64-mingw32-strip'
 ar = 'x86_64-w64-mingw32-ar'
+windres = 'x86_64-w64-mingw32-windres'
 
 [built-in options]
 cpp_link_args = ['-static', '-static-libgcc', '-static-libstdc++']

--- a/meson.build
+++ b/meson.build
@@ -40,6 +40,13 @@ lib_dxgi = cpp.find_library('dxgi')
 lib_d3d11 = cpp.find_library('d3d11')
 lib_version = cpp.find_library('version')
 
+res_ext = '.o'
+wrc = find_program('windres')
+wrc_generator = generator(wrc,
+  output    : [ '@BASENAME@' + res_ext ],
+  arguments : [ '-i', '@INPUT@', '-o', '@OUTPUT@' ],
+)
+
 dxvk_nvapi_version = vcs_tag(
   command: ['git', 'describe', '--always', '--tags', '--dirty=+'],
   input:  'version.h.in',

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,3 +1,5 @@
+dxvk_nvapi_res = wrc_generator.process('version.rc')
+
 nvapi_src = files([
   'dxvk/dxvk_interfaces.cpp',
   'vkd3d-proton/vkd3d-proton_interfaces.cpp',
@@ -27,7 +29,7 @@ nvapi_src = files([
   'nvapi_interface.cpp',
 ])
 
-nvapi_dll = shared_library('nvapi'+target_suffix, [ nvapi_src, dxvk_nvapi_version ],
+nvapi_dll = shared_library('nvapi'+target_suffix, [ nvapi_src, dxvk_nvapi_version, dxvk_nvapi_res ],
   name_prefix         : '',
   dependencies        : [ lib_dxgi, lib_d3d11, lib_version ],
   include_directories : [ vk_headers ],

--- a/src/version.rc
+++ b/src/version.rc
@@ -1,0 +1,31 @@
+#include <windows.h>
+
+// DLL version information.
+VS_VERSION_INFO    VERSIONINFO
+FILEVERSION        0,6,3
+PRODUCTVERSION     0,6,3
+FILEFLAGSMASK      VS_FFI_FILEFLAGSMASK
+FILEFLAGS          0
+FILEOS VOS_NT_WINDOWS32
+FILETYPE VFT_DLL
+FILESUBTYPE VFT2_UNKNOWN
+BEGIN
+  BLOCK "StringFileInfo"
+  BEGIN
+    BLOCK "080904b0"
+    BEGIN
+      VALUE "CompanyName",      "DXVK-NVAPI Library"
+      VALUE "FileDescription",  "NVAPI Open Source Interface"
+      VALUE "FileVersion",      "0.6.3"
+      VALUE "InternalName",     "nvapi.dll"
+      VALUE "LegalCopyright",   "MIT license"
+      VALUE "OriginalFilename", "nvapi.dll"
+      VALUE "ProductName",      "DXVK-NVAPI"
+      VALUE "ProductVersion",   "0.6.3"
+    END
+  END
+  BLOCK "VarFileInfo"
+  BEGIN
+    VALUE "Translation", 0x0809, 1200
+  END
+END


### PR DESCRIPTION
There is not really support for adding other than numbers for the version string, so using VCS_TAG seems out of the question. Used the "release" tag, but this will for now need manual update for each release.

GPU Caps Viewer still shows "unknown" for the file version of the .dll, so this is mostly just for some cosmetic "information" - similar to what DXVK does for d3d11.dll and such. "For completeness" so to speak?
![nvapi_dll](https://github.com/jp7677/dxvk-nvapi/assets/33990277/744f8412-7dae-4ee9-bfcc-c6bd5c343f99)
