### PR TITLE
Allow disabling entrypoints by name via environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ The following environment variables tweak DXVK-NVAPI's runtime behavior:
 
 - `DXVK_NVAPI_DRIVER_VERSION` lets you override the reported driver version. Valid values are numbers between 100 and 99999. Use e.g. `DXVK_NVAPI_DRIVER_VERSION=47141` to report driver version `471.41`.
 - `DXVK_NVAPI_ALLOW_OTHER_DRIVERS`, when set to `1`, allows DXVK-NVAPI to initialize for a non-NVIDIA GPU.
+- `DXVK_NVAPI_DISABLE_ENTRYPOINTS`, when set to a comma-separated list of NVAPI entrypoint names, will hide their implementation from the application. For example, `DXVK_NVAPI_DISABLE_ENTRYPOINTS=NvAPI_D3D11_BeginUAVOverlap,NvAPI_D3D11_EndUAVOverlap` will report D3D11 barrier control extensions as not available.
 - `DXVK_NVAPI_GPU_ARCH`, when set to one of supported NVIDIA GPU architecture IDs will override reported GPU architecture. Currently supported values are:
   - `GK100` (Kepler)
   - `GM200` (Maxwell)

--- a/src/nvapi_interface.cpp
+++ b/src/nvapi_interface.cpp
@@ -159,7 +159,7 @@ extern "C" {
 
 #undef INSERT_AND_RETURN_WHEN_EQUALS
 
-        log::info(str::format("NvAPI_QueryInterface ", name, ": Not implemented method"));
+        log::info(str::format("NvAPI_QueryInterface (", name, "): Not implemented method"));
         return registry.insert({id, nullptr}).first->second;
     }
 }

--- a/src/nvapi_interface.cpp
+++ b/src/nvapi_interface.cpp
@@ -7,7 +7,7 @@ extern "C" {
     using namespace dxvk;
 
     static const auto disabledString = str::fromnullable(std::getenv("DXVK_NVAPI_DISABLE_ENTRYPOINTS"));
-    static const auto disabled = str::split<std::unordered_set<std::string_view>>(disabledString, std::regex(","));
+    static const auto disabled = str::split<std::set<std::string_view, str::CaseInsensitiveCompare<std::string_view>>>(disabledString, std::regex(","));
 
     static std::unordered_map<NvU32, void*> registry;
 

--- a/src/nvapi_private.h
+++ b/src/nvapi_private.h
@@ -3,20 +3,26 @@
 #include <algorithm>
 #include <array>
 #include <cctype>
+#include <concepts>
 #include <cstddef>
 #include <cstdint>
 #include <ctime>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
+#include <iterator>
 #include <locale>
 #include <map>
 #include <memory>
 #include <mutex>
 #include <optional>
+#include <regex>
 #include <set>
 #include <sstream>
+#include <string_view>
+#include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 

--- a/src/nvapi_private.h
+++ b/src/nvapi_private.h
@@ -22,7 +22,6 @@
 #include <string_view>
 #include <string>
 #include <unordered_map>
-#include <unordered_set>
 #include <utility>
 #include <vector>
 

--- a/src/nvapi_private.h
+++ b/src/nvapi_private.h
@@ -15,6 +15,7 @@
 #include <map>
 #include <memory>
 #include <mutex>
+#include <numeric>
 #include <optional>
 #include <regex>
 #include <set>

--- a/src/util/util_string.cpp
+++ b/src/util/util_string.cpp
@@ -40,4 +40,8 @@ namespace dxvk::str {
         str.resize(NVAPI_SHORT_STRING_MAX - 1);
         strcpy(nvss, str.c_str());
     }
+
+    std::string fromnullable(const char* str) {
+        return str ? std::string(str) : std::string();
+    }
 }

--- a/src/util/util_string.h
+++ b/src/util/util_string.h
@@ -38,4 +38,33 @@ namespace dxvk::str {
         append(stream, args...);
         return stream.str();
     }
