### PR TITLE
Improve logging

### DIFF
--- a/src/nvapi.cpp
+++ b/src/nvapi.cpp
@@ -15,6 +15,8 @@ extern "C" {
     NvAPI_Status __cdecl NvAPI_EnumLogicalGPUs(NvLogicalGpuHandle nvGPUHandle[NVAPI_MAX_LOGICAL_GPUS], NvU32* pGpuCount) {
         constexpr auto n = __func__;
 
+        Enter(n);
+
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);
 
@@ -32,6 +34,8 @@ extern "C" {
     NvAPI_Status __cdecl NvAPI_EnumPhysicalGPUs(NvPhysicalGpuHandle nvGPUHandle[NVAPI_MAX_PHYSICAL_GPUS], NvU32* pGpuCount) {
         constexpr auto n = __func__;
 
+        Enter(n);
+
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);
 
@@ -48,6 +52,8 @@ extern "C" {
 
     NvAPI_Status __cdecl NvAPI_EnumTCCPhysicalGPUs(NvPhysicalGpuHandle nvGPUHandle[NVAPI_MAX_PHYSICAL_GPUS], NvU32* pGpuCount) {
         constexpr auto n = __func__;
+
+        Enter(n);
 
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);
@@ -67,6 +73,8 @@ extern "C" {
     NvAPI_Status __cdecl NvAPI_GetGPUIDfromPhysicalGPU(NvPhysicalGpuHandle hPhysicalGpu, NvU32* pGpuId) {
         constexpr auto n = __func__;
 
+        Enter(n);
+
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);
 
@@ -85,6 +93,8 @@ extern "C" {
 
     NvAPI_Status __cdecl NvAPI_GetPhysicalGPUFromGPUID(NvU32 gpuId, NvPhysicalGpuHandle* hPhysicalGpu) {
         constexpr auto n = __func__;
+
+        Enter(n);
 
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);
@@ -108,6 +118,8 @@ extern "C" {
     NvAPI_Status __cdecl NvAPI_GetDisplayDriverVersion(NvDisplayHandle hNvDisplay, NV_DISPLAY_DRIVER_VERSION* pVersion) {
         constexpr auto n = __func__;
 
+        Enter(n);
+
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);
 
@@ -130,6 +142,8 @@ extern "C" {
     NvAPI_Status __cdecl NvAPI_GetLogicalGPUFromPhysicalGPU(NvPhysicalGpuHandle hPhysicalGPU, NvLogicalGpuHandle* pLogicalGPU) {
         constexpr auto n = __func__;
 
+        Enter(n);
+
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);
 
@@ -148,6 +162,8 @@ extern "C" {
     NvAPI_Status __cdecl NvAPI_GetLogicalGPUFromDisplay(NvDisplayHandle hNvDisp, NvLogicalGpuHandle* pLogicalGPU) {
         constexpr auto n = __func__;
 
+        Enter(n);
+
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);
 
@@ -165,6 +181,8 @@ extern "C" {
 
     NvAPI_Status __cdecl NvAPI_GetPhysicalGPUsFromLogicalGPU(NvLogicalGpuHandle hLogicalGPU, NvPhysicalGpuHandle hPhysicalGPU[NVAPI_MAX_PHYSICAL_GPUS], NvU32* pGpuCount) {
         constexpr auto n = __func__;
+
+        Enter(n);
 
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);
@@ -185,6 +203,8 @@ extern "C" {
     NvAPI_Status __cdecl NvAPI_GetPhysicalGPUsFromDisplay(NvDisplayHandle hNvDisp, NvPhysicalGpuHandle nvGPUHandle[NVAPI_MAX_PHYSICAL_GPUS], NvU32* pGpuCount) {
         constexpr auto n = __func__;
 
+        Enter(n);
+
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);
 
@@ -204,6 +224,8 @@ extern "C" {
     NvAPI_Status __cdecl NvAPI_EnumNvidiaDisplayHandle(NvU32 thisEnum, NvDisplayHandle* pNvDispHandle) {
         constexpr auto n = __func__;
 
+        Enter(n);
+
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);
 
@@ -220,12 +242,17 @@ extern "C" {
     }
 
     NvAPI_Status __cdecl NvAPI_EnumNvidiaUnAttachedDisplayHandle(NvU32 thisEnum, NvUnAttachedDisplayHandle* pNvUnAttachedDispHandle) {
+        constexpr auto n = __func__;
+
+        Enter(n);
         // DXVK does not know about unattached displays
-        return EndEnumeration(str::format(__func__, " (", thisEnum, ")"));
+        return EndEnumeration(str::format(n, " (", thisEnum, ")"));
     }
 
     NvAPI_Status __cdecl NvAPI_GetAssociatedNvidiaDisplayName(NvDisplayHandle NvDispHandle, NvAPI_ShortString szDisplayName) {
         constexpr auto n = __func__;
+
+        Enter(n);
 
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);
@@ -245,6 +272,8 @@ extern "C" {
     NvAPI_Status __cdecl NvAPI_GetAssociatedNvidiaDisplayHandle(const char* szDisplayName, NvDisplayHandle* pNvDispHandle) {
         constexpr auto n = __func__;
 
+        Enter(n);
+
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);
 
@@ -263,6 +292,8 @@ extern "C" {
     NvAPI_Status __cdecl NvAPI_GetInterfaceVersionString(NvAPI_ShortString szDesc) {
         constexpr auto n = __func__;
 
+        Enter(n);
+
         if (szDesc == nullptr)
             return InvalidArgument(n);
 
@@ -273,6 +304,8 @@ extern "C" {
 
     NvAPI_Status __cdecl NvAPI_GetErrorMessage(NvAPI_Status nr, NvAPI_ShortString szDesc) {
         constexpr auto n = __func__;
+
+        Enter(n);
 
         if (szDesc == nullptr)
             return InvalidArgument(n);
@@ -285,6 +318,8 @@ extern "C" {
 
     NvAPI_Status __cdecl NvAPI_Unload() {
         constexpr auto n = __func__;
+
+        Enter(n);
 
         std::scoped_lock lock(initializationMutex);
 
@@ -299,6 +334,8 @@ extern "C" {
 
     NvAPI_Status __cdecl NvAPI_Initialize() {
         constexpr auto n = __func__;
+
+        Enter(n);
 
         std::scoped_lock lock(initializationMutex);
 

--- a/src/nvapi_d3d.cpp
+++ b/src/nvapi_d3d.cpp
@@ -9,7 +9,7 @@ extern "C" {
 
     NvAPI_Status __cdecl NvAPI_D3D_GetObjectHandleForResource(IUnknown* pDevice, IUnknown* pResource, NVDX_ObjectHandle* pHandle) {
         constexpr auto n = __func__;
-        static bool alreadyLogged = false;
+        thread_local bool alreadyLogged = false;
 
         Enter(n, alreadyLogged);
 
@@ -24,7 +24,7 @@ extern "C" {
 
     NvAPI_Status __cdecl NvAPI_D3D_SetResourceHint(IUnknown* pDev, NVDX_ObjectHandle obj, NVAPI_D3D_SETRESOURCEHINT_CATEGORY dwHintCategory, NvU32 dwHintName, NvU32* pdwHintValue) {
         constexpr auto n = __func__;
-        static bool alreadyLogged = false;
+        thread_local bool alreadyLogged = false;
 
         Enter(n, alreadyLogged);
         return NoImplementation(n, alreadyLogged);
@@ -32,7 +32,7 @@ extern "C" {
 
     NvAPI_Status __cdecl NvAPI_D3D_BeginResourceRendering(IUnknown* pDeviceOrContext, NVDX_ObjectHandle obj, NvU32 Flags) {
         constexpr auto n = __func__;
-        static bool alreadyLogged = false;
+        thread_local bool alreadyLogged = false;
 
         Enter(n, alreadyLogged);
         // Synchronisation hints for SLI...
@@ -41,7 +41,7 @@ extern "C" {
 
     NvAPI_Status __cdecl NvAPI_D3D_EndResourceRendering(IUnknown* pDeviceOrContext, NVDX_ObjectHandle obj, NvU32 Flags) {
         constexpr auto n = __func__;
-        static bool alreadyLogged = false;
+        thread_local bool alreadyLogged = false;
 
         Enter(n, alreadyLogged);
         return Ok(n, alreadyLogged);
@@ -49,7 +49,7 @@ extern "C" {
 
     NvAPI_Status __cdecl NvAPI_D3D_GetCurrentSLIState(IUnknown* pDevice, NV_GET_CURRENT_SLI_STATE* pSliState) {
         constexpr auto n = __func__;
-        static bool alreadyLoggedOk = false;
+        thread_local bool alreadyLoggedOk = false;
 
         Enter(n, alreadyLoggedOk);
 
@@ -98,7 +98,7 @@ extern "C" {
 
     NvAPI_Status __cdecl NvAPI_D3D1x_GetGraphicsCapabilities(IUnknown* pDevice, NvU32 structVersion, NV_D3D1x_GRAPHICS_CAPS* pGraphicsCaps) {
         constexpr auto n = __func__;
-        static bool alreadyLoggedOk = false;
+        thread_local bool alreadyLoggedOk = false;
 
         Enter(n, alreadyLoggedOk);
 
@@ -133,9 +133,9 @@ extern "C" {
 
     NvAPI_Status __cdecl NvAPI_D3D_Sleep(IUnknown* pDevice) {
         constexpr auto n = __func__;
-        static bool alreadyLoggedNoReflex = false;
-        static bool alreadyLoggedError = false;
-        static bool alreadyLoggedOk = false;
+        thread_local bool alreadyLoggedNoReflex = false;
+        thread_local bool alreadyLoggedError = false;
+        thread_local bool alreadyLoggedOk = false;
 
         Enter(n, alreadyLoggedNoReflex || alreadyLoggedError || alreadyLoggedOk);
 
@@ -156,9 +156,9 @@ extern "C" {
 
     NvAPI_Status __cdecl NvAPI_D3D_SetSleepMode(IUnknown* pDevice, NV_SET_SLEEP_MODE_PARAMS* pSetSleepModeParams) {
         constexpr auto n = __func__;
-        static bool alreadyLoggedOk = false;
-        static bool alreadyLoggedNoReflex = false;
-        static bool alreadyLoggedError = false;
+        thread_local bool alreadyLoggedOk = false;
+        thread_local bool alreadyLoggedNoReflex = false;
+        thread_local bool alreadyLoggedError = false;
 
         static bool lastLowLatencyMode = false;
         static uint32_t lastMinimumIntervalUs = UINT32_MAX;
@@ -194,8 +194,8 @@ extern "C" {
 
     NvAPI_Status __cdecl NvAPI_D3D_GetSleepStatus(IUnknown* pDevice, NV_GET_SLEEP_STATUS_PARAMS* pGetSleepStatusParams) {
         constexpr auto n = __func__;
-        static bool alreadyLoggedNoReflex = false;
-        static bool alreadyLoggedOk = false;
+        thread_local bool alreadyLoggedNoReflex = false;
+        thread_local bool alreadyLoggedOk = false;
 
         Enter(n, alreadyLoggedNoReflex || alreadyLoggedOk);
 
@@ -218,9 +218,9 @@ extern "C" {
 
     NvAPI_Status __cdecl NvAPI_D3D_GetLatency(IUnknown* pDev, NV_LATENCY_RESULT_PARAMS* pGetLatencyParams) {
         constexpr auto n = __func__;
-        static bool alreadyLoggedNoImpl = false;
-        static bool alreadyLoggedError = false;
-        static bool alreadyLoggedOk = false;
+        thread_local bool alreadyLoggedNoImpl = false;
+        thread_local bool alreadyLoggedError = false;
+        thread_local bool alreadyLoggedOk = false;
 
         Enter(n, alreadyLoggedNoImpl || alreadyLoggedError || alreadyLoggedOk);
 
@@ -244,9 +244,9 @@ extern "C" {
 
     NvAPI_Status __cdecl NvAPI_D3D_SetLatencyMarker(IUnknown* pDev, NV_LATENCY_MARKER_PARAMS* pSetLatencyMarkerParams) {
         constexpr auto n = __func__;
-        static bool alreadyLoggedNoImpl = false;
-        static bool alreadyLoggedError = false;
-        static bool alreadyLoggedOk = false;
+        thread_local bool alreadyLoggedNoImpl = false;
+        thread_local bool alreadyLoggedError = false;
+        thread_local bool alreadyLoggedOk = false;
 
         Enter(n, alreadyLoggedNoImpl || alreadyLoggedError || alreadyLoggedOk);
 

--- a/src/nvapi_d3d.cpp
+++ b/src/nvapi_d3d.cpp
@@ -11,6 +11,8 @@ extern "C" {
         constexpr auto n = __func__;
         static bool alreadyLogged = false;
 
+        Enter(n, alreadyLogged);
+
         if (pResource == nullptr || pHandle == nullptr)
             return InvalidArgument(n);
 
@@ -21,24 +23,35 @@ extern "C" {
     }
 
     NvAPI_Status __cdecl NvAPI_D3D_SetResourceHint(IUnknown* pDev, NVDX_ObjectHandle obj, NVAPI_D3D_SETRESOURCEHINT_CATEGORY dwHintCategory, NvU32 dwHintName, NvU32* pdwHintValue) {
+        constexpr auto n = __func__;
         static bool alreadyLogged = false;
-        return NoImplementation(__func__, alreadyLogged);
+
+        Enter(n, alreadyLogged);
+        return NoImplementation(n, alreadyLogged);
     }
 
     NvAPI_Status __cdecl NvAPI_D3D_BeginResourceRendering(IUnknown* pDeviceOrContext, NVDX_ObjectHandle obj, NvU32 Flags) {
+        constexpr auto n = __func__;
         static bool alreadyLogged = false;
+
+        Enter(n, alreadyLogged);
         // Synchronisation hints for SLI...
-        return Ok(__func__, alreadyLogged);
+        return Ok(n, alreadyLogged);
     }
 
     NvAPI_Status __cdecl NvAPI_D3D_EndResourceRendering(IUnknown* pDeviceOrContext, NVDX_ObjectHandle obj, NvU32 Flags) {
+        constexpr auto n = __func__;
         static bool alreadyLogged = false;
-        return Ok(__func__, alreadyLogged);
+
+        Enter(n, alreadyLogged);
+        return Ok(n, alreadyLogged);
     }
 
     NvAPI_Status __cdecl NvAPI_D3D_GetCurrentSLIState(IUnknown* pDevice, NV_GET_CURRENT_SLI_STATE* pSliState) {
         constexpr auto n = __func__;
         static bool alreadyLoggedOk = false;
+
+        Enter(n, alreadyLoggedOk);
 
         if (pDevice == nullptr || pSliState == nullptr)
             return InvalidArgument(n);
@@ -75,6 +88,8 @@ extern "C" {
     NvAPI_Status __cdecl NvAPI_D3D_ImplicitSLIControl(IMPLICIT_SLI_CONTROL implicitSLIControl) {
         constexpr auto n = __func__;
 
+        Enter(n);
+
         if (implicitSLIControl == ENABLE_IMPLICIT_SLI)
             return Error(n); // No SLI with this implementation
 
@@ -84,6 +99,8 @@ extern "C" {
     NvAPI_Status __cdecl NvAPI_D3D1x_GetGraphicsCapabilities(IUnknown* pDevice, NvU32 structVersion, NV_D3D1x_GRAPHICS_CAPS* pGraphicsCaps) {
         constexpr auto n = __func__;
         static bool alreadyLoggedOk = false;
+
+        Enter(n, alreadyLoggedOk);
 
         if (pGraphicsCaps == nullptr)
             return InvalidArgument(n);
@@ -120,6 +137,8 @@ extern "C" {
         static bool alreadyLoggedError = false;
         static bool alreadyLoggedOk = false;
 
+        Enter(n, alreadyLoggedNoReflex || alreadyLoggedError || alreadyLoggedOk);
+
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);
 
@@ -143,6 +162,12 @@ extern "C" {
 
         static bool lastLowLatencyMode = false;
         static uint32_t lastMinimumIntervalUs = UINT32_MAX;
+
+        if (pSetSleepModeParams != nullptr
+            && (lastLowLatencyMode != pSetSleepModeParams->bLowLatencyMode || lastMinimumIntervalUs != pSetSleepModeParams->minimumIntervalUs))
+            Enter(n);
+        else
+            Enter(n, alreadyLoggedOk || alreadyLoggedNoReflex || alreadyLoggedError);
 
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);
@@ -172,6 +197,8 @@ extern "C" {
         static bool alreadyLoggedNoReflex = false;
         static bool alreadyLoggedOk = false;
 
+        Enter(n, alreadyLoggedNoReflex || alreadyLoggedOk);
+
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);
 
@@ -194,6 +221,8 @@ extern "C" {
         static bool alreadyLoggedNoImpl = false;
         static bool alreadyLoggedError = false;
         static bool alreadyLoggedOk = false;
+
+        Enter(n, alreadyLoggedNoImpl || alreadyLoggedError || alreadyLoggedOk);
 
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);
@@ -218,6 +247,8 @@ extern "C" {
         static bool alreadyLoggedNoImpl = false;
         static bool alreadyLoggedError = false;
         static bool alreadyLoggedOk = false;
+
+        Enter(n, alreadyLoggedNoImpl || alreadyLoggedError || alreadyLoggedOk);
 
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);

--- a/src/nvapi_d3d11.cpp
+++ b/src/nvapi_d3d11.cpp
@@ -99,8 +99,8 @@ extern "C" {
 
     NvAPI_Status __cdecl NvAPI_D3D11_SetDepthBoundsTest(IUnknown* pDeviceOrContext, NvU32 bEnable, float fMinDepth, float fMaxDepth) {
         constexpr auto n = __func__;
-        static bool alreadyLoggedError = false;
-        static bool alreadyLoggedOk = false;
+        thread_local bool alreadyLoggedError = false;
+        thread_local bool alreadyLoggedOk = false;
 
         Enter(n, alreadyLoggedError || alreadyLoggedOk);
 
@@ -115,8 +115,8 @@ extern "C" {
 
     NvAPI_Status __cdecl NvAPI_D3D11_BeginUAVOverlap(IUnknown* pDeviceOrContext) {
         constexpr auto n = __func__;
-        static bool alreadyLoggedError = false;
-        static bool alreadyLoggedOk = false;
+        thread_local bool alreadyLoggedError = false;
+        thread_local bool alreadyLoggedOk = false;
 
         Enter(n, alreadyLoggedError || alreadyLoggedOk);
 
@@ -131,8 +131,8 @@ extern "C" {
 
     NvAPI_Status __cdecl NvAPI_D3D11_EndUAVOverlap(IUnknown* pDeviceOrContext) {
         constexpr auto n = __func__;
-        static bool alreadyLoggedError = false;
-        static bool alreadyLoggedOk = false;
+        thread_local bool alreadyLoggedError = false;
+        thread_local bool alreadyLoggedOk = false;
 
         Enter(n, alreadyLoggedError || alreadyLoggedOk);
 
@@ -147,8 +147,8 @@ extern "C" {
 
     NvAPI_Status __cdecl NvAPI_D3D11_MultiDrawInstancedIndirect(ID3D11DeviceContext* pDevContext11, NvU32 drawCount, ID3D11Buffer* pBuffer, NvU32 alignedByteOffsetForArgs, NvU32 alignedByteStrideForArgs) {
         constexpr auto n = __func__;
-        static bool alreadyLoggedError = false;
-        static bool alreadyLoggedOk = false;
+        thread_local bool alreadyLoggedError = false;
+        thread_local bool alreadyLoggedOk = false;
 
         Enter(n, alreadyLoggedError || alreadyLoggedOk);
 
@@ -163,8 +163,8 @@ extern "C" {
 
     NvAPI_Status __cdecl NvAPI_D3D11_MultiDrawIndexedInstancedIndirect(ID3D11DeviceContext* pDevContext11, NvU32 drawCount, ID3D11Buffer* pBuffer, NvU32 alignedByteOffsetForArgs, NvU32 alignedByteStrideForArgs) {
         constexpr auto n = __func__;
-        static bool alreadyLoggedError = false;
-        static bool alreadyLoggedOk = false;
+        thread_local bool alreadyLoggedError = false;
+        thread_local bool alreadyLoggedOk = false;
 
         Enter(n, alreadyLoggedError || alreadyLoggedOk);
 
@@ -179,8 +179,8 @@ extern "C" {
 
     NvAPI_Status __cdecl NvAPI_D3D11_CreateCubinComputeShader(ID3D11Device* pDevice, const void* pCubin, NvU32 size, NvU32 blockX, NvU32 blockY, NvU32 blockZ, NVDX_ObjectHandle* phShader) {
         constexpr auto n = __func__;
-        static bool alreadyLoggedError = false;
-        static bool alreadyLoggedOk = false;
+        thread_local bool alreadyLoggedError = false;
+        thread_local bool alreadyLoggedOk = false;
 
         Enter(n, alreadyLoggedError || alreadyLoggedOk);
 
@@ -195,8 +195,8 @@ extern "C" {
 
     NvAPI_Status __cdecl NvAPI_D3D11_CreateCubinComputeShaderWithName(ID3D11Device* pDevice, const void* pCubin, NvU32 size, NvU32 blockX, NvU32 blockY, NvU32 blockZ, const char* pShaderName, NVDX_ObjectHandle* phShader) {
         constexpr auto n = __func__;
-        static bool alreadyLoggedError = false;
-        static bool alreadyLoggedOk = false;
+        thread_local bool alreadyLoggedError = false;
+        thread_local bool alreadyLoggedOk = false;
 
         Enter(n, alreadyLoggedError || alreadyLoggedOk);
 
@@ -211,8 +211,8 @@ extern "C" {
 
     NvAPI_Status __cdecl NvAPI_D3D11_LaunchCubinShader(ID3D11DeviceContext* pDeviceContext, NVDX_ObjectHandle hShader, NvU32 gridX, NvU32 gridY, NvU32 gridZ, const void* pParams, NvU32 paramSize, const NVDX_ObjectHandle* pReadResources, NvU32 numReadResources, const NVDX_ObjectHandle* pWriteResources, NvU32 numWriteResources) {
         constexpr auto n = __func__;
-        static bool alreadyLoggedError = false;
-        static bool alreadyLoggedOk = false;
+        thread_local bool alreadyLoggedError = false;
+        thread_local bool alreadyLoggedOk = false;
 
         Enter(n, alreadyLoggedError || alreadyLoggedOk);
 
@@ -227,8 +227,8 @@ extern "C" {
 
     NvAPI_Status __cdecl NvAPI_D3D11_DestroyCubinComputeShader(ID3D11Device* pDevice, NVDX_ObjectHandle hShader) {
         constexpr auto n = __func__;
-        static bool alreadyLoggedError = false;
-        static bool alreadyLoggedOk = false;
+        thread_local bool alreadyLoggedError = false;
+        thread_local bool alreadyLoggedOk = false;
 
         Enter(n, alreadyLoggedError || alreadyLoggedOk);
 
@@ -243,7 +243,7 @@ extern "C" {
 
     NvAPI_Status __cdecl NvAPI_D3D11_IsFatbinPTXSupported(ID3D11Device* pDevice, bool* pSupported) {
         constexpr auto n = __func__;
-        static bool alreadyLoggedOk = false;
+        thread_local bool alreadyLoggedOk = false;
 
         Enter(n, alreadyLoggedOk);
 
@@ -257,8 +257,8 @@ extern "C" {
 
     NvAPI_Status __cdecl NvAPI_D3D11_CreateUnorderedAccessView(ID3D11Device* pDevice, ID3D11Resource* pResource, const D3D11_UNORDERED_ACCESS_VIEW_DESC* pDesc, ID3D11UnorderedAccessView** ppUAV, NvU32* pDriverHandle) {
         constexpr auto n = __func__;
-        static bool alreadyLoggedError = false;
-        static bool alreadyLoggedOk = false;
+        thread_local bool alreadyLoggedError = false;
+        thread_local bool alreadyLoggedOk = false;
 
         Enter(n, alreadyLoggedError || alreadyLoggedOk);
 
@@ -273,8 +273,8 @@ extern "C" {
 
     NvAPI_Status __cdecl NvAPI_D3D11_CreateShaderResourceView(ID3D11Device* pDevice, ID3D11Resource* pResource, const D3D11_SHADER_RESOURCE_VIEW_DESC* pDesc, ID3D11ShaderResourceView** ppSRV, NvU32* pDriverHandle) {
         constexpr auto n = __func__;
-        static bool alreadyLoggedError = false;
-        static bool alreadyLoggedOk = false;
+        thread_local bool alreadyLoggedError = false;
+        thread_local bool alreadyLoggedOk = false;
 
         Enter(n, alreadyLoggedError || alreadyLoggedOk);
 
@@ -289,8 +289,8 @@ extern "C" {
 
     NvAPI_Status __cdecl NvAPI_D3D11_GetResourceHandle(ID3D11Device* pDevice, ID3D11Resource* pResource, NVDX_ObjectHandle* phObject) {
         constexpr auto n = __func__;
-        static bool alreadyLoggedOk = false;
-        static bool alreadyLoggedError = false;
+        thread_local bool alreadyLoggedOk = false;
+        thread_local bool alreadyLoggedError = false;
 
         Enter(n, alreadyLoggedError || alreadyLoggedOk);
 
@@ -305,8 +305,8 @@ extern "C" {
 
     NvAPI_Status __cdecl NvAPI_D3D11_GetResourceGPUVirtualAddress(ID3D11Device* pDevice, const NVDX_ObjectHandle hResource, NvU64* pGpuVA) {
         constexpr auto n = __func__;
-        static bool alreadyLoggedOk = false;
-        static bool alreadyLoggedError = false;
+        thread_local bool alreadyLoggedOk = false;
+        thread_local bool alreadyLoggedError = false;
 
         Enter(n, alreadyLoggedError || alreadyLoggedOk);
 
@@ -322,8 +322,8 @@ extern "C" {
 
     NvAPI_Status __cdecl NvAPI_D3D11_GetResourceGPUVirtualAddressEx(ID3D11Device* pDevice, NV_GET_GPU_VIRTUAL_ADDRESS* pParams) {
         constexpr auto n = __func__;
-        static bool alreadyLoggedOk = false;
-        static bool alreadyLoggedError = false;
+        thread_local bool alreadyLoggedOk = false;
+        thread_local bool alreadyLoggedError = false;
 
         Enter(n, alreadyLoggedError || alreadyLoggedOk);
 
@@ -344,8 +344,8 @@ extern "C" {
 
     NvAPI_Status __cdecl NvAPI_D3D11_CreateSamplerState(ID3D11Device* pDevice, const D3D11_SAMPLER_DESC* pSamplerDesc, ID3D11SamplerState** ppSamplerState, NvU32* pDriverHandle) {
         constexpr auto n = __func__;
-        static bool alreadyLoggedError = false;
-        static bool alreadyLoggedOk = false;
+        thread_local bool alreadyLoggedError = false;
+        thread_local bool alreadyLoggedOk = false;
 
         Enter(n, alreadyLoggedError || alreadyLoggedOk);
 
@@ -360,8 +360,8 @@ extern "C" {
 
     NvAPI_Status __cdecl NvAPI_D3D11_GetCudaTextureObject(ID3D11Device* pDevice, NvU32 srvDriverHandle, NvU32 samplerDriverHandle, NvU32* pCudaTextureHandle) {
         constexpr auto n = __func__;
-        static bool alreadyLoggedError = false;
-        static bool alreadyLoggedOk = false;
+        thread_local bool alreadyLoggedError = false;
+        thread_local bool alreadyLoggedOk = false;
 
         Enter(n, alreadyLoggedError || alreadyLoggedOk);
 

--- a/src/nvapi_d3d11.cpp
+++ b/src/nvapi_d3d11.cpp
@@ -11,6 +11,8 @@ extern "C" {
     NvAPI_Status __cdecl NvAPI_D3D11_CreateDevice(IDXGIAdapter* pAdapter, D3D_DRIVER_TYPE DriverType, HMODULE Software, UINT Flags, CONST D3D_FEATURE_LEVEL* pFeatureLevels, UINT FeatureLevels, UINT SDKVersion, ID3D11Device** ppDevice, D3D_FEATURE_LEVEL* pFeatureLevel, ID3D11DeviceContext** ppImmediateContext, NVAPI_DEVICE_FEATURE_LEVEL* pSupportedLevel) {
         constexpr auto n = __func__;
 
+        Enter(n);
+
         if (pSupportedLevel == nullptr)
             return InvalidArgument(n);
 
@@ -24,6 +26,8 @@ extern "C" {
 
     NvAPI_Status __cdecl NvAPI_D3D11_CreateDeviceAndSwapChain(IDXGIAdapter* pAdapter, D3D_DRIVER_TYPE DriverType, HMODULE Software, UINT Flags, CONST D3D_FEATURE_LEVEL* pFeatureLevels, UINT FeatureLevels, UINT SDKVersion, CONST DXGI_SWAP_CHAIN_DESC* pSwapChainDesc, IDXGISwapChain** ppSwapChain, ID3D11Device** ppDevice, D3D_FEATURE_LEVEL* pFeatureLevel, ID3D11DeviceContext** ppImmediateContext, NVAPI_DEVICE_FEATURE_LEVEL* pSupportedLevel) {
         constexpr auto n = __func__;
+
+        Enter(n);
 
         if (pSupportedLevel == nullptr)
             return InvalidArgument(n);
@@ -39,6 +43,8 @@ extern "C" {
     NvAPI_Status __cdecl NvAPI_D3D11_IsNvShaderExtnOpCodeSupported(IUnknown* pDeviceOrContext, NvU32 code, bool* supported) {
         constexpr auto n = __func__;
 
+        Enter(n);
+
         if (pDeviceOrContext == nullptr || supported == nullptr)
             return InvalidArgument(n);
 
@@ -50,6 +56,8 @@ extern "C" {
 
     NvAPI_Status __cdecl NvAPI_D3D11_MultiGPU_GetCaps(PNV_MULTIGPU_CAPS pMultiGPUCaps) {
         constexpr auto n = __func__;
+
+        Enter(n);
 
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);
@@ -82,14 +90,19 @@ extern "C" {
     }
 
     NvAPI_Status __cdecl NvAPI_D3D11_MultiGPU_Init(bool bEnable) {
+        constexpr auto n = __func__;
+
+        Enter(n);
         // Just acknowledge the request since there is nothing to do here
-        return Ok(__func__);
+        return Ok(n);
     }
 
     NvAPI_Status __cdecl NvAPI_D3D11_SetDepthBoundsTest(IUnknown* pDeviceOrContext, NvU32 bEnable, float fMinDepth, float fMaxDepth) {
         constexpr auto n = __func__;
         static bool alreadyLoggedError = false;
         static bool alreadyLoggedOk = false;
+
+        Enter(n, alreadyLoggedError || alreadyLoggedOk);
 
         if (pDeviceOrContext == nullptr)
             return InvalidArgument(n);
@@ -105,6 +118,8 @@ extern "C" {
         static bool alreadyLoggedError = false;
         static bool alreadyLoggedOk = false;
 
+        Enter(n, alreadyLoggedError || alreadyLoggedOk);
+
         if (pDeviceOrContext == nullptr)
             return InvalidArgument(n);
 
@@ -118,6 +133,8 @@ extern "C" {
         constexpr auto n = __func__;
         static bool alreadyLoggedError = false;
         static bool alreadyLoggedOk = false;
+
+        Enter(n, alreadyLoggedError || alreadyLoggedOk);
 
         if (pDeviceOrContext == nullptr)
             return InvalidArgument(n);
@@ -133,6 +150,8 @@ extern "C" {
         static bool alreadyLoggedError = false;
         static bool alreadyLoggedOk = false;
 
+        Enter(n, alreadyLoggedError || alreadyLoggedOk);
+
         if (pDevContext11 == nullptr || pBuffer == nullptr)
             return InvalidArgument(n);
 
@@ -146,6 +165,8 @@ extern "C" {
         constexpr auto n = __func__;
         static bool alreadyLoggedError = false;
         static bool alreadyLoggedOk = false;
+
+        Enter(n, alreadyLoggedError || alreadyLoggedOk);
 
         if (pDevContext11 == nullptr || pBuffer == nullptr)
             return InvalidArgument(n);
@@ -161,6 +182,8 @@ extern "C" {
         static bool alreadyLoggedError = false;
         static bool alreadyLoggedOk = false;
 
+        Enter(n, alreadyLoggedError || alreadyLoggedOk);
+
         if (pDevice == nullptr || pCubin == nullptr || phShader == nullptr)
             return InvalidArgument(n);
 
@@ -174,6 +197,8 @@ extern "C" {
         constexpr auto n = __func__;
         static bool alreadyLoggedError = false;
         static bool alreadyLoggedOk = false;
+
+        Enter(n, alreadyLoggedError || alreadyLoggedOk);
 
         if (pDevice == nullptr || pCubin == nullptr || pShaderName == nullptr || phShader == nullptr)
             return InvalidArgument(n);
@@ -189,6 +214,8 @@ extern "C" {
         static bool alreadyLoggedError = false;
         static bool alreadyLoggedOk = false;
 
+        Enter(n, alreadyLoggedError || alreadyLoggedOk);
+
         if (pDeviceContext == nullptr)
             return InvalidArgument(n);
 
@@ -203,6 +230,8 @@ extern "C" {
         static bool alreadyLoggedError = false;
         static bool alreadyLoggedOk = false;
 
+        Enter(n, alreadyLoggedError || alreadyLoggedOk);
+
         if (pDevice == nullptr)
             return InvalidArgument(n);
 
@@ -216,6 +245,8 @@ extern "C" {
         constexpr auto n = __func__;
         static bool alreadyLoggedOk = false;
 
+        Enter(n, alreadyLoggedOk);
+
         if (pDevice == nullptr || pSupported == nullptr)
             return InvalidArgument(n);
 
@@ -228,6 +259,8 @@ extern "C" {
         constexpr auto n = __func__;
         static bool alreadyLoggedError = false;
         static bool alreadyLoggedOk = false;
+
+        Enter(n, alreadyLoggedError || alreadyLoggedOk);
 
         if (pDevice == nullptr || pResource == nullptr || pDesc == nullptr || ppUAV == nullptr || pDriverHandle == nullptr)
             return InvalidArgument(n);
@@ -243,6 +276,8 @@ extern "C" {
         static bool alreadyLoggedError = false;
         static bool alreadyLoggedOk = false;
 
+        Enter(n, alreadyLoggedError || alreadyLoggedOk);
+
         if (pDevice == nullptr || pResource == nullptr || pDesc == nullptr || ppSRV == nullptr || pDriverHandle == nullptr)
             return InvalidArgument(n);
 
@@ -256,6 +291,8 @@ extern "C" {
         constexpr auto n = __func__;
         static bool alreadyLoggedOk = false;
         static bool alreadyLoggedError = false;
+
+        Enter(n, alreadyLoggedError || alreadyLoggedOk);
 
         if (pDevice == nullptr || pResource == nullptr || phObject == nullptr)
             return InvalidArgument(n);
@@ -271,6 +308,8 @@ extern "C" {
         static bool alreadyLoggedOk = false;
         static bool alreadyLoggedError = false;
 
+        Enter(n, alreadyLoggedError || alreadyLoggedOk);
+
         if (pDevice == nullptr || hResource == NVDX_OBJECT_NONE || pGpuVA == nullptr)
             return InvalidArgument(n);
 
@@ -285,6 +324,8 @@ extern "C" {
         constexpr auto n = __func__;
         static bool alreadyLoggedOk = false;
         static bool alreadyLoggedError = false;
+
+        Enter(n, alreadyLoggedError || alreadyLoggedOk);
 
         if (pDevice == nullptr || pParams == nullptr)
             return InvalidArgument(n);
@@ -306,6 +347,8 @@ extern "C" {
         static bool alreadyLoggedError = false;
         static bool alreadyLoggedOk = false;
 
+        Enter(n, alreadyLoggedError || alreadyLoggedOk);
+
         if (pDevice == nullptr || pSamplerDesc == nullptr || ppSamplerState == nullptr || pDriverHandle == nullptr)
             return InvalidArgument(n);
 
@@ -319,6 +362,8 @@ extern "C" {
         constexpr auto n = __func__;
         static bool alreadyLoggedError = false;
         static bool alreadyLoggedOk = false;
+
+        Enter(n, alreadyLoggedError || alreadyLoggedOk);
 
         if (pDevice == nullptr || pCudaTextureHandle == nullptr)
             return InvalidArgument(n);

--- a/src/nvapi_d3d12.cpp
+++ b/src/nvapi_d3d12.cpp
@@ -431,11 +431,11 @@ extern "C" {
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);
 
-        if (pSetLatencyMarkerParams->version != NV_LATENCY_MARKER_PARAMS_VER1)
-            return IncompatibleStructVersion(n);
-
         if (pCommandQueue == nullptr || pSetLatencyMarkerParams == nullptr)
             return InvalidPointer(n);
+
+        if (pSetLatencyMarkerParams->version != NV_LATENCY_MARKER_PARAMS_VER1)
+            return IncompatibleStructVersion(n);
 
         ID3D12Device* pDevice;
         if (FAILED(pCommandQueue->GetDevice(IID_PPV_ARGS(&pDevice))))

--- a/src/nvapi_d3d12.cpp
+++ b/src/nvapi_d3d12.cpp
@@ -13,6 +13,8 @@ extern "C" {
     NvAPI_Status __cdecl NvAPI_D3D12_IsNvShaderExtnOpCodeSupported(ID3D12Device* pDevice, NvU32 opCode, bool* pSupported) {
         constexpr auto n = __func__;
 
+        Enter(n);
+
         if (pDevice == nullptr || pSupported == nullptr)
             return InvalidArgument(n);
 
@@ -23,13 +25,18 @@ extern "C" {
     }
 
     NvAPI_Status __cdecl NvAPI_D3D12_EnumerateMetaCommands(ID3D12Device* pDevice, NvU32* pNumMetaCommands, NVAPI_META_COMMAND_DESC* pDescs) {
-        return NotSupported(__func__);
+        constexpr auto n = __func__;
+
+        Enter(n);
+        return NotSupported(n);
     }
 
     NvAPI_Status __cdecl NvAPI_D3D12_CreateCubinComputeShaderEx(ID3D12Device* pDevice, const void* cubinData, NvU32 cubinSize, NvU32 blockX, NvU32 blockY, NvU32 blockZ, NvU32 smemSize, const char* shaderName, NVDX_ObjectHandle* pShader) {
         constexpr auto n = __func__;
         static bool alreadyLoggedError = false;
         static bool alreadyLoggedOk = false;
+
+        Enter(n, alreadyLoggedError || alreadyLoggedOk);
 
         if (pDevice == nullptr || shaderName == nullptr || pShader == nullptr)
             return InvalidArgument(n);
@@ -45,6 +52,8 @@ extern "C" {
         static bool alreadyLoggedError = false;
         static bool alreadyLoggedOk = false;
 
+        Enter(n, alreadyLoggedError || alreadyLoggedOk);
+
         if (pDevice == nullptr || shaderName == nullptr || pShader == nullptr)
             return InvalidArgument(n);
 
@@ -58,6 +67,8 @@ extern "C" {
         constexpr auto n = __func__;
         static bool alreadyLoggedError = false;
         static bool alreadyLoggedOk = false;
+
+        Enter(n, alreadyLoggedError || alreadyLoggedOk);
 
         if (pDevice == nullptr || pShader == nullptr)
             return InvalidArgument(n);
@@ -73,6 +84,8 @@ extern "C" {
         static bool alreadyLoggedError = false;
         static bool alreadyLoggedOk = false;
 
+        Enter(n, alreadyLoggedError || alreadyLoggedOk);
+
         if (pDevice == nullptr)
             return InvalidArgument(n);
 
@@ -86,6 +99,8 @@ extern "C" {
         constexpr auto n = __func__;
         static bool alreadyLoggedError = false;
         static bool alreadyLoggedOk = false;
+
+        Enter(n, alreadyLoggedError || alreadyLoggedOk);
 
         if (pDevice == nullptr || cudaTextureHandle == nullptr)
             return InvalidArgument(n);
@@ -101,6 +116,8 @@ extern "C" {
         static bool alreadyLoggedError = false;
         static bool alreadyLoggedOk = false;
 
+        Enter(n, alreadyLoggedError || alreadyLoggedOk);
+
         if (pDevice == nullptr || cudaSurfaceHandle == nullptr)
             return InvalidArgument(n);
 
@@ -114,6 +131,8 @@ extern "C" {
         constexpr auto n = __func__;
         static bool alreadyLoggedError = false;
         static bool alreadyLoggedOk = false;
+
+        Enter(n, alreadyLoggedError || alreadyLoggedOk);
 
         if (pCmdList == nullptr)
             return InvalidArgument(n);
@@ -129,6 +148,8 @@ extern "C" {
         static bool alreadyLoggedError = false;
         static bool alreadyLoggedOk = false;
 
+        Enter(n, alreadyLoggedError || alreadyLoggedOk);
+
         if (pDevice == nullptr || pUAVInfo == nullptr)
             return InvalidArgument(n);
 
@@ -140,6 +161,8 @@ extern "C" {
 
     NvAPI_Status __cdecl NvAPI_D3D12_GetGraphicsCapabilities(IUnknown* pDevice, NvU32 structVersion, NV_D3D12_GRAPHICS_CAPS* pGraphicsCaps) {
         constexpr auto n = __func__;
+
+        Enter(n);
 
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);
@@ -207,6 +230,8 @@ extern "C" {
         static bool alreadyLoggedError = false;
         static bool alreadyLoggedOk = false;
 
+        Enter(n, alreadyLoggedError || alreadyLoggedOk);
+
         if (pDevice == nullptr || isSupported == nullptr)
             return InvalidArgument(n);
 
@@ -220,6 +245,8 @@ extern "C" {
     NvAPI_Status __cdecl NvAPI_D3D12_CreateGraphicsPipelineState(ID3D12Device* pDevice, const D3D12_GRAPHICS_PIPELINE_STATE_DESC* pPSODesc, NvU32 numExtensions, const NVAPI_D3D12_PSO_EXTENSION_DESC** ppExtensions, ID3D12PipelineState** ppPSO) {
         constexpr auto n = __func__;
         static bool alreadyLoggedOk = false;
+
+        Enter(n, alreadyLoggedOk);
 
         if (pDevice == nullptr || pPSODesc == nullptr || ppExtensions == nullptr || ppPSO == nullptr)
             return InvalidArgument(n);
@@ -247,6 +274,8 @@ extern "C" {
         static bool alreadyLoggedError = false;
         static bool alreadyLoggedOk = false;
 
+        Enter(n, alreadyLoggedError || alreadyLoggedOk);
+
         if (pCommandList == nullptr)
             return InvalidArgument(n);
 
@@ -258,6 +287,8 @@ extern "C" {
 
     NvAPI_Status __cdecl NvAPI_D3D12_GetRaytracingCaps(ID3D12Device* pDevice, NVAPI_D3D12_RAYTRACING_CAPS_TYPE type, void* pData, size_t dataSize) {
         constexpr auto n = __func__;
+
+        Enter(n);
 
         if (pDevice == nullptr || pData == nullptr)
             return InvalidPointer(n);
@@ -350,6 +381,8 @@ extern "C" {
         constexpr auto n = __func__;
         static bool alreadyLoggedOk = false;
 
+        Enter(n, alreadyLoggedOk);
+
         if (pDevice == nullptr || pParams == nullptr)
             return InvalidArgument(n);
 
@@ -373,6 +406,8 @@ extern "C" {
     NvAPI_Status __cdecl NvAPI_D3D12_BuildRaytracingAccelerationStructureEx(ID3D12GraphicsCommandList4* pCommandList, const NVAPI_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_EX_PARAMS* pParams) {
         constexpr auto n = __func__;
         static bool alreadyLoggedOk = false;
+
+        Enter(n, alreadyLoggedOk);
 
         if (pCommandList == nullptr || pParams == nullptr)
             return InvalidArgument(n);
@@ -404,6 +439,8 @@ extern "C" {
         static bool alreadyLoggedError = false;
         static bool alreadyLoggedOk = false;
 
+        Enter(n, alreadyLoggedError || alreadyLoggedOk);
+
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);
 
@@ -427,6 +464,8 @@ extern "C" {
         constexpr auto n = __func__;
         static bool alreadyLoggedError = false;
         static bool alreadyLoggedOk = false;
+
+        Enter(n, alreadyLoggedError || alreadyLoggedOk);
 
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);

--- a/src/nvapi_d3d12.cpp
+++ b/src/nvapi_d3d12.cpp
@@ -33,8 +33,8 @@ extern "C" {
 
     NvAPI_Status __cdecl NvAPI_D3D12_CreateCubinComputeShaderEx(ID3D12Device* pDevice, const void* cubinData, NvU32 cubinSize, NvU32 blockX, NvU32 blockY, NvU32 blockZ, NvU32 smemSize, const char* shaderName, NVDX_ObjectHandle* pShader) {
         constexpr auto n = __func__;
-        static bool alreadyLoggedError = false;
-        static bool alreadyLoggedOk = false;
+        thread_local bool alreadyLoggedError = false;
+        thread_local bool alreadyLoggedOk = false;
 
         Enter(n, alreadyLoggedError || alreadyLoggedOk);
 
@@ -49,8 +49,8 @@ extern "C" {
 
     NvAPI_Status __cdecl NvAPI_D3D12_CreateCubinComputeShaderWithName(ID3D12Device* pDevice, const void* cubinData, NvU32 cubinSize, NvU32 blockX, NvU32 blockY, NvU32 blockZ, const char* shaderName, NVDX_ObjectHandle* pShader) {
         constexpr auto n = __func__;
-        static bool alreadyLoggedError = false;
-        static bool alreadyLoggedOk = false;
+        thread_local bool alreadyLoggedError = false;
+        thread_local bool alreadyLoggedOk = false;
 
         Enter(n, alreadyLoggedError || alreadyLoggedOk);
 
@@ -65,8 +65,8 @@ extern "C" {
 
     NvAPI_Status __cdecl NvAPI_D3D12_CreateCubinComputeShader(ID3D12Device* pDevice, const void* cubinData, NvU32 cubinSize, NvU32 blockX, NvU32 blockY, NvU32 blockZ, NVDX_ObjectHandle* pShader) {
         constexpr auto n = __func__;
-        static bool alreadyLoggedError = false;
-        static bool alreadyLoggedOk = false;
+        thread_local bool alreadyLoggedError = false;
+        thread_local bool alreadyLoggedOk = false;
 
         Enter(n, alreadyLoggedError || alreadyLoggedOk);
 
@@ -81,8 +81,8 @@ extern "C" {
 
     NvAPI_Status __cdecl NvAPI_D3D12_DestroyCubinComputeShader(ID3D12Device* pDevice, NVDX_ObjectHandle pShader) {
         constexpr auto n = __func__;
-        static bool alreadyLoggedError = false;
-        static bool alreadyLoggedOk = false;
+        thread_local bool alreadyLoggedError = false;
+        thread_local bool alreadyLoggedOk = false;
 
         Enter(n, alreadyLoggedError || alreadyLoggedOk);
 
@@ -97,8 +97,8 @@ extern "C" {
 
     NvAPI_Status __cdecl NvAPI_D3D12_GetCudaTextureObject(ID3D12Device* pDevice, D3D12_CPU_DESCRIPTOR_HANDLE srvHandle, D3D12_CPU_DESCRIPTOR_HANDLE samplerHandle, NvU32* cudaTextureHandle) {
         constexpr auto n = __func__;
-        static bool alreadyLoggedError = false;
-        static bool alreadyLoggedOk = false;
+        thread_local bool alreadyLoggedError = false;
+        thread_local bool alreadyLoggedOk = false;
 
         Enter(n, alreadyLoggedError || alreadyLoggedOk);
 
@@ -113,8 +113,8 @@ extern "C" {
 
     NvAPI_Status __cdecl NvAPI_D3D12_GetCudaSurfaceObject(ID3D12Device* pDevice, D3D12_CPU_DESCRIPTOR_HANDLE uavHandle, NvU32* cudaSurfaceHandle) {
         constexpr auto n = __func__;
-        static bool alreadyLoggedError = false;
-        static bool alreadyLoggedOk = false;
+        thread_local bool alreadyLoggedError = false;
+        thread_local bool alreadyLoggedOk = false;
 
         Enter(n, alreadyLoggedError || alreadyLoggedOk);
 
@@ -129,8 +129,8 @@ extern "C" {
 
     NvAPI_Status __cdecl NvAPI_D3D12_LaunchCubinShader(ID3D12GraphicsCommandList* pCmdList, NVDX_ObjectHandle pShader, NvU32 blockX, NvU32 blockY, NvU32 blockZ, const void* params, NvU32 paramSize) {
         constexpr auto n = __func__;
-        static bool alreadyLoggedError = false;
-        static bool alreadyLoggedOk = false;
+        thread_local bool alreadyLoggedError = false;
+        thread_local bool alreadyLoggedOk = false;
 
         Enter(n, alreadyLoggedError || alreadyLoggedOk);
 
@@ -145,8 +145,8 @@ extern "C" {
 
     NvAPI_Status __cdecl NvAPI_D3D12_CaptureUAVInfo(ID3D12Device* pDevice, NVAPI_UAV_INFO* pUAVInfo) {
         constexpr auto n = __func__;
-        static bool alreadyLoggedError = false;
-        static bool alreadyLoggedOk = false;
+        thread_local bool alreadyLoggedError = false;
+        thread_local bool alreadyLoggedOk = false;
 
         Enter(n, alreadyLoggedError || alreadyLoggedOk);
 
@@ -227,8 +227,8 @@ extern "C" {
 
     NvAPI_Status __cdecl NvAPI_D3D12_IsFatbinPTXSupported(ID3D12Device* pDevice, bool* isSupported) {
         constexpr auto n = __func__;
-        static bool alreadyLoggedError = false;
-        static bool alreadyLoggedOk = false;
+        thread_local bool alreadyLoggedError = false;
+        thread_local bool alreadyLoggedOk = false;
 
         Enter(n, alreadyLoggedError || alreadyLoggedOk);
 
@@ -244,7 +244,7 @@ extern "C" {
 
     NvAPI_Status __cdecl NvAPI_D3D12_CreateGraphicsPipelineState(ID3D12Device* pDevice, const D3D12_GRAPHICS_PIPELINE_STATE_DESC* pPSODesc, NvU32 numExtensions, const NVAPI_D3D12_PSO_EXTENSION_DESC** ppExtensions, ID3D12PipelineState** ppPSO) {
         constexpr auto n = __func__;
-        static bool alreadyLoggedOk = false;
+        thread_local bool alreadyLoggedOk = false;
 
         Enter(n, alreadyLoggedOk);
 
@@ -271,8 +271,8 @@ extern "C" {
 
     NvAPI_Status __cdecl NvAPI_D3D12_SetDepthBoundsTestValues(ID3D12GraphicsCommandList* pCommandList, const float minDepth, const float maxDepth) {
         constexpr auto n = __func__;
-        static bool alreadyLoggedError = false;
-        static bool alreadyLoggedOk = false;
+        thread_local bool alreadyLoggedError = false;
+        thread_local bool alreadyLoggedOk = false;
 
         Enter(n, alreadyLoggedError || alreadyLoggedOk);
 
@@ -379,7 +379,7 @@ extern "C" {
 
     NvAPI_Status __cdecl NvAPI_D3D12_GetRaytracingAccelerationStructurePrebuildInfoEx(ID3D12Device5* pDevice, NVAPI_GET_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO_EX_PARAMS* pParams) {
         constexpr auto n = __func__;
-        static bool alreadyLoggedOk = false;
+        thread_local bool alreadyLoggedOk = false;
 
         Enter(n, alreadyLoggedOk);
 
@@ -405,7 +405,7 @@ extern "C" {
 
     NvAPI_Status __cdecl NvAPI_D3D12_BuildRaytracingAccelerationStructureEx(ID3D12GraphicsCommandList4* pCommandList, const NVAPI_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_EX_PARAMS* pParams) {
         constexpr auto n = __func__;
-        static bool alreadyLoggedOk = false;
+        thread_local bool alreadyLoggedOk = false;
 
         Enter(n, alreadyLoggedOk);
 
@@ -436,8 +436,8 @@ extern "C" {
 
     NvAPI_Status __cdecl NvAPI_D3D12_NotifyOutOfBandCommandQueue(ID3D12CommandQueue* pCommandQueue, NV_OUT_OF_BAND_CQ_TYPE cqType) {
         constexpr auto n = __func__;
-        static bool alreadyLoggedError = false;
-        static bool alreadyLoggedOk = false;
+        thread_local bool alreadyLoggedError = false;
+        thread_local bool alreadyLoggedOk = false;
 
         Enter(n, alreadyLoggedError || alreadyLoggedOk);
 
@@ -462,8 +462,8 @@ extern "C" {
 
     NvAPI_Status __cdecl NvAPI_D3D12_SetAsyncFrameMarker(ID3D12CommandQueue* pCommandQueue, NV_LATENCY_MARKER_PARAMS* pSetLatencyMarkerParams) {
         constexpr auto n = __func__;
-        static bool alreadyLoggedError = false;
-        static bool alreadyLoggedOk = false;
+        thread_local bool alreadyLoggedError = false;
+        thread_local bool alreadyLoggedOk = false;
 
         Enter(n, alreadyLoggedError || alreadyLoggedOk);
 

--- a/src/nvapi_disp.cpp
+++ b/src/nvapi_disp.cpp
@@ -40,6 +40,8 @@ extern "C" {
     NvAPI_Status __cdecl NvAPI_Disp_GetHdrCapabilities(NvU32 displayId, NV_HDR_CAPABILITIES* pHdrCapabilities) {
         constexpr auto n = __func__;
 
+        Enter(n);
+
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);
 
@@ -111,6 +113,8 @@ extern "C" {
 
     NvAPI_Status __cdecl NvAPI_Disp_HdrColorControl(NvU32 displayId, NV_HDR_COLOR_DATA* pHdrColorData) {
         constexpr auto n = __func__;
+
+        Enter(n);
 
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);
@@ -206,6 +210,8 @@ extern "C" {
     NvAPI_Status __cdecl NvAPI_DISP_GetDisplayIdByDisplayName(const char* displayName, NvU32* displayId) {
         constexpr auto n = __func__;
 
+        Enter(n);
+
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);
 
@@ -223,6 +229,8 @@ extern "C" {
 
     NvAPI_Status __cdecl NvAPI_DISP_GetGDIPrimaryDisplayId(NvU32* displayId) {
         constexpr auto n = __func__;
+
+        Enter(n);
 
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);

--- a/src/nvapi_drs.cpp
+++ b/src/nvapi_drs.cpp
@@ -12,6 +12,8 @@ extern "C" {
     NvAPI_Status __cdecl NvAPI_DRS_CreateSession(NvDRSSessionHandle* phSession) {
         constexpr auto n = __func__;
 
+        Enter(n);
+
         if (phSession == nullptr)
             return InvalidArgument(n);
 
@@ -21,19 +23,30 @@ extern "C" {
     }
 
     NvAPI_Status __cdecl NvAPI_DRS_LoadSettings(NvDRSSessionHandle hSession) {
-        return Ok(__func__);
+        constexpr auto n = __func__;
+
+        Enter(n);
+        return Ok(n);
     }
 
     NvAPI_Status __cdecl NvAPI_DRS_FindProfileByName(NvDRSSessionHandle hSession, NvAPI_UnicodeString profileName, NvDRSProfileHandle* phProfile) {
-        return ProfileNotFound(str::format(__func__, " (", str::fromnvus(profileName), ")"));
+        constexpr auto n = __func__;
+
+        Enter(n);
+        return ProfileNotFound(str::format(n, " (", str::fromnvus(profileName), ")"));
     }
 
     NvAPI_Status __cdecl NvAPI_DRS_FindApplicationByName(NvDRSSessionHandle hSession, NvAPI_UnicodeString appName, NvDRSProfileHandle* phProfile, NVDRS_APPLICATION* pApplication) {
-        return ExecutableNotFound(str::format(__func__, " (", str::fromnvus(appName), ")"));
+        constexpr auto n = __func__;
+
+        Enter(n);
+        return ExecutableNotFound(str::format(n, " (", str::fromnvus(appName), ")"));
     }
 
     NvAPI_Status __cdecl NvAPI_DRS_GetBaseProfile(NvDRSSessionHandle hSession, NvDRSProfileHandle* phProfile) {
         constexpr auto n = __func__;
+
+        Enter(n);
 
         if (phProfile == nullptr)
             return InvalidArgument(n);
@@ -46,6 +59,8 @@ extern "C" {
     NvAPI_Status __cdecl NvAPI_DRS_GetCurrentGlobalProfile(NvDRSSessionHandle hSession, NvDRSProfileHandle* phProfile) {
         constexpr auto n = __func__;
 
+        Enter(n);
+
         if (phProfile == nullptr)
             return InvalidArgument(n);
 
@@ -56,6 +71,8 @@ extern "C" {
 
     NvAPI_Status __cdecl NvAPI_DRS_GetSetting(NvDRSSessionHandle hSession, NvDRSProfileHandle hProfile, NvU32 settingId, NVDRS_SETTING* pSetting) {
         constexpr auto n = __func__;
+
+        Enter(n);
 
         auto id = str::format("0x", std::hex, settingId);
         auto name = std::string("Unknown");
@@ -78,6 +95,9 @@ extern "C" {
     }
 
     NvAPI_Status __cdecl NvAPI_DRS_DestroySession(NvDRSSessionHandle hSession) {
-        return Ok(__func__);
+        constexpr auto n = __func__;
+
+        Enter(n);
+        return Ok(n);
     }
 }

--- a/src/nvapi_gpu.cpp
+++ b/src/nvapi_gpu.cpp
@@ -56,9 +56,9 @@ extern "C" {
 
     NvAPI_Status __cdecl NvAPI_GPU_GetCurrentPCIEDownstreamWidth(NvPhysicalGpuHandle hPhysicalGpu, NvU32* pWidth) {
         constexpr auto n = __func__;
-        static bool alreadyLoggedNoNvml = false;
-        static bool alreadyLoggedHandleInvalidated = false;
-        static bool alreadyLoggedOk = false;
+        thread_local bool alreadyLoggedNoNvml = false;
+        thread_local bool alreadyLoggedHandleInvalidated = false;
+        thread_local bool alreadyLoggedOk = false;
 
         Enter(n, alreadyLoggedNoNvml || alreadyLoggedHandleInvalidated || alreadyLoggedOk);
 
@@ -97,9 +97,9 @@ extern "C" {
 
     NvAPI_Status __cdecl NvAPI_GPU_GetIRQ(NvPhysicalGpuHandle hPhysicalGpu, NvU32* pIRQ) {
         constexpr auto n = __func__;
-        static bool alreadyLoggedNoNvml = false;
-        static bool alreadyLoggedHandleInvalidated = false;
-        static bool alreadyLoggedOk = false;
+        thread_local bool alreadyLoggedNoNvml = false;
+        thread_local bool alreadyLoggedHandleInvalidated = false;
+        thread_local bool alreadyLoggedOk = false;
 
         Enter(n, alreadyLoggedNoNvml || alreadyLoggedHandleInvalidated || alreadyLoggedOk);
 
@@ -138,9 +138,9 @@ extern "C" {
 
     NvAPI_Status __cdecl NvAPI_GPU_GetGpuCoreCount(NvPhysicalGpuHandle hPhysicalGpu, NvU32* pCount) {
         constexpr auto n = __func__;
-        static bool alreadyLoggedNoNvml = false;
-        static bool alreadyLoggedHandleInvalidated = false;
-        static bool alreadyLoggedOk = false;
+        thread_local bool alreadyLoggedNoNvml = false;
+        thread_local bool alreadyLoggedHandleInvalidated = false;
+        thread_local bool alreadyLoggedOk = false;
 
         Enter(n, alreadyLoggedNoNvml || alreadyLoggedHandleInvalidated || alreadyLoggedOk);
 
@@ -637,9 +637,9 @@ extern "C" {
 
     NvAPI_Status __cdecl NvAPI_GPU_GetDynamicPstatesInfoEx(NvPhysicalGpuHandle hPhysicalGpu, NV_GPU_DYNAMIC_PSTATES_INFO_EX* pDynamicPstatesInfoEx) {
         constexpr auto n = __func__;
-        static bool alreadyLoggedNoNvml = false;
-        static bool alreadyLoggedHandleInvalidated = false;
-        static bool alreadyLoggedOk = false;
+        thread_local bool alreadyLoggedNoNvml = false;
+        thread_local bool alreadyLoggedHandleInvalidated = false;
+        thread_local bool alreadyLoggedOk = false;
 
         Enter(n, alreadyLoggedNoNvml || alreadyLoggedHandleInvalidated || alreadyLoggedOk);
 
@@ -734,9 +734,9 @@ extern "C" {
 
     NvAPI_Status __cdecl NvAPI_GPU_GetThermalSettings(NvPhysicalGpuHandle hPhysicalGpu, NvU32 sensorIndex, NV_GPU_THERMAL_SETTINGS* pThermalSettings) {
         constexpr auto n = __func__;
-        static bool alreadyLoggedNoNvml = false;
-        static bool alreadyLoggedHandleInvalidated = false;
-        static bool alreadyLoggedOk = false;
+        thread_local bool alreadyLoggedNoNvml = false;
+        thread_local bool alreadyLoggedHandleInvalidated = false;
+        thread_local bool alreadyLoggedOk = false;
 
         Enter(n, alreadyLoggedNoNvml || alreadyLoggedHandleInvalidated || alreadyLoggedOk);
 
@@ -889,9 +889,9 @@ extern "C" {
 
     NvAPI_Status __cdecl NvAPI_GPU_GetCurrentPstate(NvPhysicalGpuHandle hPhysicalGpu, NV_GPU_PERF_PSTATE_ID* pCurrentPstate) {
         constexpr auto n = __func__;
-        static bool alreadyLoggedNoNvml = false;
-        static bool alreadyLoggedHandleInvalidated = false;
-        static bool alreadyLoggedOk = false;
+        thread_local bool alreadyLoggedNoNvml = false;
+        thread_local bool alreadyLoggedHandleInvalidated = false;
+        thread_local bool alreadyLoggedOk = false;
 
         Enter(n, alreadyLoggedNoNvml || alreadyLoggedHandleInvalidated || alreadyLoggedOk);
 
@@ -933,10 +933,10 @@ extern "C" {
 
     NvAPI_Status __cdecl NvAPI_GPU_GetAllClockFrequencies(NvPhysicalGpuHandle hPhysicalGpu, NV_GPU_CLOCK_FREQUENCIES* pClkFreqs) {
         constexpr auto n = __func__;
-        static bool alreadyLoggedNotSupported = false;
-        static bool alreadyLoggedNoNvml = false;
-        static bool alreadyLoggedHandleInvalidated = false;
-        static bool alreadyLoggedOk = false;
+        thread_local bool alreadyLoggedNotSupported = false;
+        thread_local bool alreadyLoggedNoNvml = false;
+        thread_local bool alreadyLoggedHandleInvalidated = false;
+        thread_local bool alreadyLoggedOk = false;
 
         Enter(n, alreadyLoggedNotSupported || alreadyLoggedNoNvml || alreadyLoggedHandleInvalidated || alreadyLoggedOk);
 

--- a/src/nvapi_gpu.cpp
+++ b/src/nvapi_gpu.cpp
@@ -10,6 +10,8 @@ extern "C" {
     NvAPI_Status __cdecl NvAPI_GPU_GetConnectedDisplayIds(NvPhysicalGpuHandle hPhysicalGpu, NV_GPU_DISPLAYIDS* pDisplayIds, NvU32* pDisplayIdCount, NvU32 flags) {
         constexpr auto n = __func__;
 
+        Enter(n);
+
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);
 
@@ -58,6 +60,8 @@ extern "C" {
         static bool alreadyLoggedHandleInvalidated = false;
         static bool alreadyLoggedOk = false;
 
+        Enter(n, alreadyLoggedNoNvml || alreadyLoggedHandleInvalidated || alreadyLoggedOk);
+
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);
 
@@ -96,6 +100,8 @@ extern "C" {
         static bool alreadyLoggedNoNvml = false;
         static bool alreadyLoggedHandleInvalidated = false;
         static bool alreadyLoggedOk = false;
+
+        Enter(n, alreadyLoggedNoNvml || alreadyLoggedHandleInvalidated || alreadyLoggedOk);
 
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);
@@ -136,6 +142,8 @@ extern "C" {
         static bool alreadyLoggedHandleInvalidated = false;
         static bool alreadyLoggedOk = false;
 
+        Enter(n, alreadyLoggedNoNvml || alreadyLoggedHandleInvalidated || alreadyLoggedOk);
+
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);
 
@@ -175,6 +183,8 @@ extern "C" {
     NvAPI_Status __cdecl NvAPI_GPU_GetGPUType(NvPhysicalGpuHandle hPhysicalGpu, NV_GPU_TYPE* pGpuType) {
         constexpr auto n = __func__;
 
+        Enter(n);
+
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);
 
@@ -193,6 +203,8 @@ extern "C" {
     NvAPI_Status __cdecl NvAPI_GPU_GetSystemType(NvPhysicalGpuHandle hPhysicalGpu, NV_SYSTEM_TYPE* pSystemType) {
         constexpr auto n = __func__;
 
+        Enter(n);
+
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);
 
@@ -206,6 +218,8 @@ extern "C" {
 
     NvAPI_Status __cdecl NvAPI_GPU_GetPCIIdentifiers(NvPhysicalGpuHandle hPhysicalGpu, NvU32* pDeviceId, NvU32* pSubSystemId, NvU32* pRevisionId, NvU32* pExtDeviceId) {
         constexpr auto n = __func__;
+
+        Enter(n);
 
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);
@@ -228,6 +242,8 @@ extern "C" {
     NvAPI_Status __cdecl NvAPI_GPU_GetFullName(NvPhysicalGpuHandle hPhysicalGpu, NvAPI_ShortString szName) {
         constexpr auto n = __func__;
 
+        Enter(n);
+
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);
 
@@ -246,6 +262,8 @@ extern "C" {
     NvAPI_Status __cdecl NvAPI_GPU_GetBusId(NvPhysicalGpuHandle hPhysicalGpu, NvU32* pBusId) {
         constexpr auto n = __func__;
 
+        Enter(n);
+
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);
 
@@ -263,6 +281,8 @@ extern "C" {
 
     NvAPI_Status __cdecl NvAPI_GPU_GetBusSlotId(NvPhysicalGpuHandle hPhysicalGpu, NvU32* pBusSlotId) {
         constexpr auto n = __func__;
+
+        Enter(n);
 
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);
@@ -284,6 +304,8 @@ extern "C" {
 
     NvAPI_Status __cdecl NvAPI_GPU_GetBusType(NvPhysicalGpuHandle hPhysicalGpu, NV_GPU_BUS_TYPE* pBusType) {
         constexpr auto n = __func__;
+
+        Enter(n);
 
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);
@@ -315,6 +337,8 @@ extern "C" {
     NvAPI_Status __cdecl NvAPI_GPU_GetPhysicalFrameBufferSize(NvPhysicalGpuHandle hPhysicalGpu, NvU32* pSize) {
         constexpr auto n = __func__;
 
+        Enter(n);
+
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);
 
@@ -333,6 +357,8 @@ extern "C" {
     NvAPI_Status __cdecl NvAPI_GPU_GetVirtualFrameBufferSize(NvPhysicalGpuHandle hPhysicalGpu, NvU32* pSize) {
         constexpr auto n = __func__;
 
+        Enter(n);
+
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);
 
@@ -350,6 +376,8 @@ extern "C" {
 
     NvAPI_Status __cdecl NvAPI_GPU_GetAdapterIdFromPhysicalGpu(NvPhysicalGpuHandle hPhysicalGpu, void* pOSAdapterId) {
         constexpr auto n = __func__;
+
+        Enter(n);
 
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);
@@ -372,6 +400,8 @@ extern "C" {
 
     NvAPI_Status __cdecl NvAPI_GPU_GetLogicalGpuInfo(NvLogicalGpuHandle hLogicalGpu, NV_LOGICAL_GPU_DATA* pLogicalGpuData) {
         constexpr auto n = __func__;
+
+        Enter(n);
 
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);
@@ -405,6 +435,9 @@ extern "C" {
 
     NvAPI_Status __cdecl NvAPI_GPU_GetArchInfo(NvPhysicalGpuHandle hPhysicalGpu, NV_GPU_ARCH_INFO* pGpuArchInfo) {
         constexpr auto n = __func__;
+
+        Enter(n);
+
         auto returnAddress = _ReturnAddress();
 
         if (nvapiAdapterRegistry == nullptr)
@@ -483,6 +516,8 @@ extern "C" {
     NvAPI_Status __cdecl NvAPI_GPU_CudaEnumComputeCapableGpus(NV_COMPUTE_GPU_TOPOLOGY* pComputeTopo) {
         constexpr auto n = __func__;
 
+        Enter(n);
+
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);
 
@@ -524,6 +559,8 @@ extern "C" {
     NvAPI_Status __cdecl NvAPI_GPU_GetGPUInfo(NvPhysicalGpuHandle hPhysicalGpu, NV_GPU_INFO* pGpuInfo) {
         constexpr auto n = __func__;
 
+        Enter(n);
+
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);
 
@@ -563,6 +600,8 @@ extern "C" {
     NvAPI_Status __cdecl NvAPI_GPU_GetVbiosVersionString(NvPhysicalGpuHandle hPhysicalGpu, NvAPI_ShortString szBiosRevision) {
         constexpr auto n = __func__;
 
+        Enter(n);
+
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);
 
@@ -601,6 +640,8 @@ extern "C" {
         static bool alreadyLoggedNoNvml = false;
         static bool alreadyLoggedHandleInvalidated = false;
         static bool alreadyLoggedOk = false;
+
+        Enter(n, alreadyLoggedNoNvml || alreadyLoggedHandleInvalidated || alreadyLoggedOk);
 
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);
@@ -696,6 +737,8 @@ extern "C" {
         static bool alreadyLoggedNoNvml = false;
         static bool alreadyLoggedHandleInvalidated = false;
         static bool alreadyLoggedOk = false;
+
+        Enter(n, alreadyLoggedNoNvml || alreadyLoggedHandleInvalidated || alreadyLoggedOk);
 
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);
@@ -850,6 +893,8 @@ extern "C" {
         static bool alreadyLoggedHandleInvalidated = false;
         static bool alreadyLoggedOk = false;
 
+        Enter(n, alreadyLoggedNoNvml || alreadyLoggedHandleInvalidated || alreadyLoggedOk);
+
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);
 
@@ -892,6 +937,8 @@ extern "C" {
         static bool alreadyLoggedNoNvml = false;
         static bool alreadyLoggedHandleInvalidated = false;
         static bool alreadyLoggedOk = false;
+
+        Enter(n, alreadyLoggedNotSupported || alreadyLoggedNoNvml || alreadyLoggedHandleInvalidated || alreadyLoggedOk);
 
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);
@@ -1026,6 +1073,8 @@ extern "C" {
 
     NvAPI_Status __cdecl NvAPI_GPU_GetPstates20(NvPhysicalGpuHandle hPhysicalGpu, NV_GPU_PERF_PSTATES20_INFO* pPstatesInfo) {
         constexpr auto n = __func__;
+
+        Enter(n);
 
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);

--- a/src/nvapi_mosaic.cpp
+++ b/src/nvapi_mosaic.cpp
@@ -5,6 +5,9 @@ extern "C" {
     using namespace dxvk;
 
     NvAPI_Status __cdecl NvAPI_Mosaic_GetDisplayViewportsByResolution(NvU32 displayId, NvU32 srcWidth, NvU32 srcHeight, NV_RECT viewports[NV_MOSAIC_MAX_DISPLAYS], NvU8* bezelCorrected) {
-        return MosaicNotActive("NvAPI_Mosaic_GetDisplayViewportsByResolution");
+        constexpr auto n = __func__;
+
+        Enter(n);
+        return MosaicNotActive(n);
     }
 }

--- a/src/nvapi_sys.cpp
+++ b/src/nvapi_sys.cpp
@@ -9,6 +9,8 @@ extern "C" {
     NvAPI_Status __cdecl NvAPI_SYS_GetPhysicalGpuFromDisplayId(NvU32 displayId, NvPhysicalGpuHandle* hPhysicalGpu) {
         constexpr auto n = __func__;
 
+        Enter(n);
+
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);
 
@@ -27,6 +29,8 @@ extern "C" {
     NvAPI_Status __cdecl NvAPI_SYS_GetDriverAndBranchVersion(NvU32* pDriverVersion, NvAPI_ShortString szBuildBranchString) {
         constexpr auto n = __func__;
 
+        Enter(n);
+
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);
 
@@ -41,6 +45,8 @@ extern "C" {
 
     NvAPI_Status __cdecl NvAPI_SYS_GetDisplayDriverInfo(NV_DISPLAY_DRIVER_INFO* pDriverInfo) {
         constexpr auto n = __func__;
+
+        Enter(n);
 
         if (nvapiAdapterRegistry == nullptr)
             return ApiNotInitialized(n);

--- a/src/util/util_statuscode.h
+++ b/src/util/util_statuscode.h
@@ -5,6 +5,16 @@
 #include "util_log.h"
 
 namespace dxvk {
+    inline void Enter(const std::string& logMessage) {
+        log::write(str::format(logMessage, ": Enter"));
+    }
+
+    inline void Enter(const std::string& logMessage, bool omit) {
+        if (!omit) {
+            log::write(str::format(logMessage, ": Enter"));
+        }
+    }
+
     inline NvAPI_Status Ok() {
         return NVAPI_OK;
     }

--- a/src/util/util_statuscode.h
+++ b/src/util/util_statuscode.h
@@ -20,7 +20,7 @@ namespace dxvk {
     }
 
     inline NvAPI_Status Ok(const std::string& logMessage) {
-        log::write(str::format(logMessage, ": OK"));
+        log::write(str::format("<-", logMessage, ": OK"));
         return NVAPI_OK;
     }
 
@@ -28,7 +28,7 @@ namespace dxvk {
         if (std::exchange(alreadyLogged, true))
             return NVAPI_OK;
 
-        log::write(str::format(logMessage, ": OK"));
+        log::write(str::format("<-", logMessage, ": OK"));
         return NVAPI_OK;
     }
 
@@ -37,7 +37,7 @@ namespace dxvk {
     }
 
     inline NvAPI_Status Error(const std::string& logMessage) {
-        log::write(str::format(logMessage, ": Error"));
+        log::write(str::format("<-", logMessage, ": Error"));
         return NVAPI_ERROR;
     }
 
@@ -45,7 +45,7 @@ namespace dxvk {
         if (std::exchange(alreadyLogged, true))
             return NVAPI_ERROR;
 
-        log::write(str::format(logMessage, ": Error"));
+        log::write(str::format("<-", logMessage, ": Error"));
         return NVAPI_ERROR;
     }
 
@@ -54,7 +54,7 @@ namespace dxvk {
     }
 
     inline NvAPI_Status NoImplementation(const std::string& logMessage) {
-        log::write(str::format(logMessage, ": No implementation"));
+        log::write(str::format("<-", logMessage, ": No implementation"));
         return NVAPI_NO_IMPLEMENTATION;
     }
 
@@ -62,47 +62,47 @@ namespace dxvk {
         if (std::exchange(alreadyLogged, true))
             return NVAPI_NO_IMPLEMENTATION;
 
-        log::write(str::format(logMessage, ": No implementation"));
+        log::write(str::format("<-", logMessage, ": No implementation"));
         return NVAPI_NO_IMPLEMENTATION;
     }
 
     inline NvAPI_Status EndEnumeration(const std::string& logMessage) {
-        log::write(str::format(logMessage, ": End enumeration"));
+        log::write(str::format("<-", logMessage, ": End enumeration"));
         return NVAPI_END_ENUMERATION;
     }
 
     inline NvAPI_Status ApiNotInitialized(const std::string& logMessage) {
-        log::write(str::format(logMessage, ": API not initialized"));
+        log::write(str::format("<-", logMessage, ": API not initialized"));
         return NVAPI_API_NOT_INTIALIZED;
     }
 
     inline NvAPI_Status InvalidPointer(const std::string& logMessage) {
-        log::write(str::format(logMessage, ": Invalid pointer"));
+        log::write(str::format("<-", logMessage, ": Invalid pointer"));
         return NVAPI_INVALID_POINTER;
     }
 
     inline NvAPI_Status InvalidArgument(const std::string& logMessage) {
-        log::write(str::format(logMessage, ": Invalid argument"));
+        log::write(str::format("<-", logMessage, ": Invalid argument"));
         return NVAPI_INVALID_ARGUMENT;
     }
 
     inline NvAPI_Status ExpectedPhysicalGpuHandle(const std::string& logMessage) {
-        log::write(str::format(logMessage, ": Expected physical GPU handle"));
+        log::write(str::format("<-", logMessage, ": Expected physical GPU handle"));
         return NVAPI_EXPECTED_PHYSICAL_GPU_HANDLE;
     }
 
     inline NvAPI_Status ExpectedLogicalGpuHandle(const std::string& logMessage) {
-        log::write(str::format(logMessage, ": Expected logical GPU handle"));
+        log::write(str::format("<-", logMessage, ": Expected logical GPU handle"));
         return NVAPI_EXPECTED_LOGICAL_GPU_HANDLE;
     }
 
     inline NvAPI_Status IncompatibleStructVersion(const std::string& logMessage) {
-        log::write(str::format(logMessage, ": Incompatible struct version"));
+        log::write(str::format("<-", logMessage, ": Incompatible struct version"));
         return NVAPI_INCOMPATIBLE_STRUCT_VERSION;
     }
 
     inline NvAPI_Status HandleInvalidated(const std::string& logMessage) {
-        log::write(str::format(logMessage, ": Handle invalidated"));
+        log::write(str::format("<-", logMessage, ": Handle invalidated"));
         return NVAPI_HANDLE_INVALIDATED;
     }
 
@@ -110,17 +110,17 @@ namespace dxvk {
         if (std::exchange(alreadyLogged, true))
             return NVAPI_HANDLE_INVALIDATED;
 
-        log::write(str::format(logMessage, ": Handle invalidated"));
+        log::write(str::format("<-", logMessage, ": Handle invalidated"));
         return NVAPI_HANDLE_INVALIDATED;
     }
 
     inline NvAPI_Status ExpectedDisplayHandle(const std::string& logMessage) {
-        log::write(str::format(logMessage, ": Expected display handle"));
+        log::write(str::format("<-", logMessage, ": Expected display handle"));
         return NVAPI_EXPECTED_DISPLAY_HANDLE;
     }
 
     inline NvAPI_Status NotSupported(const std::string& logMessage) {
-        log::write(str::format(logMessage, ": Not supported"));
+        log::write(str::format("<-", logMessage, ": Not supported"));
         return NVAPI_NOT_SUPPORTED;
     }
 
@@ -128,42 +128,42 @@ namespace dxvk {
         if (std::exchange(alreadyLogged, true))
             return NVAPI_NOT_SUPPORTED;
 
-        log::write(str::format(logMessage, ": Not supported"));
+        log::write(str::format("<-", logMessage, ": Not supported"));
         return NVAPI_NOT_SUPPORTED;
     }
 
     inline NvAPI_Status InvalidDisplayId(const std::string& logMessage) {
-        log::write(str::format(logMessage, ": Invalid display ID"));
+        log::write(str::format("<-", logMessage, ": Invalid display ID"));
         return NVAPI_INVALID_DISPLAY_ID;
     }
 
     inline NvAPI_Status MosaicNotActive(const std::string& logMessage) {
-        log::write(str::format(logMessage, ": Mosaic not active"));
+        log::write(str::format("<-", logMessage, ": Mosaic not active"));
         return NVAPI_MOSAIC_NOT_ACTIVE;
     }
 
     inline NvAPI_Status NvidiaDeviceNotFound(const std::string& logMessage) {
-        log::write(str::format(logMessage, ": NVIDIA or other suitable device not found or initialization failed"));
+        log::write(str::format("<-", logMessage, ": NVIDIA or other suitable device not found or initialization failed"));
         return NVAPI_NVIDIA_DEVICE_NOT_FOUND;
     }
 
     inline NvAPI_Status ProfileNotFound(const std::string& logMessage) {
-        log::write(str::format(logMessage, ": Profile not found"));
+        log::write(str::format("<-", logMessage, ": Profile not found"));
         return NVAPI_PROFILE_NOT_FOUND;
     }
 
     inline NvAPI_Status ExecutableNotFound(const std::string& logMessage) {
-        log::write(str::format(logMessage, ": Executable not found"));
+        log::write(str::format("<-", logMessage, ": Executable not found"));
         return NVAPI_EXECUTABLE_NOT_FOUND;
     }
 
     inline NvAPI_Status SettingNotFound(const std::string& logMessage) {
-        log::write(str::format(logMessage, ": Setting not found"));
+        log::write(str::format("<-", logMessage, ": Setting not found"));
         return NVAPI_SETTING_NOT_FOUND;
     }
 
     inline NvAPI_Status InsufficientBuffer(const std::string& logMessage) {
-        log::write(str::format(logMessage, ": Insufficient Buffer"));
+        log::write(str::format("<-", logMessage, ": Insufficient Buffer"));
         return NVAPI_INSUFFICIENT_BUFFER;
     }
 }


### PR DESCRIPTION
Took a look at our logging,  with this PR it looks like:

ACC startup and benchmark run.

<details>
  <summary>dxvk-nvapi-log</summary>

```syslog
---------- 2024-05-31 16:53:01 ----------
dxvk-nvapi:0308:0312:NvAPI_QueryInterface (0xad298d3f): Unknown function ID
dxvk-nvapi:0308:0312:NvAPI_Initialize: Enter
dxvk-nvapi:0308:0312:DXVK-NVAPI v0.7.0-23-g107f990 (AC2-Win64-Shipping.exe)
dxvk-nvapi:0308:0312:Successfully acquired Vulkan vkGetInstanceProcAddr @ 0x6ffffbc1d310
dxvk-nvapi:0308:0312:Successfully loaded nvml.dll
dxvk-nvapi:0308:0312:NVML loaded and initialized successfully
dxvk-nvapi:0308:0312:NvAPI Device: NVIDIA GeForce RTX 3090 (555.42.2)
dxvk-nvapi:0308:0312:NvAPI Output: \\.\DISPLAY1
dxvk-nvapi:0308:0312:<-NvAPI_Initialize: OK
dxvk-nvapi:0308:0312:NvAPI_QueryInterface (0x33c7358c): Unknown function ID
dxvk-nvapi:0308:0312:NvAPI_QueryInterface (0x593e8644): Unknown function ID
dxvk-nvapi:0308:0312:NvAPI_D3D11_IsNvShaderExtnOpCodeSupported: Enter
dxvk-nvapi:0308:0312:<-NvAPI_D3D11_IsNvShaderExtnOpCodeSupported (20/NV_EXTN_OP_UINT64_ATOMIC): OK
dxvk-nvapi:0308:0312:NvAPI_D3D11_IsNvShaderExtnOpCodeSupported: Enter
dxvk-nvapi:0308:0312:<-NvAPI_D3D11_IsNvShaderExtnOpCodeSupported (1/NV_EXTN_OP_SHFL): OK
dxvk-nvapi:0308:0312:NvAPI_D3D_GetCurrentSLIState: Enter
dxvk-nvapi:0308:0312:<-NvAPI_D3D_GetCurrentSLIState: OK
dxvk-nvapi:0308:0312:NvAPI_DISP_GetDisplayIdByDisplayName: Enter
dxvk-nvapi:0308:0312:<-NvAPI_DISP_GetDisplayIdByDisplayName (\\.\DISPLAY1): OK
dxvk-nvapi:0308:0312:NvAPI_Disp_GetHdrCapabilities: Enter
dxvk-nvapi:0308:0312:<-NvAPI_Disp_GetHdrCapabilities (0x10001): OK
dxvk-nvapi:0308:0312:NvAPI_EnumPhysicalGPUs: Enter
dxvk-nvapi:0308:0312:<-NvAPI_EnumPhysicalGPUs: OK
dxvk-nvapi:0308:0312:NvAPI_GPU_GetPstates20: Enter
dxvk-nvapi:0308:0312:<-NvAPI_GPU_GetPstates20: No implementation
dxvk-nvapi:0308:0312:NvAPI_D3D11_BeginUAVOverlap: Enter
dxvk-nvapi:0308:0312:<-NvAPI_D3D11_BeginUAVOverlap: OK
dxvk-nvapi:0308:0312:NvAPI_QueryInterface NvAPI_D3D11_SetNvShaderExtnSlot: Not implemented method
dxvk-nvapi:0308:0692:NvAPI_D3D_GetObjectHandleForResource: Enter
dxvk-nvapi:0308:0692:<-NvAPI_D3D_GetObjectHandleForResource: OK
dxvk-nvapi:0308:0692:NvAPI_D3D_SetResourceHint: Enter
dxvk-nvapi:0308:0692:<-NvAPI_D3D_SetResourceHint: No implementation
dxvk-nvapi:0308:0312:NvAPI_Initialize: Enter
dxvk-nvapi:0308:0312:<-NvAPI_Initialize: OK
dxvk-nvapi:0308:0312:NvAPI_DRS_CreateSession: Enter
dxvk-nvapi:0308:0312:<-NvAPI_DRS_CreateSession: OK
dxvk-nvapi:0308:0312:NvAPI_DRS_LoadSettings: Enter
dxvk-nvapi:0308:0312:<-NvAPI_DRS_LoadSettings: OK
dxvk-nvapi:0308:0312:NvAPI_DRS_GetBaseProfile: Enter
dxvk-nvapi:0308:0312:<-NvAPI_DRS_GetBaseProfile: OK
dxvk-nvapi:0308:0312:NvAPI_DRS_GetSetting: Enter
dxvk-nvapi:0308:0312:<-NvAPI_DRS_GetSetting (0x10afb76b/Unknown): Setting not found
dxvk-nvapi:0308:0312:NvAPI_EnumPhysicalGPUs: Enter
dxvk-nvapi:0308:0312:<-NvAPI_EnumPhysicalGPUs: OK
dxvk-nvapi:0308:0312:NvAPI_GetLogicalGPUFromPhysicalGPU: Enter
dxvk-nvapi:0308:0312:<-NvAPI_GetLogicalGPUFromPhysicalGPU: OK
dxvk-nvapi:0308:0312:NvAPI_GPU_GetLogicalGpuInfo: Enter
dxvk-nvapi:0308:0312:<-NvAPI_GPU_GetLogicalGpuInfo: OK
dxvk-nvapi:0308:0312:NvAPI_DRS_GetSetting: Enter
dxvk-nvapi:0308:0312:<-NvAPI_DRS_GetSetting (0x10e41df2/Unknown): Setting not found
dxvk-nvapi:0308:0312:NvAPI_QueryInterface (0xf2400ab): Unknown function ID
dxvk-nvapi:0308:0312:NvAPI_EnumPhysicalGPUs: Enter
dxvk-nvapi:0308:0312:<-NvAPI_EnumPhysicalGPUs: OK
dxvk-nvapi:0308:0312:NvAPI_GetLogicalGPUFromPhysicalGPU: Enter
dxvk-nvapi:0308:0312:<-NvAPI_GetLogicalGPUFromPhysicalGPU: OK
dxvk-nvapi:0308:0312:NvAPI_GPU_GetLogicalGpuInfo: Enter
dxvk-nvapi:0308:0312:<-NvAPI_GPU_GetLogicalGpuInfo: OK
dxvk-nvapi:0308:0312:NvAPI_DRS_GetSetting: Enter
dxvk-nvapi:0308:0312:<-NvAPI_DRS_GetSetting (0x10e41df2/Unknown): Setting not found
dxvk-nvapi:0308:0312:NvAPI_GPU_GetArchInfo: Enter
dxvk-nvapi:0308:0312:<-NvAPI_GPU_GetArchInfo: OK
dxvk-nvapi:0308:0312:NvAPI_SYS_GetDriverAndBranchVersion: Enter
dxvk-nvapi:0308:0312:<-NvAPI_SYS_GetDriverAndBranchVersion: OK
dxvk-nvapi:0308:0312:NvAPI_DRS_CreateSession: Enter
dxvk-nvapi:0308:0312:<-NvAPI_DRS_CreateSession: OK
dxvk-nvapi:0308:0312:NvAPI_QueryInterface (0xa782ea46): Unknown function ID
dxvk-nvapi:0308:0312:NvAPI_DRS_FindApplicationByName: Enter
dxvk-nvapi:0308:0312:<-NvAPI_DRS_FindApplicationByName (Z:\home\jpeters\.local\share\Steam\steamapps\common\Assetto Corsa Competizione\AC2\Binaries\Win64\AC2-Win64-Shipping.exe): Executable not found
dxvk-nvapi:0308:0312:NvAPI_DRS_DestroySession: Enter
dxvk-nvapi:0308:0312:<-NvAPI_DRS_DestroySession: OK
dxvk-nvapi:0308:0312:NvAPI_DRS_GetSetting: Enter
dxvk-nvapi:0308:0312:<-NvAPI_DRS_GetSetting (0x10afb764/Unknown): Setting not found
dxvk-nvapi:0308:0312:NvAPI_Initialize: Enter
dxvk-nvapi:0308:0312:<-NvAPI_Initialize: OK
dxvk-nvapi:0308:0312:NvAPI_DRS_CreateSession: Enter
dxvk-nvapi:0308:0312:<-NvAPI_DRS_CreateSession: OK
dxvk-nvapi:0308:0312:NvAPI_DRS_LoadSettings: Enter
dxvk-nvapi:0308:0312:<-NvAPI_DRS_LoadSettings: OK
dxvk-nvapi:0308:0312:NvAPI_DRS_GetBaseProfile: Enter
dxvk-nvapi:0308:0312:<-NvAPI_DRS_GetBaseProfile: OK
dxvk-nvapi:0308:0312:NvAPI_DRS_GetSetting: Enter
dxvk-nvapi:0308:0312:<-NvAPI_DRS_GetSetting (0x10afb76b/Unknown): Setting not found
dxvk-nvapi:0308:0312:NvAPI_D3D11_CreateSamplerState: Enter
dxvk-nvapi:0308:0312:<-NvAPI_D3D11_CreateSamplerState: OK
dxvk-nvapi:0308:0312:NvAPI_D3D11_IsFatbinPTXSupported: Enter
dxvk-nvapi:0308:0312:<-NvAPI_D3D11_IsFatbinPTXSupported(Supported): OK
dxvk-nvapi:0308:0312:NvAPI_EnumPhysicalGPUs: Enter
dxvk-nvapi:0308:0312:<-NvAPI_EnumPhysicalGPUs: OK
dxvk-nvapi:0308:0312:NvAPI_GPU_GetAdapterIdFromPhysicalGpu: Enter
dxvk-nvapi:0308:0312:<-NvAPI_GPU_GetAdapterIdFromPhysicalGpu: OK
dxvk-nvapi:0308:0312:NvAPI_GPU_GetArchInfo: Enter
dxvk-nvapi:0308:0312:<-NvAPI_GPU_GetArchInfo: OK
dxvk-nvapi:0308:0312:NvAPI_D3D1x_GetGraphicsCapabilities: Enter
dxvk-nvapi:0308:0312:<-NvAPI_D3D1x_GetGraphicsCapabilities: OK
dxvk-nvapi:0308:0312:NvAPI_DRS_GetSetting: Enter
dxvk-nvapi:0308:0312:<-NvAPI_DRS_GetSetting (0x10afb76a/Unknown): Setting not found
dxvk-nvapi:0308:0312:NvAPI_DRS_GetSetting: Enter
dxvk-nvapi:0308:0312:<-NvAPI_DRS_GetSetting (0x10afb76c/Unknown): Setting not found
dxvk-nvapi:0308:0312:NvAPI_D3D11_CreateCubinComputeShaderWithName: Enter
dxvk-nvapi:0308:0312:<-NvAPI_D3D11_CreateCubinComputeShaderWithName: OK
dxvk-nvapi:0308:0836:NvAPI_D3D11_EndUAVOverlap: Enter
dxvk-nvapi:0308:0836:<-NvAPI_D3D11_EndUAVOverlap: OK
dxvk-nvapi:0308:0836:NvAPI_D3D11_BeginUAVOverlap: Enter
dxvk-nvapi:0308:0836:<-NvAPI_D3D11_BeginUAVOverlap: OK
dxvk-nvapi:0308:0836:NvAPI_D3D11_SetDepthBoundsTest: Enter
dxvk-nvapi:0308:0836:<-NvAPI_D3D11_SetDepthBoundsTest: OK
dxvk-nvapi:0308:0836:NvAPI_D3D11_CreateCubinComputeShaderWithName: Enter
dxvk-nvapi:0308:0836:<-NvAPI_D3D11_CreateCubinComputeShaderWithName: OK
dxvk-nvapi:0308:0836:NvAPI_D3D11_CreateUnorderedAccessView: Enter
dxvk-nvapi:0308:0836:<-NvAPI_D3D11_CreateUnorderedAccessView: OK
dxvk-nvapi:0308:0836:NvAPI_D3D11_GetResourceHandle: Enter
dxvk-nvapi:0308:0836:<-NvAPI_D3D11_GetResourceHandle: OK
dxvk-nvapi:0308:0836:NvAPI_D3D11_GetResourceGPUVirtualAddressEx: Enter
dxvk-nvapi:0308:0836:<-NvAPI_D3D11_GetResourceGPUVirtualAddressEx: OK
dxvk-nvapi:0308:0836:NvAPI_D3D11_GetResourceGPUVirtualAddress: Enter
dxvk-nvapi:0308:0836:<-NvAPI_D3D11_GetResourceGPUVirtualAddress: OK
dxvk-nvapi:0308:0836:NvAPI_D3D11_CreateShaderResourceView: Enter
dxvk-nvapi:0308:0836:<-NvAPI_D3D11_CreateShaderResourceView: OK
dxvk-nvapi:0308:0836:NvAPI_D3D11_GetCudaTextureObject: Enter
dxvk-nvapi:0308:0836:<-NvAPI_D3D11_GetCudaTextureObject: OK
dxvk-nvapi:0308:0836:NvAPI_D3D11_LaunchCubinShader: Enter
dxvk-nvapi:0308:0836:<-NvAPI_D3D11_LaunchCubinShader: OK
dxvk-nvapi:0308:0312:NvAPI_DRS_DestroySession: Enter
dxvk-nvapi:0308:0312:<-NvAPI_DRS_DestroySession: OK
dxvk-nvapi:0308:0312:NvAPI_D3D11_DestroyCubinComputeShader: Enter
dxvk-nvapi:0308:0312:<-NvAPI_D3D11_DestroyCubinComputeShader: OK
dxvk-nvapi:0308:0312:NvAPI_DRS_DestroySession: Enter
dxvk-nvapi:0308:0312:<-NvAPI_DRS_DestroySession: OK
```
</details>

- Added fixed prefix, PID, TID
- Log entering entrypoints
- Discard identical logging by thread
- Minor things found along the road (first two commits)

Logging enter/exit in pairs is not 100% procent whatertight, you wont find a pair when e.g. first call succeeded and second call failed. But imho still much better than what we had. 

Closes #180  