### PR TITLE
Try to improve Reflex command queue lookups

### DIFF
--- a/src/d3d/nvapi_d3d_low_latency_device.cpp
+++ b/src/d3d/nvapi_d3d_low_latency_device.cpp
@@ -72,7 +72,7 @@ namespace dxvk {
         if (FAILED(d3dLowLatencyDevice->GetLatencyInfo(latencyResults)))
             return false;
 
-        auto frameIdGenerator = GetFrameIdGenerator(device);
+        auto frameIdGenerator = GetFrameIdGenerator(d3dLowLatencyDevice.ptr());
         for (auto& frameReport : latencyResults->frame_reports) {
             frameReport.frameID = frameIdGenerator->GetApplicationFrameId(frameReport.frameID);
             if (!frameReport.frameID) {
@@ -90,7 +90,7 @@ namespace dxvk {
             return false;
 
         return SUCCEEDED(d3dLowLatencyDevice->SetLatencyMarker(
-            GetFrameIdGenerator(device)->GetLowLatencyDeviceFrameId(frameID), markerType));
+            GetFrameIdGenerator(d3dLowLatencyDevice.ptr())->GetLowLatencyDeviceFrameId(frameID), markerType));
     }
 
     void NvapiD3dLowLatencyDevice::ClearCacheMaps() {
@@ -118,7 +118,7 @@ namespace dxvk {
         return d3dLowLatencyDevice;
     }
 
-    LowLatencyFrameIdGenerator* NvapiD3dLowLatencyDevice::GetFrameIdGenerator(IUnknown* device) {
+    LowLatencyFrameIdGenerator* NvapiD3dLowLatencyDevice::GetFrameIdGenerator(ID3DLowLatencyDevice* device) {
         std::scoped_lock lock(m_lowLatencyFrameIdGeneratorMutex);
         auto it = m_frameIdGeneratorMap.find(device);
         if (it != m_frameIdGeneratorMap.end())

--- a/src/d3d/nvapi_d3d_low_latency_device.h
+++ b/src/d3d/nvapi_d3d_low_latency_device.h
@@ -26,10 +26,12 @@ namespace dxvk {
     class NvapiD3dLowLatencyDevice {
       public:
         static bool SupportsLowLatency(IUnknown* device);
+        static bool SupportsLowLatency(ID3D12CommandQueue* commandQueue);
         static bool LatencySleep(IUnknown* device);
         static bool SetLatencySleepMode(IUnknown* device, bool lowLatencyMode, bool lowLatencyBoost, uint32_t minimumIntervalUs);
         static bool GetLatencyInfo(IUnknown* device, D3D_LATENCY_RESULTS* latencyResults);
         static bool SetLatencyMarker(IUnknown* device, uint64_t frameID, uint32_t markerType);
+        static bool SetLatencyMarker(ID3D12CommandQueue* commandQueue, uint64_t frameID, uint32_t markerType);
 
         static void ClearCacheMaps();
 
@@ -41,6 +43,7 @@ namespace dxvk {
         inline static std::mutex m_lowLatencyFrameIdGeneratorMutex;
 
         [[nodiscard]] static Com<ID3DLowLatencyDevice> GetLowLatencyDevice(IUnknown* device);
+        [[nodiscard]] static Com<ID3DLowLatencyDevice> GetLowLatencyDevice(ID3D12CommandQueue* commandQueue);
         [[nodiscard]] static LowLatencyFrameIdGenerator* GetFrameIdGenerator(ID3DLowLatencyDevice* device);
     };
 }

--- a/src/d3d/nvapi_d3d_low_latency_device.h
+++ b/src/d3d/nvapi_d3d_low_latency_device.h
@@ -35,12 +35,12 @@ namespace dxvk {
 
       private:
         inline static std::unordered_map<IUnknown*, ID3DLowLatencyDevice*> m_lowLatencyDeviceMap;
-        inline static std::unordered_map<IUnknown*, std::unique_ptr<LowLatencyFrameIdGenerator>> m_frameIdGeneratorMap;
+        inline static std::unordered_map<ID3DLowLatencyDevice*, std::unique_ptr<LowLatencyFrameIdGenerator>> m_frameIdGeneratorMap;
 
         inline static std::mutex m_lowLatencyDeviceMutex;
         inline static std::mutex m_lowLatencyFrameIdGeneratorMutex;
 
         [[nodiscard]] static Com<ID3DLowLatencyDevice> GetLowLatencyDevice(IUnknown* device);
-        [[nodiscard]] static LowLatencyFrameIdGenerator* GetFrameIdGenerator(IUnknown* device);
+        [[nodiscard]] static LowLatencyFrameIdGenerator* GetFrameIdGenerator(ID3DLowLatencyDevice* device);
     };
 }

--- a/src/nvapi_d3d12.cpp
+++ b/src/nvapi_d3d12.cpp
@@ -471,11 +471,7 @@ extern "C" {
         if (pCommandQueue == nullptr)
             return InvalidPointer(n);
 
-        ID3D12Device* pDevice;
-        if (FAILED(pCommandQueue->GetDevice(IID_PPV_ARGS(&pDevice))))
-            return InvalidArgument(n);
-
-        if (nvapiD3dInstance->IsUsingLfx() || !NvapiD3dLowLatencyDevice::SupportsLowLatency(pDevice))
+        if (nvapiD3dInstance->IsUsingLfx() || !NvapiD3dLowLatencyDevice::SupportsLowLatency(pCommandQueue))
             return NoImplementation(n);
 
         if (!NvapiD3d12Device::NotifyOutOfBandCommandQueue(pCommandQueue, static_cast<D3D12_OUT_OF_BAND_CQ_TYPE>(cqType)))
@@ -501,14 +497,10 @@ extern "C" {
         if (pSetLatencyMarkerParams->version != NV_LATENCY_MARKER_PARAMS_VER1)
             return IncompatibleStructVersion(n);
 
-        ID3D12Device* pDevice;
-        if (FAILED(pCommandQueue->GetDevice(IID_PPV_ARGS(&pDevice))))
-            return InvalidArgument(n);
-
-        if (nvapiD3dInstance->IsUsingLfx() || !NvapiD3dLowLatencyDevice::SupportsLowLatency(pDevice))
+        if (nvapiD3dInstance->IsUsingLfx() || !NvapiD3dLowLatencyDevice::SupportsLowLatency(pCommandQueue))
             return NoImplementation(n);
 
-        if (!NvapiD3dLowLatencyDevice::SetLatencyMarker(pDevice, pSetLatencyMarkerParams->frameID, pSetLatencyMarkerParams->markerType))
+        if (!NvapiD3dLowLatencyDevice::SetLatencyMarker(pCommandQueue, pSetLatencyMarkerParams->frameID, pSetLatencyMarkerParams->markerType))
             return Error(n, alreadyLoggedError);
 
         return Ok(n, alreadyLoggedOk);

--- a/tests/nvapi_d3d12.cpp
+++ b/tests/nvapi_d3d12.cpp
@@ -82,6 +82,7 @@ TEST_CASE("D3D12 methods succeed", "[.d3d12]") {
         .RETURN(commandQueueRefCount);
     ALLOW_CALL(commandQueue, GetDevice(__uuidof(ID3D12Device), _))
         .LR_SIDE_EFFECT(*_2 = static_cast<ID3D12Device*>(&device))
+        .LR_SIDE_EFFECT(deviceRefCount++)
         .RETURN(S_OK);
 
     SECTION("CreateGraphicsPipelineState for other than SetDepthBounds returns not-supported") {
@@ -912,5 +913,9 @@ TEST_CASE("D3D12 methods succeed", "[.d3d12]") {
                 REQUIRE(NvAPI_D3D12_SetAsyncFrameMarker(nullptr, &params) == NVAPI_INVALID_POINTER);
             }
         }
+
+        REQUIRE(deviceRefCount == 0);
+        REQUIRE(commandListRefCount == 0);
+        REQUIRE(lowLatencyDeviceRefCount == 0);
     }
 }

--- a/tests/nvapi_d3d12.cpp
+++ b/tests/nvapi_d3d12.cpp
@@ -803,6 +803,10 @@ TEST_CASE("D3D12 methods succeed", "[.d3d12]") {
 
         auto e = ConfigureDefaultTestEnvironment(*dxgiFactory, *vulkan, *nvml, *lfx, adapter, output);
 
+        ALLOW_CALL(commandQueue, GetDevice(__uuidof(ID3DLowLatencyDevice), _))
+            .LR_SIDE_EFFECT(*_2 = static_cast<ID3DLowLatencyDevice*>(&lowLatencyDevice))
+            .LR_SIDE_EFFECT(lowLatencyDeviceRefCount++)
+            .RETURN(S_OK);
         ALLOW_CALL(device, QueryInterface(__uuidof(ID3DLowLatencyDevice), _))
             .LR_SIDE_EFFECT(*_2 = static_cast<ID3DLowLatencyDevice*>(&lowLatencyDevice))
             .LR_SIDE_EFFECT(lowLatencyDeviceRefCount++)


### PR DESCRIPTION
This lets us avoid having to `QueryInterface` on every call to `NvAPI_D3D12_SetAsyncFrameMarker`. The consequence of doing it like this is that now there might be multiple entries in `m_lowLatencyDeviceMap` pointing to the same `ID3DLowLatencyDevice` so in order to still correctly have a single frame ID generator per `ID3DLowLatencyDevice`, their map is now keyed on low latency devices which we have to retrieve on every call anyway.

We could further reduce the lookups if we either returned intermediate `ID3DLowLatencyDevice` from `SupportsLowLatency` and then acted on it in the following call or if we just got rid of explicit `SupportsLowLatency` and had methods like `SetFrameMarker` returned more detailed error codes (or just `NvAPI_Status` directly). But that's an idea for another day.