### PR TITLE
nvapi: Include vulkan_core.h

### DIFF
--- a/src/nvapi_private.h
+++ b/src/nvapi_private.h
@@ -36,7 +36,7 @@
 #else
 #include "../inc/d3d12.h"
 #endif
-#include <vulkan/vulkan.h>
+#include <vulkan/vulkan_core.h>
 #include "../inc/nvml.h"
 
 #ifdef __GNUC__


### PR DESCRIPTION
That's all we need.

Originated from the first NVOF PR where that include was used in `nvofapi_image.h`. Good idea to use overall.
