### PR TITLE
Some DMM-related fixes and improvements

### DIFF
--- a/src/nvapi_d3d12.cpp
+++ b/src/nvapi_d3d12.cpp
@@ -277,6 +277,13 @@ extern "C" {
                 *(NVAPI_D3D12_RAYTRACING_OPACITY_MICROMAP_CAPS*)pData = NVAPI_D3D12_RAYTRACING_OPACITY_MICROMAP_CAP_NONE;
                 break;
 
+            case NVAPI_D3D12_RAYTRACING_CAPS_TYPE_DISPLACEMENT_MICROMAP:
+                if (dataSize != sizeof(NVAPI_D3D12_RAYTRACING_DISPLACEMENT_MICROMAP_CAPS))
+                    return InvalidArgument(n);
+
+                *(NVAPI_D3D12_RAYTRACING_DISPLACEMENT_MICROMAP_CAPS*)pData = NVAPI_D3D12_RAYTRACING_DISPLACEMENT_MICROMAP_CAP_NONE;
+                break;
+
             default:
                 return InvalidArgument(n);
         }
@@ -286,7 +293,7 @@ extern "C" {
 
     static bool ConvertBuildRaytracingAccelerationStructureInputs(const NVAPI_D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS_EX* nvDesc, std::vector<D3D12_RAYTRACING_GEOMETRY_DESC>& geometryDescs, D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS* d3dDesc) {
         d3dDesc->Type = nvDesc->type;
-        // assume that OMM via VK_EXT_opacity_micromap is not supported, allow only standard flags to be passed
+        // assume that OMM via VK_EXT_opacity_micromap and DMM via VK_NV_displacement_micromap are not supported, allow only standard flags to be passed
         d3dDesc->Flags = static_cast<D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAGS>(nvDesc->flags & 0x3f);
         d3dDesc->NumDescs = nvDesc->numDescs;
         d3dDesc->DescsLayout = nvDesc->descsLayout;
@@ -320,7 +327,13 @@ extern "C" {
                         d3dGeoDesc.AABBs = nvGeoDesc.aabbs;
                         break;
                     case NVAPI_D3D12_RAYTRACING_GEOMETRY_TYPE_OMM_TRIANGLES_EX: // GetRaytracingCaps reports no OMM caps, we shouldn't reach this
+                        log::write("Triangles with OMM attachment passed to acceleration structure build when OMM is not supported");
+                        return false;
+                    case NVAPI_D3D12_RAYTRACING_GEOMETRY_TYPE_DMM_TRIANGLES_EX: // GetRaytracingCaps reports no DMM caps, we shouldn't reach this
+                        log::write("Triangles with DMM attachment passed to acceleration structure build when DMM is not supported");
+                        return false;
                     default:
+                        log::write(str::format("Unknown NVAPI_D3D12_RAYTRACING_GEOMETRY_TYPE_EX: ", nvGeoDesc.type));
                         return false;
                 }
             }

--- a/src/nvapi_d3d12.cpp
+++ b/src/nvapi_d3d12.cpp
@@ -302,14 +302,11 @@ extern "C" {
         }
 
         if (d3dDesc->Type == D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL && d3dDesc->DescsLayout == D3D12_ELEMENTS_LAYOUT_ARRAY) {
-            if (nvDesc->geometryDescStrideInBytes != sizeof(NVAPI_D3D12_RAYTRACING_GEOMETRY_DESC_EX))
-                return false;
-
             geometryDescs.resize(d3dDesc->NumDescs);
 
             for (unsigned i = 0; i < d3dDesc->NumDescs; ++i) {
                 auto& d3dGeoDesc = geometryDescs[i];
-                auto& nvGeoDesc = nvDesc->pGeometryDescs[i];
+                auto& nvGeoDesc = *reinterpret_cast<const NVAPI_D3D12_RAYTRACING_GEOMETRY_DESC_EX*>(reinterpret_cast<const std::byte*>(nvDesc->pGeometryDescs) + (i * nvDesc->geometryDescStrideInBytes));
 
                 d3dGeoDesc.Flags = nvGeoDesc.flags;
 

--- a/tests/nvapi_d3d12.cpp
+++ b/tests/nvapi_d3d12.cpp
@@ -467,9 +467,14 @@ TEST_CASE("D3D12 methods succeed", "[.d3d12]") {
         REQUIRE(caps == NVAPI_D3D12_RAYTRACING_OPACITY_MICROMAP_CAP_NONE);
     }
 
+    SECTION("GetRaytracingCaps returns OK and claims that Displacement Micromap is not supported") {
+        NVAPI_D3D12_RAYTRACING_DISPLACEMENT_MICROMAP_CAPS caps;
+        REQUIRE(NvAPI_D3D12_GetRaytracingCaps(static_cast<ID3D12Device*>(&device), NVAPI_D3D12_RAYTRACING_CAPS_TYPE_DISPLACEMENT_MICROMAP, &caps, sizeof(caps)) == NVAPI_OK);
+        REQUIRE(caps == NVAPI_D3D12_RAYTRACING_DISPLACEMENT_MICROMAP_CAP_NONE);
+    }
+
     SECTION("GetRaytracingAccelerationStructurePrebuildInfoEx succeeds") {
         SECTION("GetRaytracingAccelerationStructurePrebuildInfoEx returns OK") {
-            NVAPI_D3D12_RAYTRACING_GEOMETRY_DESC_EX geometryDescEx{};
             NVAPI_D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS_EX desc{};
             D3D12_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO info{};
             NVAPI_GET_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO_EX_PARAMS params{};


### PR DESCRIPTION
We should keep games built against older NVAPI working, so instead of failing when encountering unexpected `geometryDescStrideInBytes` (like, when using NVAPI headers from before 535 in which DMMs were added causing the union to grow) this will try to access array members by manually calculating their address (and this will now keep working without rebuilding or updating headers if another union member is added in the future).

Adding tests this led me to discover a bug where we assume that after `NvAPI_D3D12_GetRaytracingAccelerationStructurePrebuildInfoEx` / `NvAPI_D3D12_BuildRaytracingAccelerationStructureEx` returns, we can still read values from pointer passed in `pGeometryDescs` which is not the case (because it points to data of a `std::vector` living on the stack of called function). To avoid this issue, the content of this array is now copied to another local `std::vector` as a side effect.