### PR TITLE
Allow overriding GPU Architecture using environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,14 @@ The following environment variables tweak DXVK-NVAPI's runtime behavior:
 
 - `DXVK_NVAPI_DRIVER_VERSION` lets you override the reported driver version. Valid values are numbers between 100 and 99999. Use e.g. `DXVK_NVAPI_DRIVER_VERSION=47141` to report driver version `471.41`.
 - `DXVK_NVAPI_ALLOW_OTHER_DRIVERS`, when set to `1`, allows DXVK-NVAPI to initialize for a non-NVIDIA GPU.
+- `DXVK_NVAPI_GPU_ARCH`, when set to one of supported NVIDIA GPU architecture IDs will override reported GPU architecture. Currently supported values are:
+  - `GK100` (Kepler)
+  - `GM200` (Maxwell)
+  - `GP100` (Pascal)
+  - `GV100` (Volta)
+  - `TU100` (Turing)
+  - `GA100` (Ampere)
+  - `AD100` (Ada)
 - `DXVK_NVAPI_LOG_LEVEL` set to `info` prints log statements. The default behavior omits any logging. Please fill an issue if using log servery `info` creates log spam. Setting severity to `trace` logs all entry points enter and exits, this has a severe effect on performance. All other log levels will be interpreted as `none`.
 - `DXVK_NVAPI_LOG_PATH` enables file logging additionally to console output and sets the path where the log file `dxvk-nvapi.log` should be written to. Log statements are appended to an existing file. Please remove this file once in a while to prevent excessive grow. This requires `DXVK_NVAPI_LOG_LEVEL` set to `info`.
 

--- a/src/nvapi_gpu.cpp
+++ b/src/nvapi_gpu.cpp
@@ -470,12 +470,7 @@ extern "C" {
             return IncompatibleStructVersion(n);
 
         auto architectureId = adapter->GetArchitectureId();
-
-        if (env::needsAmpereSpoofing(architectureId, returnAddress))
-            architectureId = NV_GPU_ARCHITECTURE_GA100;
-
-        if (env::needsPascalSpoofing(architectureId))
-            architectureId = NV_GPU_ARCHITECTURE_GP100;
+        architectureId = env::needsGpuArchitectureSpoofing(architectureId, returnAddress).value_or(architectureId);
 
         // Assume the implementation ID from the architecture ID. No simple way
         // to do a more fine-grained query at this time. Would need wine-nvml

--- a/src/nvapi_private.h
+++ b/src/nvapi_private.h
@@ -2,12 +2,14 @@
 
 #include <algorithm>
 #include <array>
+#include <cctype>
 #include <cstddef>
 #include <cstdint>
 #include <ctime>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
+#include <locale>
 #include <map>
 #include <memory>
 #include <mutex>

--- a/src/nvapi_private.h
+++ b/src/nvapi_private.h
@@ -1,22 +1,22 @@
 #pragma once
 
+#include <algorithm>
+#include <array>
 #include <cstddef>
 #include <cstdint>
-#include <iostream>
-#include <iomanip>
-#include <algorithm>
-#include <map>
-#include <set>
-#include <optional>
-#include <sstream>
-#include <fstream>
 #include <ctime>
-#include <mutex>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <map>
 #include <memory>
+#include <mutex>
+#include <optional>
+#include <set>
+#include <sstream>
 #include <unordered_map>
 #include <utility>
 #include <vector>
-#include <array>
 
 #include <dxgi1_6.h>
 #include <d3d11_1.h>

--- a/src/sysinfo/nvapi_adapter.cpp
+++ b/src/sysinfo/nvapi_adapter.cpp
@@ -223,7 +223,7 @@ namespace dxvk {
     NV_GPU_ARCHITECTURE_ID NvapiAdapter::GetArchitectureId() const {
         if (!this->HasNvProprietaryDriver() && !this->HasNvkDriver()) {
             // DXVK_NVAPI_ALLOW_OTHER_DRIVERS must be set, otherwise this would be unreachable
-            log::info(str::format(allowOtherDriversEnvName, " is set, spoofing Pascal for GPU with non-NVIDIA proprietary driver"));
+            log::info(str::format(allowOtherDriversEnvName, " is set, using Pascal architecture for non-NVIDIA GPUs by default"));
             return NV_GPU_ARCHITECTURE_GP100;
         }
 

--- a/src/util/util_env.h
+++ b/src/util/util_env.h
@@ -9,9 +9,7 @@ namespace dxvk::env {
 
     std::string getCurrentDateTime();
 
-    bool needsAmpereSpoofing(NV_GPU_ARCHITECTURE_ID architectureId, void* pReturnAddress);
-
-    bool needsPascalSpoofing(NV_GPU_ARCHITECTURE_ID architectureId);
-
     bool needsSucceededGpuQuery();
+
+    std::optional<NV_GPU_ARCHITECTURE_ID> needsGpuArchitectureSpoofing(NV_GPU_ARCHITECTURE_ID architectureId, void* returnAddress);
 }


### PR DESCRIPTION
As Ghost of Tsushima recently proved to us, it might be beneficial to have some ability to control reported GPU Arch to games without having to modify the source code and rebuild each time.

Not sure if this is how it should be implemented though, it might be preferable to have all this extracted to some `NV_GPU_ARCHITECTURE_ID env::getGpuArchOverride()` method instead.