### PR TITLE
Spoof Pascal for non-NVIDIA propietary driver

### DIFF
--- a/src/nvapi_gpu.cpp
+++ b/src/nvapi_gpu.cpp
@@ -382,9 +382,6 @@ extern "C" {
         if (pGpuArchInfo->version != NV_GPU_ARCH_INFO_VER_1 && pGpuArchInfo->version != NV_GPU_ARCH_INFO_VER_2)
             return IncompatibleStructVersion(n);
 
-        if (!adapter->HasNvProprietaryDriver())
-            return NvidiaDeviceNotFound(n);
-
         auto architectureId = adapter->GetArchitectureId();
 
         if (env::needsAmpereSpoofing(architectureId, returnAddress))

--- a/src/sysinfo/nvapi_adapter.h
+++ b/src/sysinfo/nvapi_adapter.h
@@ -62,6 +62,8 @@ namespace dxvk {
 
         [[nodiscard]] bool IsVkDeviceExtensionSupported(std::string name) const;
 
+        constexpr static auto driverVersionEnvName = "DXVK_NVAPI_DRIVER_VERSION";
+        constexpr static auto allowOtherDriversEnvName = "DXVK_NVAPI_ALLOW_OTHER_DRIVERS";
         constexpr static uint16_t NvidiaPciVendorId = 0x10de;
     };
 }

--- a/src/sysinfo/nvapi_output.cpp
+++ b/src/sysinfo/nvapi_output.cpp
@@ -17,11 +17,11 @@ namespace dxvk {
         m_deviceName = str::fromws(desc.DeviceName);
         log::write(str::format("NvAPI Output: ", m_deviceName));
 
-        MONITORINFO info;
+        MONITORINFO info{};
         info.cbSize = sizeof(MONITORINFO);
         ::GetMonitorInfo(desc.Monitor, &info);
 
-        m_isPrimary = (info.dwFlags & MONITORINFOF_PRIMARY);
+        m_isPrimary = info.dwFlags & MONITORINFOF_PRIMARY;
 
         Com<IDXGIOutput6> dxgiOutput6;
         if (SUCCEEDED(dxgiOutput->QueryInterface(IID_PPV_ARGS(&dxgiOutput6)))) {


### PR DESCRIPTION
Not that cool to do this, but seems to help to use LatencyFlex on AMD GPUs with Streamline because `NvAPI_GPU_GetArchInfo` no longer fails.

There shouldn't be any side effects since DLSS requires at least Turing.