### PR TITLE
Ensure that we don't lose struct version

### DIFF
--- a/.clang-tidy-ignore
+++ b/.clang-tidy-ignore
@@ -1,0 +1,2 @@
+external/*
+inc/*

--- a/src/nvapi_disp.cpp
+++ b/src/nvapi_disp.cpp
@@ -59,6 +59,7 @@ extern "C" {
             case NV_HDR_CAPABILITIES_VER1: {
                 auto pHdrCapabilitiesV1 = reinterpret_cast<NV_HDR_CAPABILITIES_V1*>(pHdrCapabilities);
                 *pHdrCapabilitiesV1 = {};
+                pHdrCapabilitiesV1->version = NV_HDR_CAPABILITIES_VER1;
                 pHdrCapabilitiesV1->isST2084EotfSupported = data.HasST2084Support;
                 pHdrCapabilitiesV1->display_data.displayPrimary_x0 = data.RedPrimaryX;
                 pHdrCapabilitiesV1->display_data.displayPrimary_y0 = data.RedPrimaryY;
@@ -76,6 +77,7 @@ extern "C" {
             case NV_HDR_CAPABILITIES_VER2: {
                 auto pHdrCapabilitiesV2 = reinterpret_cast<NV_HDR_CAPABILITIES_V2*>(pHdrCapabilities);
                 *pHdrCapabilitiesV2 = {};
+                pHdrCapabilitiesV2->version = NV_HDR_CAPABILITIES_VER2;
                 pHdrCapabilitiesV2->isST2084EotfSupported = data.HasST2084Support;
                 pHdrCapabilitiesV2->display_data.displayPrimary_x0 = data.RedPrimaryX;
                 pHdrCapabilitiesV2->display_data.displayPrimary_y0 = data.RedPrimaryY;
@@ -92,6 +94,7 @@ extern "C" {
             }
             case NV_HDR_CAPABILITIES_VER3:
                 *pHdrCapabilities = {};
+                pHdrCapabilities->version = NV_HDR_CAPABILITIES_VER3;
                 pHdrCapabilities->isST2084EotfSupported = data.HasST2084Support;
                 pHdrCapabilities->display_data.displayPrimary_x0 = data.RedPrimaryX;
                 pHdrCapabilities->display_data.displayPrimary_y0 = data.RedPrimaryY;

--- a/src/nvapi_gpu.cpp
+++ b/src/nvapi_gpu.cpp
@@ -36,10 +36,12 @@ extern "C" {
             return InsufficientBuffer(n);
         }
 
-        switch (pDisplayIds->version) {
+        auto version = pDisplayIds->version;
+        switch (version) {
             case NV_GPU_DISPLAYIDS_VER1: // Both versions use the same NV_GPU_DISPLAYIDS struct
             case NV_GPU_DISPLAYIDS_VER2: {
                 *pDisplayIds = {};
+                pDisplayIds->version = version;
                 for (auto i = 0U; i < count; i++) {
                     auto output = nvapiAdapterRegistry->GetOutput(adapter, i);
                     pDisplayIds[i].displayId = output->GetId();
@@ -693,10 +695,12 @@ extern "C" {
             case NV_GPU_INFO_VER1: {
                 auto pGpuInfoV1 = reinterpret_cast<NV_GPU_INFO_V1*>(pGpuInfo);
                 *pGpuInfoV1 = {};
+                pGpuInfoV1->version = NV_GPU_INFO_VER1;
                 break;
             }
             case NV_GPU_INFO_VER2:
                 *pGpuInfo = {};
+                pGpuInfo->version = NV_GPU_INFO_VER2;
                 if (architectureId >= NV_GPU_ARCHITECTURE_TU100) {
                     // Values are taken from RTX4080
                     pGpuInfo->rayTracingCores = 76;

--- a/tests/nvapi_d3d11.cpp
+++ b/tests/nvapi_d3d11.cpp
@@ -453,6 +453,7 @@ TEST_CASE("D3D11 MultiGPU methods succeed", "[.d3d11]") {
         NV_MULTIGPU_CAPS_V1 multiGPUCaps{};
 
         REQUIRE(NvAPI_D3D11_MultiGPU_GetCaps(reinterpret_cast<PNV_MULTIGPU_CAPS>(&multiGPUCaps)) == NVAPI_OK);
+        REQUIRE(multiGPUCaps.multiGPUVersion == 3);
         REQUIRE(multiGPUCaps.nTotalGPUs == 1);
         REQUIRE(multiGPUCaps.nSLIGPUs == 0);
     }
@@ -462,21 +463,9 @@ TEST_CASE("D3D11 MultiGPU methods succeed", "[.d3d11]") {
         multiGPUCaps.version = NV_MULTIGPU_CAPS_VER2;
 
         REQUIRE(NvAPI_D3D11_MultiGPU_GetCaps(&multiGPUCaps) == NVAPI_OK);
+        REQUIRE(multiGPUCaps.multiGPUVersion == 3);
         REQUIRE(multiGPUCaps.nTotalGPUs == 1);
         REQUIRE(multiGPUCaps.nSLIGPUs == 0);
-    }
-
-    SECTION("MultiGPU_GetCaps with unknown struct version returns incompatible-struct-version") {
-        NV_MULTIGPU_CAPS multiGPUCaps{};
-        multiGPUCaps.version = NV_MULTIGPU_CAPS_VER2 + 1;
-        REQUIRE(NvAPI_D3D11_MultiGPU_GetCaps(&multiGPUCaps) == NVAPI_INCOMPATIBLE_STRUCT_VERSION);
-    }
-
-    SECTION("MultiGPU_GetCaps with current struct version returns not incompatible-struct-version") {
-        // This test fails when a header update provides a newer not yet implemented struct version
-        NV_MULTIGPU_CAPS multiGPUCaps{};
-        multiGPUCaps.version = NV_MULTIGPU_CAPS_VER;
-        REQUIRE(NvAPI_D3D11_MultiGPU_GetCaps(&multiGPUCaps) != NVAPI_INCOMPATIBLE_STRUCT_VERSION);
     }
 
     SECTION("MultiGPU_Init returns OK") {


### PR DESCRIPTION
Based on logs of `NvAPI_GPU_GetMemoryInfo` usage, structs can and will be reused. The one's where we zero'ed the struct version are probably not of that category, but lets be consistent and safe everywhere.

TODO:
- [x] Test  `NvAPI_D3D11_MultiGPU_GetCaps` explicitly with Senua's Sacrifice VR, that title made us introduce that function