+
+    std::string fromnullable(const char* str);
+
+    template <typename T>
+        requires std::default_initializable<T>
+        && std::constructible_from<typename T::value_type, std::string::const_iterator, std::string::const_iterator>
+        && requires(T t, T::iterator it, T::value_type&& s) {
+               requires std::input_iterator<typename T::iterator>;
+               { t.end() } -> std::same_as<typename T::iterator>;
+               { t.insert(it, s) } -> std::same_as<typename T::iterator>;
+           }
+    T split(const std::string& str, const std::regex& separator) {
+        static const std::sregex_token_iterator end;
+
+        T result;
+
+        if (str.empty())
+            return result;
+
+        std::transform(
+            std::sregex_token_iterator(str.begin(), str.end(), separator, -1),
+            end,
+            std::inserter(result, result.end()),
+            [](const std::ssub_match& match) {
+                return typename T::value_type(match.first, match.second);
+            });
+
+        return result;
+    }
 }

--- a/src/util/util_string.h
+++ b/src/util/util_string.h
@@ -67,4 +67,23 @@ namespace dxvk::str {
 
         return result;
     }
+
+    template <typename T>
+        requires requires(T t) {
+            requires std::input_iterator<typename T::iterator>;
+            { t.begin() } -> std::same_as<typename T::iterator>;
+            { t.end() } -> std::same_as<typename T::iterator>;
+        }
+    struct CaseInsensitiveCompare {
+        bool operator()(const T& lhs, const T& rhs) const {
+            return std::lexicographical_compare(
+                lhs.begin(),
+                lhs.end(),
+                rhs.begin(),
+                rhs.end(),
+                [](const auto& l, const auto& r) {
+                    return std::toupper(l, std::locale::classic()) < std::toupper(r, std::locale::classic());
+                });
+        }
+    };
 }

--- a/src/util/util_string.h
+++ b/src/util/util_string.h
@@ -86,4 +86,28 @@ namespace dxvk::str {
                 });
         }
     };
+
+    template <typename T>
+        requires requires(T t) {
+            requires std::input_iterator<typename T::iterator>;
+            { t.begin() } -> std::same_as<typename T::iterator>;
+            { t.end() } -> std::same_as<typename T::iterator>;
+        }
+    std::string implode(const std::string_view& separator, const T& items) {
+        auto first = items.begin();
+        auto last = items.end();
+
+        if (first == last)
+            return {};
+
+        auto init = *first++;
+
+        return std::accumulate(
+            first,
+            last,
+            std::string{init},
+            [&separator](std::string&& lhs, const auto& rhs) {
+                return lhs.append(separator).append(rhs);
+            });
+    }
 }

--- a/tests/util.cpp
+++ b/tests/util.cpp
@@ -84,6 +84,13 @@ TEST_CASE("String", "[.util]") {
         REQUIRE(set.contains("nvapi_initialize"));
         REQUIRE(set.contains("NVAPI_INITIALIZE"));
     }
