### PR TITLE
sysinfo: Report 999.99 as version for  non-NVIDIA proprietary driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ DXVK 1.10 and older does not support `DXVK_ENABLE_NVAPI`. Disable the `nvapiHack
 
 Using DXVK-NVAPI with other GPU vendors / drivers has very limited use. Outside of testing, only Reflex (LatencyFlex) or HDR entry points provide benefits. This requires DXVK to see the GPU as an NVIDIA GPU. Use `DXVK_CONFIG="dxgi.hideAmdGpu = True"` to spoof an AMD GPU as NVIDIA GPU. Use `DXVK_CONFIG="dxgi.customVendorId = 10de"` for generally spoofing an NVIDIA GPU. 
 
-Setting `DXVK_NVAPI_ALLOW_OTHER_DRIVERS=1` is needed for successful DXVK-NVAPI initialization when using a driver other than the NVIDIA proprietary driver like RADV or NVK. Overriding the reported driver version is additionally recommended. The reported GPU arrchitecture for other drivers is always Pascal to prevent attempts to initialize DLSS. This behavior cannot be changed without modifying the source code.
+Setting `DXVK_NVAPI_ALLOW_OTHER_DRIVERS=1` is needed for successful DXVK-NVAPI initialization when using a driver other than the NVIDIA proprietary driver like RADV or NVK. The reported driver version will be 999.99. Overriding the reported driver version is still recommended. The reported GPU arrchitecture for other drivers is always Pascal to prevent attempts to initialize DLSS. This behavior cannot be changed without modifying the source code.
 
 ## Tweaks, debugging and troubleshooting
 

--- a/src/sysinfo/nvapi_adapter.cpp
+++ b/src/sysinfo/nvapi_adapter.cpp
@@ -79,7 +79,10 @@ namespace dxvk {
                 VK_VERSION_MINOR(m_vkProperties.driverVersion >> 0) >> 2,
                 VK_VERSION_PATCH(m_vkProperties.driverVersion >> 2) >> 4);
         else
-            m_vkDriverVersion = m_vkProperties.driverVersion;
+            // Reporting e.g. Mesa driver versions turned out to be not very useful
+            // since those will usually always fail driver version checks,
+            // so just report a number that should be "useful" until the end of time
+            m_vkDriverVersion = VK_MAKE_VERSION(999, 99, 0);
 
         log::write(str::format("NvAPI Device: ", m_vkProperties.deviceName, " (",
             VK_VERSION_MAJOR(m_vkDriverVersion), ".",

--- a/tests/nvapi_sysinfo.cpp
+++ b/tests/nvapi_sysinfo.cpp
@@ -175,7 +175,7 @@ TEST_CASE("Sysinfo methods succeed", "[.sysinfo]") {
         auto args = GENERATE(
             Data{VK_DRIVER_ID_NVIDIA_PROPRIETARY, 470, 45, 1, 47045},
             Data{VK_DRIVER_ID_NVIDIA_PROPRIETARY, 470, 101, 1, 47099},
-            Data{VK_DRIVER_ID_AMD_OPEN_SOURCE, 21, 2, 3, 2102});
+            Data{VK_DRIVER_ID_AMD_OPEN_SOURCE, 21, 2, 3, 99999});
 
         ::SetEnvironmentVariableA("DXVK_NVAPI_ALLOW_OTHER_DRIVERS", "1");
 


### PR DESCRIPTION
Reporting Mesa version numbers turned out to be not very useful.

@Saancreed Any thoughts?