### PR TITLE
Revert "util: Spoof Ada and later GPUs as Ampere for Ghost of Tsushima"

### DIFF
--- a/src/util/util_env.cpp
+++ b/src/util/util_env.cpp
@@ -117,19 +117,10 @@ namespace dxvk::env {
         }
     }
 
-    bool isGhostOfTsushima() {
-        return getExecutableName() == std::string("GhostOfTsushima.exe");
-    }
-
     bool needsAmpereSpoofing(NV_GPU_ARCHITECTURE_ID architectureId, void* pReturnAddress) {
         // Check if we need to workaround NVIDIA Bug 3634851
         if (architectureId >= NV_GPU_ARCHITECTURE_AD100 && isDLSSVersion20To24(pReturnAddress)) {
             log::info("Spoofing Ampere for Ada and later due to DLSS version 2.0-2.4");
-            return true;
-        }
-
-        if (architectureId >= NV_GPU_ARCHITECTURE_AD100 && isGhostOfTsushima()) {
-            log::info("Spoofing Ampere for Ada and later due to detecting GhostOfTsushima.exe");
             return true;
         }
 


### PR DESCRIPTION
This reverts commit f86f56b24737d117098a80133516edfb553fe39a.

To be merged after DLSS FG support is in place. Let me know if I should actually write a new commit message.