### PR TITLE
Use __wine_dbg_output for console output

### DIFF
--- a/src/d3d/lfx.h
+++ b/src/d3d/lfx.h
@@ -13,8 +13,8 @@ namespace dxvk {
         virtual void SetTargetFrameTime(uint64_t frame_time_ns);
 
       private:
-        typedef void (*PFN_lfx_WaitAndBeginFrame)();
-        typedef void (*PFN_lfx_SetTargetFrameTime)(__int64);
+        using PFN_lfx_WaitAndBeginFrame = void (*)();
+        using PFN_lfx_SetTargetFrameTime = void (*)(__int64);
 
         HMODULE m_lfxModule{};
         PFN_lfx_WaitAndBeginFrame m_lfx_WaitAndBeginFrame{};

--- a/src/util/util_log.cpp
+++ b/src/util/util_log.cpp
@@ -1,8 +1,27 @@
 #include "util_log.h"
 #include "util_env.h"
+#include "util_string.h"
+
+using PFN_wineDbgOutput = int(__cdecl*)(const char*);
+
+static PFN_wineDbgOutput wineDbgOutput = nullptr;
 
 namespace dxvk::log {
+    void print(const std::string& message) {
+        auto line = message + '\n';
+        if (wineDbgOutput)
+            wineDbgOutput(line.c_str());
+        else
+            std::cerr << line;
+    }
+
     void initialize(std::ofstream& filestream, bool& skipAllLogging) {
+#ifdef _WIN32
+        auto ntdllModule = ::GetModuleHandleA("ntdll.dll");
+        if (ntdllModule != nullptr)
+            wineDbgOutput = reinterpret_cast<PFN_wineDbgOutput>(reinterpret_cast<void*>(GetProcAddress(ntdllModule, "__wine_dbg_output")));
+#endif
+
         constexpr auto logLevelEnvName = "DXVK_NVAPI_LOG_LEVEL";
         constexpr auto logPathEnvName = "DXVK_NVAPI_LOG_PATH";
         constexpr auto logFileName = "dxvk-nvapi.log";
@@ -23,7 +42,7 @@ namespace dxvk::log {
         auto fullPath = logPath + logFileName;
         filestream = std::ofstream(fullPath, std::ios::app);
         filestream << "---------- " << env::getCurrentDateTime() << " ----------" << std::endl;
-        std::cerr << logPathEnvName << " is set to '" << logPath << "', appending log statements to " << fullPath << std::endl;
+        print(str::format(logPathEnvName, " is set to '", logPath, "', appending log statements to ", fullPath));
     }
 
     void write(const std::string& message) {
@@ -36,7 +55,7 @@ namespace dxvk::log {
         if (skipAllLogging)
             return;
 
-        std::cerr << message << std::endl;
+        print(message);
         if (filestream)
             filestream << message << std::endl;
     }


### PR DESCRIPTION
This mirrors what DXVK and VKD3D-Proton does for printing to console (https://github.com/doitsujin/dxvk/commit/05fb634f9102f18e6a2c9e84939d0fb0a3618671) and also fixes lost console output on Wine 8.12.