### PR TITLE
Implement NvAPI_GetAssociatedNvidiaDisplayHandle

### DIFF
--- a/src/nvapi.cpp
+++ b/src/nvapi.cpp
@@ -221,6 +221,24 @@ extern "C" {
         return Ok(n);
     }
 
+    NvAPI_Status __cdecl NvAPI_GetAssociatedNvidiaDisplayHandle(const char* szDisplayName, NvDisplayHandle* pNvDispHandle) {
+        constexpr auto n = __func__;
+
+        if (nvapiAdapterRegistry == nullptr)
+            return ApiNotInitialized(n);
+
+        if (szDisplayName == nullptr)
+            return InvalidArgument(n);
+
+        auto output = nvapiAdapterRegistry->FindOutput(szDisplayName);
+        if (output == nullptr)
+            return NvidiaDeviceNotFound(n);
+
+        *pNvDispHandle = reinterpret_cast<NvDisplayHandle>(output);
+
+        return Ok(n);
+    }
+
     NvAPI_Status __cdecl NvAPI_GetInterfaceVersionString(NvAPI_ShortString szDesc) {
         constexpr auto n = __func__;
 

--- a/src/nvapi_interface.cpp
+++ b/src/nvapi_interface.cpp
@@ -131,6 +131,7 @@ extern "C" {
         INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_EnumNvidiaDisplayHandle)
         INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_EnumNvidiaUnAttachedDisplayHandle)
         INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_GetAssociatedNvidiaDisplayName)
+        INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_GetAssociatedNvidiaDisplayHandle)
         INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_GetInterfaceVersionString)
         INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_GetErrorMessage)
         INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_Unload)

--- a/tests/nvapi_sysinfo_topo.cpp
+++ b/tests/nvapi_sysinfo_topo.cpp
@@ -213,6 +213,28 @@ TEST_CASE("Topology methods succeed", "[.sysinfo-topo]") {
         REQUIRE(NvAPI_GetAssociatedNvidiaDisplayName(handle4, name4) == NVAPI_INVALID_ARGUMENT);
     }
 
+    SECTION("GetAssociatedNvidiaDisplayHandle succeeds") {
+        NvDisplayHandle handle1 = nullptr;
+        NvDisplayHandle handle2 = nullptr;
+        NvDisplayHandle handle3 = nullptr;
+        REQUIRE(NvAPI_EnumNvidiaDisplayHandle(0U, &handle1) == NVAPI_OK);
+        REQUIRE(NvAPI_EnumNvidiaDisplayHandle(1U, &handle2) == NVAPI_OK);
+        REQUIRE(NvAPI_EnumNvidiaDisplayHandle(2U, &handle3) == NVAPI_OK);
+
+        NvDisplayHandle handle;
+
+        REQUIRE(NvAPI_GetAssociatedNvidiaDisplayHandle("Output1", &handle) == NVAPI_OK);
+        REQUIRE(handle == handle1);
+
+        REQUIRE(NvAPI_GetAssociatedNvidiaDisplayHandle("Output2", &handle) == NVAPI_OK);
+        REQUIRE(handle == handle2);
+
+        REQUIRE(NvAPI_GetAssociatedNvidiaDisplayHandle("Output3", &handle) == NVAPI_OK);
+        REQUIRE(handle == handle3);
+
+        REQUIRE(NvAPI_GetAssociatedNvidiaDisplayHandle("Output4", &handle) == NVAPI_NVIDIA_DEVICE_NOT_FOUND);
+    }
+
     SECTION("GetGDIPrimaryDisplayId succeeds") {
         NvU32 displayId;
         REQUIRE(NvAPI_DISP_GetGDIPrimaryDisplayId(&displayId) == NVAPI_NVIDIA_DEVICE_NOT_FOUND); // MONITORINFO.dwFlags isn't mocked


### PR DESCRIPTION
This is needed to get the NVIDIA Tech demo "Apollo 11 Lunar Landing Demo" running. Downloaded from here: 
https://us.download.nvidia.com/downloads/cool_stuff/demos/Setup-Apollo-11-(1.05).exe