+
+    SECTION("implode") {
+        REQUIRE(dxvk::str::implode(",", std::vector<std::string_view>{}) == std::string());
+        REQUIRE(dxvk::str::implode(",", std::vector<std::string_view>{"foo"}) == std::string("foo"));
+        REQUIRE(dxvk::str::implode(" ", std::vector<std::string_view>{"foo", "bar"}) == std::string("foo bar"));
+        REQUIRE(dxvk::str::implode(", ", std::vector<std::string_view>{"foo", "bar", "baz"}) == std::string("foo, bar, baz"));
+    }
 }
 
 TEST_CASE("Version", "[.util]") {

--- a/tests/util.cpp
+++ b/tests/util.cpp
@@ -35,12 +35,12 @@ TEST_CASE("Log", "[.util]") {
 }
 
 TEST_CASE("String", "[.util]") {
-    SECTION("NVAPI Unicode-String") {
+    SECTION("fromnvus") {
         NvAPI_UnicodeString us = {'U', 'n', 'i', 'c', 'o', 'd', 'e'};
         REQUIRE(dxvk::str::fromnvus(us) == std::string("Unicode"));
     }
 
-    SECTION("NVAPI Short-String") {
+    SECTION("tonvss") {
         NvAPI_ShortString ss{};
 
         dxvk::str::tonvss(ss, std::string("Short-String"));
@@ -50,7 +50,7 @@ TEST_CASE("String", "[.util]") {
         REQUIRE_THAT(ss, SizeIs(64));
     }
 
-    SECTION("std::string") {
+    SECTION("fromnullable") {
         REQUIRE(dxvk::str::fromnullable(nullptr) == std::string());
         REQUIRE(dxvk::str::fromnullable("") == std::string());
         REQUIRE(dxvk::str::fromnullable("string") == std::string("string"));

--- a/tests/util.cpp
+++ b/tests/util.cpp
@@ -56,6 +56,17 @@ TEST_CASE("String", "[.util]") {
         REQUIRE(dxvk::str::fromnullable("string") == std::string("string"));
     }
 
+    SECTION("split") {
+        REQUIRE(dxvk::str::split<std::set<std::string>>("", std::regex(",")).size() == 0);
+
+        auto result = dxvk::str::split<std::set<std::string>>("foo,bar,baz", std::regex(","));
+
+        REQUIRE(result.size() == 3);
+        REQUIRE(result.contains("foo"));
+        REQUIRE(result.contains("bar"));
+        REQUIRE(result.contains("baz"));
+    }
+
     SECTION("CaseInsensitiveCompare") {
         dxvk::str::CaseInsensitiveCompare<std::string_view> compare;
 

--- a/tests/util.cpp
+++ b/tests/util.cpp
@@ -49,6 +49,12 @@ TEST_CASE("String", "[.util]") {
         dxvk::str::tonvss(ss, std::string("Longer-Than-Short-String-Longer-Than-Short-String-Longer-Than-Short-String"));
         REQUIRE_THAT(ss, SizeIs(64));
     }
+
+    SECTION("std::string") {
+        REQUIRE(dxvk::str::fromnullable(nullptr) == std::string());
+        REQUIRE(dxvk::str::fromnullable("") == std::string());
+        REQUIRE(dxvk::str::fromnullable("string") == std::string("string"));
+    }
 }
 
 TEST_CASE("Version", "[.util]") {

--- a/tests/util.cpp
+++ b/tests/util.cpp
@@ -55,6 +55,35 @@ TEST_CASE("String", "[.util]") {
         REQUIRE(dxvk::str::fromnullable("") == std::string());
         REQUIRE(dxvk::str::fromnullable("string") == std::string("string"));
     }
+
+    SECTION("CaseInsensitiveCompare") {
+        dxvk::str::CaseInsensitiveCompare<std::string_view> compare;
+
+        struct Data {
+            const char* lhs;
+            const char* rhs;
+            bool result;
+        };
+
+        auto args = GENERATE(
+            Data{"aa", "aa", false},
+            Data{"ab", "aa", false},
+            Data{"aa", "ab", true},
+            Data{"AA", "aa", false},
+            Data{"AB", "aa", false},
+            Data{"AA", "ab", true},
+            Data{"aa", "AA", false},
+            Data{"ab", "AA", false},
+            Data{"aa", "AB", true});
+
+        REQUIRE(compare(args.lhs, args.rhs) == args.result);
+
+        std::set<std::string_view, dxvk::str::CaseInsensitiveCompare<std::string_view>> set{"NvAPI_Initialize"};
+
+        REQUIRE(set.contains("NvAPI_Initialize"));
+        REQUIRE(set.contains("nvapi_initialize"));
+        REQUIRE(set.contains("NVAPI_INITIALIZE"));
+    }
 }
 
 TEST_CASE("Version", "[.util]") {


### PR DESCRIPTION
Includes some C++ concepts fun, hopefully not too crazy but I wanted the string splitting helper to be fairly generic. Interestingly, I found it easier to do with regex-based separators than matching plain substrings or single characters.

Testing this automatically is a bit tricky because entrypoints are cached, and so is the processed variable value, and I'm kinda afraid it would interfere with other tests. Any ideas, or are you fine with no tests for this thing?