### PR TITLE
nvapi: Use fallthrough when checking struct versions

### DIFF
--- a/src/nvapi_d3d.cpp
+++ b/src/nvapi_d3d.cpp
@@ -65,18 +65,11 @@ extern "C" {
             return InvalidArgument(n);
 
         switch (pSliState->version) {
-            case NV_GET_CURRENT_SLI_STATE_VER1: {
-                auto pSliStateV1 = reinterpret_cast<NV_GET_CURRENT_SLI_STATE_V1*>(pSliState);
-                // Report that SLI is not available
-                pSliStateV1->maxNumAFRGroups = 1;
-                pSliStateV1->numAFRGroups = 1;
-                pSliStateV1->currentAFRIndex = 0;
-                pSliStateV1->nextFrameAFRIndex = 0;
-                pSliStateV1->previousFrameAFRIndex = 0;
-                pSliStateV1->bIsCurAFRGroupNew = false;
-                break;
-            }
             case NV_GET_CURRENT_SLI_STATE_VER2:
+                // Report that SLI is not available
+                pSliState->numVRSLIGpus = 0;
+                [[fallthrough]];
+            case NV_GET_CURRENT_SLI_STATE_VER1:
                 // Report that SLI is not available
                 pSliState->maxNumAFRGroups = 1;
                 pSliState->numAFRGroups = 1;
@@ -84,7 +77,6 @@ extern "C" {
                 pSliState->nextFrameAFRIndex = 0;
                 pSliState->previousFrameAFRIndex = 0;
                 pSliState->bIsCurAFRGroupNew = false;
-                pSliState->numVRSLIGpus = 0;
                 break;
             default:
                 return IncompatibleStructVersion(n, pSliState->version);
@@ -116,21 +108,16 @@ extern "C" {
             return InvalidArgument(n);
 
         switch (structVersion) {
-            case NV_D3D1x_GRAPHICS_CAPS_VER1: {
-                auto pGraphicsCapsV1 = reinterpret_cast<NV_D3D1x_GRAPHICS_CAPS_V1*>(pGraphicsCaps);
-                *pGraphicsCapsV1 = {};
-                pGraphicsCapsV1->bExclusiveScissorRectsSupported = 0;
-                pGraphicsCapsV1->bVariablePixelRateShadingSupported = 0;
-                break;
-            }
+
             case NV_D3D1x_GRAPHICS_CAPS_VER2:
-                *pGraphicsCaps = {};
                 // bFastUAVClearSupported is reported mostly for the sake of DLSS.
                 // All NVIDIA Vulkan drivers support this.
                 pGraphicsCaps->bFastUAVClearSupported = 1;
                 // dummy SM version number (unused by DLSS):
                 pGraphicsCaps->majorSMVersion = 0;
                 pGraphicsCaps->minorSMVersion = 0;
+                [[fallthrough]];
+            case NV_D3D1x_GRAPHICS_CAPS_VER1:
                 pGraphicsCaps->bExclusiveScissorRectsSupported = 0;
                 pGraphicsCaps->bVariablePixelRateShadingSupported = 0;
                 break;

--- a/src/nvapi_d3d11.cpp
+++ b/src/nvapi_d3d11.cpp
@@ -71,21 +71,14 @@ extern "C" {
 
         switch (pMultiGPUCaps->version) {
             case 0: // NV_MULTIGPU_CAPS_V1 has no version field
-            case NV_MULTIGPU_CAPS_VER1: {
-                auto pMultiGPUCapsV1 = reinterpret_cast<NV_MULTIGPU_CAPS_V1*>(pMultiGPUCaps);
-                *pMultiGPUCapsV1 = {};
-                // Report that SLI is not available
-                pMultiGPUCapsV1->nTotalGPUs = nvapiAdapterRegistry->GetAdapterCount();
-                pMultiGPUCapsV1->nSLIGPUs = 0;
-                break;
-            }
-            case NV_MULTIGPU_CAPS_VER2: {
+            case NV_MULTIGPU_CAPS_VER2:
+                [[fallthrough]];
+            case NV_MULTIGPU_CAPS_VER1:
                 *pMultiGPUCaps = {};
                 // Report that SLI is not available
                 pMultiGPUCaps->nTotalGPUs = nvapiAdapterRegistry->GetAdapterCount();
                 pMultiGPUCaps->nSLIGPUs = 0;
                 break;
-            }
             default:
                 return IncompatibleStructVersion(n, pMultiGPUCaps->version);
         }

--- a/src/nvapi_disp.cpp
+++ b/src/nvapi_disp.cpp
@@ -56,41 +56,11 @@ extern "C" {
         const auto& data = output->GetColorData();
 
         switch (pHdrCapabilities->version) {
-            case NV_HDR_CAPABILITIES_VER1: {
-                auto pHdrCapabilitiesV1 = reinterpret_cast<NV_HDR_CAPABILITIES_V1*>(pHdrCapabilities);
-                *pHdrCapabilitiesV1 = {};
-                pHdrCapabilitiesV1->isST2084EotfSupported = data.HasST2084Support;
-                pHdrCapabilitiesV1->display_data.displayPrimary_x0 = data.RedPrimaryX;
-                pHdrCapabilitiesV1->display_data.displayPrimary_y0 = data.RedPrimaryY;
-                pHdrCapabilitiesV1->display_data.displayPrimary_x1 = data.GreenPrimaryX;
-                pHdrCapabilitiesV1->display_data.displayPrimary_y1 = data.GreenPrimaryY;
-                pHdrCapabilitiesV1->display_data.displayPrimary_x2 = data.BluePrimaryX;
-                pHdrCapabilitiesV1->display_data.displayPrimary_y2 = data.BluePrimaryY;
-                pHdrCapabilitiesV1->display_data.displayWhitePoint_x = data.WhitePointX;
-                pHdrCapabilitiesV1->display_data.displayWhitePoint_y = data.WhitePointY;
-                pHdrCapabilitiesV1->display_data.desired_content_min_luminance = data.MinLuminance;
-                pHdrCapabilitiesV1->display_data.desired_content_max_luminance = data.MaxLuminance;
-                pHdrCapabilitiesV1->display_data.desired_content_max_frame_average_luminance = data.MaxFullFrameLuminance;
-                break;
-            }
-            case NV_HDR_CAPABILITIES_VER2: {
-                auto pHdrCapabilitiesV2 = reinterpret_cast<NV_HDR_CAPABILITIES_V2*>(pHdrCapabilities);
-                *pHdrCapabilitiesV2 = {};
-                pHdrCapabilitiesV2->isST2084EotfSupported = data.HasST2084Support;
-                pHdrCapabilitiesV2->display_data.displayPrimary_x0 = data.RedPrimaryX;
-                pHdrCapabilitiesV2->display_data.displayPrimary_y0 = data.RedPrimaryY;
-                pHdrCapabilitiesV2->display_data.displayPrimary_x1 = data.GreenPrimaryX;
-                pHdrCapabilitiesV2->display_data.displayPrimary_y1 = data.GreenPrimaryY;
-                pHdrCapabilitiesV2->display_data.displayPrimary_x2 = data.BluePrimaryX;
-                pHdrCapabilitiesV2->display_data.displayPrimary_y2 = data.BluePrimaryY;
-                pHdrCapabilitiesV2->display_data.displayWhitePoint_x = data.WhitePointX;
-                pHdrCapabilitiesV2->display_data.displayWhitePoint_y = data.WhitePointY;
-                pHdrCapabilitiesV2->display_data.desired_content_min_luminance = data.MinLuminance;
-                pHdrCapabilitiesV2->display_data.desired_content_max_luminance = data.MaxLuminance;
-                pHdrCapabilitiesV2->display_data.desired_content_max_frame_average_luminance = data.MaxFullFrameLuminance;
-                break;
-            }
             case NV_HDR_CAPABILITIES_VER3:
+                [[fallthrough]];
+            case NV_HDR_CAPABILITIES_VER2:
+                [[fallthrough]];
+            case NV_HDR_CAPABILITIES_VER1:
                 *pHdrCapabilities = {};
                 pHdrCapabilities->isST2084EotfSupported = data.HasST2084Support;
                 pHdrCapabilities->display_data.displayPrimary_x0 = data.RedPrimaryX;
@@ -192,14 +162,13 @@ extern "C" {
         }
 
         if (pHdrColorData->version == NV_HDR_COLOR_DATA_VER2) {
-            auto pHDRColorDataV2 = reinterpret_cast<NV_HDR_COLOR_DATA_V2*>(pHdrColorData);
-            if (pHDRColorDataV2->cmd == NV_HDR_CMD_GET) {
-                pHDRColorDataV2->hdrColorFormat = NV_COLOR_FORMAT_RGB;
+            if (pHdrColorData->cmd == NV_HDR_CMD_GET) {
+                pHdrColorData->hdrColorFormat = NV_COLOR_FORMAT_RGB;
                 // NV_DYNAMIC_RANGE_VESA is RGB full range
                 // NV_DYNAMIC_RANGE_CEA is RGB/YCbCr limited range
                 // NV_DYNAMIC_RANGE_AUTO automatically chooses something (probably reads some EDID/CTA-861 entries)
-                pHDRColorDataV2->hdrDynamicRange = NV_DYNAMIC_RANGE_VESA;
-                pHDRColorDataV2->hdrBpc = data.BitsPerColor;
+                pHdrColorData->hdrDynamicRange = NV_DYNAMIC_RANGE_VESA;
+                pHdrColorData->hdrBpc = data.BitsPerColor;
             } else {
                 // Ignoring some extended properties of HDRColorDataV2.
                 // Nothing to set. It's all random useless garbage that you would NEVER trust an app to set.

--- a/src/nvapi_sys.cpp
+++ b/src/nvapi_sys.cpp
@@ -57,22 +57,11 @@ extern "C" {
         if (pDriverInfo == nullptr)
             return InvalidArgument(n);
 
-        if (pDriverInfo->version != NV_DISPLAY_DRIVER_INFO_VER1 && pDriverInfo->version != NV_DISPLAY_DRIVER_INFO_VER2)
-            return IncompatibleStructVersion(n, pDriverInfo->version);
-
         switch (pDriverInfo->version) {
-            case NV_DISPLAY_DRIVER_INFO_VER1: {
-                auto pDriverInfoV1 = reinterpret_cast<NV_DISPLAY_DRIVER_INFO_V1*>(pDriverInfo);
-                pDriverInfoV1->driverVersion = nvapiAdapterRegistry->GetFirstAdapter()->GetDriverVersion();
-                str::tonvss(pDriverInfoV1->szBuildBranch, str::format(NVAPI_VERSION, "_", DXVK_NVAPI_VERSION));
-                pDriverInfoV1->bIsDCHDriver = 1;              // Assume DCH driver for Windows
-                pDriverInfoV1->bIsNVIDIAStudioPackage = 0;    // Lets not support "Studio Package"
-                pDriverInfoV1->bIsNVIDIAGameReadyPackage = 1; // GameReady Package should be "safe" even if other packages is used
-                pDriverInfoV1->bIsNVIDIARTXProductionBranchPackage = 0;
-                pDriverInfoV1->bIsNVIDIARTXNewFeatureBranchPackage = 0;
-                break;
-            }
-            case NV_DISPLAY_DRIVER_INFO_VER2: {
+            case NV_DISPLAY_DRIVER_INFO_VER2:
+                str::tonvss(pDriverInfo->szBuildBaseBranch, NVAPI_VERSION);
+                [[fallthrough]];
+            case NV_DISPLAY_DRIVER_INFO_VER1:
                 pDriverInfo->driverVersion = nvapiAdapterRegistry->GetFirstAdapter()->GetDriverVersion();
                 str::tonvss(pDriverInfo->szBuildBranch, str::format(NVAPI_VERSION, "_", DXVK_NVAPI_VERSION));
                 pDriverInfo->bIsDCHDriver = 1;              // Assume DCH driver for Windows
@@ -80,11 +69,9 @@ extern "C" {
                 pDriverInfo->bIsNVIDIAGameReadyPackage = 1; // GameReady Package should be "safe" even if other packages is used
                 pDriverInfo->bIsNVIDIARTXProductionBranchPackage = 0;
                 pDriverInfo->bIsNVIDIARTXNewFeatureBranchPackage = 0;
-                str::tonvss(pDriverInfo->szBuildBaseBranch, NVAPI_VERSION);
                 break;
-            }
             default:
-                return Error(n); // Unreachable, but just to be sure
+                return IncompatibleStructVersion(n, pDriverInfo->version);
         }
 
         return Ok(n);


### PR DESCRIPTION
And skip casting versioned structs that should be the correct version

Attempt to solve #199 

Some of these makes a lot of sense, others - not so sure. Just for consistency (i hope). Will work on it.
In theory it should not be necessary to reinterpret_cast structs that should already be the correct version, as pointed out in https://github.com/jp7677/dxvk-nvapi/pull/198#discussion_r1718709030
