### PR TITLE
d3d12: Report other capabilities

### DIFF
--- a/src/sysinfo/nvapi_adapter.h
+++ b/src/sysinfo/nvapi_adapter.h
@@ -38,6 +38,7 @@ namespace dxvk {
         [[nodiscard]] uint32_t GetBoardId() const;
         [[nodiscard]] std::optional<LUID> GetLuid() const;
         [[nodiscard]] NV_GPU_ARCHITECTURE_ID GetArchitectureId() const;
+        [[nodiscard]] bool IsVkDeviceExtensionSupported(const std::string& name) const;
         [[nodiscard]] const MemoryInfo& GetMemoryInfo() const;
         [[nodiscard]] MemoryBudgetInfo GetCurrentMemoryBudgetInfo() const;
         [[nodiscard]] bool HasNvml() const;
@@ -76,8 +77,6 @@ namespace dxvk {
         nvmlDevice_t m_nvmlDevice{};
 
         uint32_t m_driverVersionOverride = 0;
-
-        [[nodiscard]] bool IsVkDeviceExtensionSupported(const std::string& name) const;
 
         constexpr static auto driverVersionEnvName = "DXVK_NVAPI_DRIVER_VERSION";
         constexpr static auto allowOtherDriversEnvName = "DXVK_NVAPI_ALLOW_OTHER_DRIVERS";

--- a/tests/nvapi_d3d12.cpp
+++ b/tests/nvapi_d3d12.cpp
@@ -232,17 +232,18 @@ TEST_CASE("D3D12 methods succeed", "[.d3d12]") {
                 std::string extensionName;
                 uint16_t expectedMajorSMVersion;
                 uint16_t expectedMinorSMVersion;
+                bool variablePixelRateShadingSupported;
             };
             auto args = GENERATE(
-                Data{VK_DRIVER_ID_NVIDIA_PROPRIETARY, 0x2600, VK_KHR_FRAGMENT_SHADING_RATE_EXTENSION_NAME, 8, 9},
-                Data{VK_DRIVER_ID_NVIDIA_PROPRIETARY, 0x2000, VK_KHR_FRAGMENT_SHADING_RATE_EXTENSION_NAME, 8, 6},
-                Data{VK_DRIVER_ID_NVIDIA_PROPRIETARY, 0x2000, VK_KHR_FRAGMENT_SHADER_BARYCENTRIC_EXTENSION_NAME, 7, 5},
-                Data{VK_DRIVER_ID_NVIDIA_PROPRIETARY, 0x2000, VK_NVX_IMAGE_VIEW_HANDLE_EXTENSION_NAME, 7, 0},
-                Data{VK_DRIVER_ID_NVIDIA_PROPRIETARY, 0x2000, VK_NV_CLIP_SPACE_W_SCALING_EXTENSION_NAME, 6, 0},
-                Data{VK_DRIVER_ID_NVIDIA_PROPRIETARY, 0x2000, VK_NV_VIEWPORT_ARRAY2_EXTENSION_NAME, 5, 0},
-                Data{VK_DRIVER_ID_MESA_NVK, 0x2600, VK_KHR_FRAGMENT_SHADING_RATE_EXTENSION_NAME, 8, 9},
-                Data{VK_DRIVER_ID_AMD_OPEN_SOURCE, 0x2000, VK_KHR_FRAGMENT_SHADING_RATE_EXTENSION_NAME, 0, 0},
-                Data{VK_DRIVER_ID_NVIDIA_PROPRIETARY, 0x2000, "ext", 0, 0});
+                Data{VK_DRIVER_ID_NVIDIA_PROPRIETARY, 0x2600, VK_KHR_FRAGMENT_SHADING_RATE_EXTENSION_NAME, 8, 9, true},
+                Data{VK_DRIVER_ID_NVIDIA_PROPRIETARY, 0x2000, VK_KHR_FRAGMENT_SHADING_RATE_EXTENSION_NAME, 8, 6, true},
+                Data{VK_DRIVER_ID_NVIDIA_PROPRIETARY, 0x2000, VK_KHR_FRAGMENT_SHADER_BARYCENTRIC_EXTENSION_NAME, 7, 5, false},
+                Data{VK_DRIVER_ID_NVIDIA_PROPRIETARY, 0x2000, VK_NVX_IMAGE_VIEW_HANDLE_EXTENSION_NAME, 7, 0, false},
+                Data{VK_DRIVER_ID_NVIDIA_PROPRIETARY, 0x2000, VK_NV_CLIP_SPACE_W_SCALING_EXTENSION_NAME, 6, 0, false},
+                Data{VK_DRIVER_ID_NVIDIA_PROPRIETARY, 0x2000, VK_NV_VIEWPORT_ARRAY2_EXTENSION_NAME, 5, 0, false},
+                Data{VK_DRIVER_ID_MESA_NVK, 0x2600, VK_KHR_FRAGMENT_SHADING_RATE_EXTENSION_NAME, 8, 9, true},
+                Data{VK_DRIVER_ID_AMD_OPEN_SOURCE, 0x2000, VK_KHR_FRAGMENT_SHADING_RATE_EXTENSION_NAME, 0, 0, false},
+                Data{VK_DRIVER_ID_NVIDIA_PROPRIETARY, 0x2000, "ext", 0, 0, false});
 
             ::SetEnvironmentVariableA("DXVK_NVAPI_ALLOW_OTHER_DRIVERS", "1");
 
@@ -268,9 +269,11 @@ TEST_CASE("D3D12 methods succeed", "[.d3d12]") {
 
             NV_D3D12_GRAPHICS_CAPS graphicsCaps;
             REQUIRE(NvAPI_D3D12_GetGraphicsCapabilities(static_cast<ID3D12Device*>(&device), NV_D3D12_GRAPHICS_CAPS_VER1, &graphicsCaps) == NVAPI_OK);
-            REQUIRE(graphicsCaps.bFastUAVClearSupported == true);
             REQUIRE(graphicsCaps.majorSMVersion == args.expectedMajorSMVersion);
             REQUIRE(graphicsCaps.minorSMVersion == args.expectedMinorSMVersion);
+            REQUIRE(graphicsCaps.bFastUAVClearSupported == true);
+            REQUIRE(graphicsCaps.bExclusiveScissorRectsSupported == false);
+            REQUIRE(graphicsCaps.bVariablePixelRateShadingSupported == args.variablePixelRateShadingSupported);
             REQUIRE(deviceRefCount == 0);
         }
 


### PR DESCRIPTION
For Turing+ only.

I'm tempted to report those two also for Turing+.
Since there are no `NvAPI_D3D12` equivalents to `NvAPI_D3D11_RSSetExclusiveScissorRects` or  `NvAPI_D3D11_RSSetViewportsPixelShadingRates` I guess those capabilities refer to D3D12 core functionalities, but should do some research into it first. 
Reporting those probably makes no difference in practice.