### PR TITLE
nvapi: Guard against null device in Reflex calls

### DIFF
--- a/src/d3d/nvapi_d3d_low_latency_device.cpp
+++ b/src/d3d/nvapi_d3d_low_latency_device.cpp
@@ -48,6 +48,9 @@ namespace dxvk {
     }
 
     Com<ID3DLowLatencyDevice> NvapiD3dLowLatencyDevice::GetLowLatencyDevice(IUnknown* device) {
+        if (device == nullptr)
+            return nullptr;
+
         std::scoped_lock lock(m_LowLatencyDeviceMutex);
         auto it = m_lowLatencyDeviceMap.find(device);
         if (it != m_lowLatencyDeviceMap.end())

--- a/src/nvapi_d3d.cpp
+++ b/src/nvapi_d3d.cpp
@@ -115,6 +115,9 @@ extern "C" {
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);
 
+        if (pDevice == nullptr)
+            return InvalidArgument(n);
+
         if (!nvapiD3dInstance->IsReflexAvailable(pDevice))
             return NoImplementation(n, alreadyLoggedNoReflex);
 
@@ -134,6 +137,9 @@ extern "C" {
 
         if (pSetSleepModeParams->version != NV_SET_SLEEP_MODE_PARAMS_VER1)
             return IncompatibleStructVersion(n);
+
+        if (pDevice == nullptr)
+            return InvalidArgument(n);
 
         if (!nvapiD3dInstance->IsReflexAvailable(pDevice))
             return NoImplementation(n, alreadyLoggedNoReflex);
@@ -155,6 +161,9 @@ extern "C" {
         if (pGetSleepStatusParams->version != NV_GET_SLEEP_STATUS_PARAMS_VER1)
             return IncompatibleStructVersion(n);
 
+        if (pDevice == nullptr)
+            return InvalidArgument(n);
+
         if (!nvapiD3dInstance->IsReflexAvailable(pDevice))
             return NoImplementation(n, alreadyLoggedNoReflex);
 
@@ -174,6 +183,9 @@ extern "C" {
 
         if (pGetLatencyParams->version != NV_LATENCY_RESULT_PARAMS_VER1)
             return IncompatibleStructVersion(n);
+
+        if (pDev == nullptr)
+            return InvalidArgument(n);
 
         if (nvapiD3dInstance->IsUsingLfx() || !NvapiD3dLowLatencyDevice::SupportsLowLatency(pDev))
             return NoImplementation(n, alreadyLoggedNoImpl);
@@ -195,6 +207,9 @@ extern "C" {
 
         if (pSetLatencyMarkerParams->version != NV_LATENCY_MARKER_PARAMS_VER1)
             return IncompatibleStructVersion(n);
+
+        if (pDev == nullptr)
+            return InvalidArgument(n);
 
         if (nvapiD3dInstance->IsUsingLfx() || !NvapiD3dLowLatencyDevice::SupportsLowLatency(pDev))
             return NoImplementation(n, alreadyLoggedNoImpl);

--- a/src/nvapi_d3d12.cpp
+++ b/src/nvapi_d3d12.cpp
@@ -408,7 +408,7 @@ extern "C" {
             return ApiNotInitialized(n);
 
         if (pCommandQueue == nullptr)
-            return InvalidArgument(n);
+            return InvalidPointer(n);
 
         ID3D12Device* pDevice;
         if (FAILED(pCommandQueue->GetDevice(IID_PPV_ARGS(&pDevice))))
@@ -435,7 +435,7 @@ extern "C" {
             return IncompatibleStructVersion(n);
 
         if (pCommandQueue == nullptr)
-            return InvalidArgument(n);
+            return InvalidPointer(n);
 
         ID3D12Device* pDevice;
         if (FAILED(pCommandQueue->GetDevice(IID_PPV_ARGS(&pDevice))))

--- a/tests/nvapi_d3d.cpp
+++ b/tests/nvapi_d3d.cpp
@@ -129,6 +129,39 @@ TEST_CASE("D3D Reflex/LatencyFleX depending methods succeed", "[.d3d]") {
     ALLOW_CALL(*lfx, IsAvailable())
         .RETURN(false);
 
+    SECTION("Reflex methods fail when given null device") {
+        SetupResourceFactory(std::move(dxgiFactory), std::move(vulkan), std::move(nvml), std::move(lfx));
+        REQUIRE(NvAPI_Initialize() == NVAPI_OK);
+
+        SECTION("GetSleepStatus returns invalid-argument") {
+            NV_GET_SLEEP_STATUS_PARAMS_V1 params{};
+            params.version = NV_GET_SLEEP_STATUS_PARAMS_VER1;
+            REQUIRE(NvAPI_D3D_GetSleepStatus(nullptr, &params) == NVAPI_INVALID_ARGUMENT);
+        }
+
+        SECTION("SetSleepMode returns invalid-argument") {
+            NV_SET_SLEEP_MODE_PARAMS params{};
+            params.version = NV_SET_SLEEP_MODE_PARAMS_VER;
+            REQUIRE(NvAPI_D3D_SetSleepMode(nullptr, &params) == NVAPI_INVALID_ARGUMENT);
+        }
+
+        SECTION("Sleep returns invalid-argument") {
+            REQUIRE(NvAPI_D3D_Sleep(nullptr) == NVAPI_INVALID_ARGUMENT);
+        }
+
+        SECTION("GetLatency returns invalid-argument") {
+            NV_LATENCY_RESULT_PARAMS params;
+            params.version = NV_LATENCY_RESULT_PARAMS_VER;
+            REQUIRE(NvAPI_D3D_GetLatency(nullptr, &params) == NVAPI_INVALID_ARGUMENT);
+        }
+
+        SECTION("SetLatencyMarker returns invalid-argument") {
+            NV_LATENCY_MARKER_PARAMS params;
+            params.version = NV_LATENCY_MARKER_PARAMS_VER;
+            REQUIRE(NvAPI_D3D_SetLatencyMarker(nullptr, &params) == NVAPI_INVALID_ARGUMENT);
+        }
+    }
+
     SECTION("LatencyFleX depending methods succeed when LFX is available") {
         ALLOW_CALL(*lfx, IsAvailable())
             .RETURN(true);

--- a/tests/nvapi_d3d12.cpp
+++ b/tests/nvapi_d3d12.cpp
@@ -821,6 +821,13 @@ TEST_CASE("D3D12 methods succeed", "[.d3d12]") {
                 REQUIRE(NvAPI_Initialize() == NVAPI_OK);
                 REQUIRE(NvAPI_D3D12_NotifyOutOfBandCommandQueue(&commandQueue, OUT_OF_BAND_RENDER) == NVAPI_NO_IMPLEMENTATION);
             }
+
+            SECTION("NotifyOutOfBandCommandQueue with null command queue returns invalid-pointer") {
+                SetupResourceFactory(std::move(dxgiFactory), std::move(vulkan), std::move(nvml), std::move(lfx));
+
+                REQUIRE(NvAPI_Initialize() == NVAPI_OK);
+                REQUIRE(NvAPI_D3D12_NotifyOutOfBandCommandQueue(nullptr, OUT_OF_BAND_RENDER) == NVAPI_INVALID_POINTER);
+            }
         }
 
         SECTION("SetAsyncFrameMarker succeeds") {
@@ -873,6 +880,16 @@ TEST_CASE("D3D12 methods succeed", "[.d3d12]") {
                 NV_LATENCY_MARKER_PARAMS params{};
                 params.version = NV_LATENCY_MARKER_PARAMS_VER;
                 REQUIRE(NvAPI_D3D12_SetAsyncFrameMarker(&commandQueue, &params) != NVAPI_INCOMPATIBLE_STRUCT_VERSION);
+            }
+
+            SECTION("SetAsyncFrameMarker with null command queue returns invalid-pointer") {
+                SetupResourceFactory(std::move(dxgiFactory), std::move(vulkan), std::move(nvml), std::move(lfx));
+
+                REQUIRE(NvAPI_Initialize() == NVAPI_OK);
+
+                NV_LATENCY_MARKER_PARAMS params{};
+                params.version = NV_LATENCY_MARKER_PARAMS_VER;
+                REQUIRE(NvAPI_D3D12_SetAsyncFrameMarker(nullptr, &params) == NVAPI_INVALID_POINTER);
             }
         }
     }


### PR DESCRIPTION
Fixes a crash in Horizon Forbidden West.