### PR TITLE
nvapi-gpu: Validate version before accessing struct fields

### DIFF
--- a/src/nvapi_gpu.cpp
+++ b/src/nvapi_gpu.cpp
@@ -341,15 +341,18 @@ extern "C" {
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);
 
-        if (pLogicalGpuData == nullptr || pLogicalGpuData->pOSAdapterId == nullptr)
+        if (pLogicalGpuData == nullptr)
+            return InvalidArgument(n);
+
+        if (pLogicalGpuData->version != NV_LOGICAL_GPU_DATA_VER1)
+            return IncompatibleStructVersion(n);
+
+        if (pLogicalGpuData->pOSAdapterId == nullptr)
             return InvalidArgument(n);
 
         auto adapter = reinterpret_cast<NvapiAdapter*>(hLogicalGpu);
         if (!nvapiAdapterRegistry->IsAdapter(adapter))
             return ExpectedLogicalGpuHandle(n);
-
-        if (pLogicalGpuData->version != NV_LOGICAL_GPU_DATA_VER1)
-            return IncompatibleStructVersion(n);
 
         auto luid = adapter->GetLuid();
         if (!luid.has_value())


### PR DESCRIPTION
The version needs to be checked before accessing any fields from the struct.

The tests for incompatible struct versions left the pOSAdapterId uninitialized, which caused flakes on MSVC. This fixes it.