### PR TITLE
util: Spoof Ada and later GPUs as Ampere for Ghost of Tsushima

### DIFF
--- a/src/util/util_env.cpp
+++ b/src/util/util_env.cpp
@@ -117,10 +117,19 @@ namespace dxvk::env {
         }
     }
 
+    bool isGhostOfTsushima() {
+        return getExecutableName() == std::string("GhostOfTsushima.exe");
+    }
+
     bool needsAmpereSpoofing(NV_GPU_ARCHITECTURE_ID architectureId, void* pReturnAddress) {
         // Check if we need to workaround NVIDIA Bug 3634851
         if (architectureId >= NV_GPU_ARCHITECTURE_AD100 && isDLSSVersion20To24(pReturnAddress)) {
             log::info("Spoofing Ampere for Ada and later due to DLSS version 2.0-2.4");
+            return true;
+        }
+
+        if (architectureId >= NV_GPU_ARCHITECTURE_AD100 && isGhostOfTsushima()) {
+            log::info("Spoofing Ampere for Ada and later due to detecting GhostOfTsushima.exe");
             return true;
         }
 


### PR DESCRIPTION
See https://github.com/HansKristian-Work/vkd3d-proton/issues/2008 and https://github.com/ValveSoftware/Proton/issues/7735#issuecomment-2136100714 for the background and descriptions of the issue this change aims to resolve.