### PR TITLE
Maxwell GM107/GM108 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ The following environment variables tweak DXVK-NVAPI's runtime behavior:
 - `DXVK_NVAPI_DISABLE_ENTRYPOINTS`, when set to a comma-separated list of NVAPI entrypoint names, will hide their implementation from the application. For example, `DXVK_NVAPI_DISABLE_ENTRYPOINTS=NvAPI_D3D11_BeginUAVOverlap,NvAPI_D3D11_EndUAVOverlap` will report D3D11 barrier control extensions as not available.
 - `DXVK_NVAPI_GPU_ARCH`, when set to one of supported NVIDIA GPU architecture IDs will override reported GPU architecture. Currently supported values are:
   - `GK100` (Kepler)
-  - `GM200` (Maxwell)
+  - `GM000` (Maxwell Gen1)
+  - `GM200` (Maxwell Gen2)
   - `GP100` (Pascal)
   - `GV100` (Volta)
   - `TU100` (Turing)

--- a/src/nvapi/nvapi_adapter.cpp
+++ b/src/nvapi/nvapi_adapter.cpp
@@ -268,6 +268,10 @@ namespace dxvk {
             || (HasNvkDriver() && IsVkDeviceExtensionSupported(VK_EXT_SHADER_VIEWPORT_INDEX_LAYER_EXTENSION_NAME)))
             return NV_GPU_ARCHITECTURE_GM200;
 
+        // VK_EXT_shader_image_atomic_int64 is supported on Maxwell 1 (GM10x) and newer
+        if (IsVkDeviceExtensionSupported(VK_EXT_SHADER_IMAGE_ATOMIC_INT64_EXTENSION_NAME))
+            return NV_GPU_ARCHITECTURE_GM000;
+
         // Fall back to Kepler
         return NV_GPU_ARCHITECTURE_GK100;
     }

--- a/src/nvapi_d3d12.cpp
+++ b/src/nvapi_d3d12.cpp
@@ -236,6 +236,7 @@ extern "C" {
                 pGraphicsCaps->minorSMVersion = 0;
                 break;
             case NV_GPU_ARCHITECTURE_GM200:
+            case NV_GPU_ARCHITECTURE_GM000:
                 pGraphicsCaps->majorSMVersion = 5;
                 pGraphicsCaps->minorSMVersion = 0;
                 break;

--- a/src/nvapi_gpu.cpp
+++ b/src/nvapi_gpu.cpp
@@ -339,7 +339,7 @@ extern "C" {
             }
         }
 
-        if (adapter->GetArchitectureId() >= NV_GPU_ARCHITECTURE_GM200)
+        if (adapter->GetArchitectureId() >= NV_GPU_ARCHITECTURE_GM000)
             *pBusType = NVAPI_GPU_BUS_TYPE_PCI_EXPRESS; // Assume PCIe on Maxwell like generation and newer
         else
             *pBusType = NVAPI_GPU_BUS_TYPE_UNDEFINED;
@@ -595,6 +595,7 @@ extern "C" {
                 implementationId = NV_GPU_ARCH_IMPLEMENTATION_GP102;
                 break;
             case NV_GPU_ARCHITECTURE_GM200:
+            case NV_GPU_ARCHITECTURE_GM000:
                 implementationId = NV_GPU_ARCH_IMPLEMENTATION_GM204;
                 break;
             case NV_GPU_ARCHITECTURE_GK100:
@@ -644,7 +645,7 @@ extern "C" {
         auto cudaCapableGpus = std::vector<NvPhysicalGpuHandle>(0);
         for (auto i = 0U; i < nvapiAdapterRegistry->GetAdapterCount(); i++) {
             auto adapter = nvapiAdapterRegistry->GetAdapter(i);
-            if (!adapter->HasNvProprietaryDriver() || adapter->GetArchitectureId() < NV_GPU_ARCHITECTURE_GM200) // Maxwell is the oldest generation we can detect
+            if (!adapter->HasNvProprietaryDriver() || adapter->GetArchitectureId() < NV_GPU_ARCHITECTURE_GM000) // Maxwell is the oldest generation we can detect
                 continue;
 
             cudaCapableGpus.push_back(reinterpret_cast<NvPhysicalGpuHandle>(adapter));

--- a/src/util/util_env.cpp
+++ b/src/util/util_env.cpp
@@ -184,6 +184,7 @@ namespace dxvk::env {
     if (overrideStr == #arch) \
         override = NV_GPU_ARCHITECTURE_##arch;
             CHECK_ARCH(GK100)
+            CHECK_ARCH(GM000)
             CHECK_ARCH(GM200)
             CHECK_ARCH(GP100)
             CHECK_ARCH(GV100)


### PR DESCRIPTION
IDK what `GM000` for but lets use it for now.

Test reports:
```patch
-    Architecture ID:            0x000000e0 (Kepler)
+    Architecture ID:            0x00000110 (Maxwell)
 ...
-    Compute capable:            -
+    Compute capable:            Yes (Compute GPU topology flags: 0x0b)
```

```log
Filters: [d3d],[d3d11],[d3d12],[drs],[sysinfo],[sysinfo-topo],[sysinfo-nvml],[sysinfo-hdr],[util],[system]
...
All tests passed (54839 assertions in 18 test cases)
```