### PR TITLE
d3d12: Improve NvAPI_D3D12_EnumerateMetaCommands

### DIFF
--- a/src/nvapi_d3d12.cpp
+++ b/src/nvapi_d3d12.cpp
@@ -31,7 +31,12 @@ extern "C" {
         if (log::tracing())
             log::trace(n, log::fmt::ptr(pDevice), log::fmt::ptr(pNumMetaCommands), log::fmt::ptr(pDescs));
 
-        return NotSupported(n);
+        if (pDevice == nullptr || pNumMetaCommands == nullptr)
+            return InvalidArgument(n);
+
+        *pNumMetaCommands = 0; // No meta commands with this implementation
+
+        return Ok(n);
     }
 
     NvAPI_Status __cdecl NvAPI_D3D12_CreateCubinComputeShaderEx(ID3D12Device* pDevice, const void* cubinData, NvU32 cubinSize, NvU32 blockX, NvU32 blockY, NvU32 blockZ, NvU32 smemSize, const char* shaderName, NVDX_ObjectHandle* pShader) {

--- a/tests/nvapi_d3d12.cpp
+++ b/tests/nvapi_d3d12.cpp
@@ -175,9 +175,10 @@ TEST_CASE("D3D12 methods succeed", "[.d3d12]") {
     }
 
     SECTION("EnumerateMetaCommands returns OK") {
-        NvU32 count = 0U;
+        NvU32 count = 1U;
         NVAPI_META_COMMAND_DESC descs{};
-        REQUIRE(NvAPI_D3D12_EnumerateMetaCommands(&device, &count, &descs) == NVAPI_NOT_SUPPORTED);
+        REQUIRE(NvAPI_D3D12_EnumerateMetaCommands(&device, &count, &descs) == NVAPI_OK);
+        REQUIRE(count == 0);
     }
 
     SECTION("GetGraphicsCapabilities succeeds") {


### PR DESCRIPTION
Return politely that we have no meta commands. Need to find a few titles though to verify that no one calls create-metacommand after this.   

cc: @SveSop 