### PR TITLE
Proton CI

### DIFF
--- a/.github/workflows/build-proton.yml
+++ b/.github/workflows/build-proton.yml
@@ -1,0 +1,26 @@
+name: Build with Proton SDK
+
+on:
+  push:
+    branches: [ master ]
+    tags: [ v* ]
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:
+
+jobs:
+  build-proton:
+    runs-on: ubuntu-latest
+    container:
+      image: registry.gitlab.steamos.cloud/proton/sniper/sdk:latest
+      options: --user 1001 # to match GHA's "runner" user: https://github.com/actions/runner/blob/3d34a3c6d6dfd7599e489b3c04fcf95a8a428434/images/Dockerfile#L52
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        submodules: recursive
+        fetch-depth: 0
+
+    - name: Build
+      run: ./package-release.sh master build


### PR DESCRIPTION
I just used the `latest` tag for the image, this way we will have to bump this only when Proton switches the Steam Runtime it uses to something other than `sniper`. Seems to work, but…

```
fatal: detected dubious ownership in repository at '/__w/dxvk-nvapi/dxvk-nvapi'
To add an exception for this directory, call:
	git config --global --add safe.directory /__w/dxvk-nvapi/dxvk-nvapi
```

Let me know if this is something we need to care about, for now the fallback appears to work well enough.