### PR TITLE
nvapi-d3d: Fix NV_LATENCY_MARKER_TYPE forwarding

### DIFF
--- a/src/nvapi/nvapi_d3d_low_latency_device.h
+++ b/src/nvapi/nvapi_d3d_low_latency_device.h
@@ -33,6 +33,8 @@ namespace dxvk {
         static bool SetLatencyMarker(IUnknown* device, uint64_t frameID, uint32_t markerType);
         static bool SetLatencyMarker(ID3D12CommandQueue* commandQueue, uint64_t frameID, uint32_t markerType);
 
+        [[nodiscard]] static std::optional<uint32_t> ToMarkerType(NV_LATENCY_MARKER_TYPE markerType);
+
         static void ClearCacheMaps();
 
       private:

--- a/tests/nvapi_d3d.cpp
+++ b/tests/nvapi_d3d.cpp
@@ -383,7 +383,7 @@ TEST_CASE("D3D Reflex/LatencyFleX depending methods succeed", "[.d3d]") {
                     .RETURN(S_OK);
                 REQUIRE_CALL(lowLatencyDevice, LatencySleep())
                     .RETURN(S_OK);
-                REQUIRE_CALL(lowLatencyDevice, SetLatencyMarker(1ULL, SIMULATION_START))
+                REQUIRE_CALL(lowLatencyDevice, SetLatencyMarker(1ULL, VK_LATENCY_MARKER_SIMULATION_START_NV))
                     .RETURN(S_OK);
 
                 SetupResourceFactory(std::move(dxgiFactory), std::move(vulkan), std::move(nvml), std::move(lfx));
@@ -399,6 +399,19 @@ TEST_CASE("D3D Reflex/LatencyFleX depending methods succeed", "[.d3d]") {
                 latencyMarkerParams.markerType = SIMULATION_START;
                 REQUIRE(NvAPI_D3D_SetSleepMode(&unknown, &sleepModeParams) == NVAPI_OK);
                 REQUIRE(NvAPI_D3D_Sleep(&unknown) == NVAPI_OK);
+                REQUIRE(NvAPI_D3D_SetLatencyMarker(&unknown, &latencyMarkerParams) == NVAPI_OK);
+            }
+
+            SECTION("SetLatencyMarker drops PC_LATENCY_PING and returns OK") {
+                FORBID_CALL(lowLatencyDevice, SetLatencyMarker(_, _));
+
+                SetupResourceFactory(std::move(dxgiFactory), std::move(vulkan), std::move(nvml), std::move(lfx));
+                REQUIRE(NvAPI_Initialize() == NVAPI_OK);
+
+                NV_LATENCY_MARKER_PARAMS latencyMarkerParams{};
+                latencyMarkerParams.version = NV_LATENCY_MARKER_PARAMS_VER1;
+                latencyMarkerParams.frameID = 123ULL;
+                latencyMarkerParams.markerType = PC_LATENCY_PING;
                 REQUIRE(NvAPI_D3D_SetLatencyMarker(&unknown, &latencyMarkerParams) == NVAPI_OK);
             }
 

--- a/tests/nvapi_d3d12.cpp
+++ b/tests/nvapi_d3d12.cpp
@@ -859,7 +859,7 @@ TEST_CASE("D3D12 methods succeed", "[.d3d12]") {
             SECTION("SetAsyncFrameMarker returns OK") {
                 SetupResourceFactory(std::move(dxgiFactory), std::move(vulkan), std::move(nvml), std::move(lfx));
 
-                REQUIRE_CALL(lowLatencyDevice, SetLatencyMarker(1ULL, OUT_OF_BAND_RENDERSUBMIT_START))
+                REQUIRE_CALL(lowLatencyDevice, SetLatencyMarker(1ULL, VK_LATENCY_MARKER_OUT_OF_BAND_RENDERSUBMIT_START_NV))
                     .RETURN(S_OK);
 
                 REQUIRE(NvAPI_Initialize() == NVAPI_OK);
@@ -868,6 +868,20 @@ TEST_CASE("D3D12 methods succeed", "[.d3d12]") {
                 params.version = NV_ASYNC_FRAME_MARKER_PARAMS_VER1;
                 params.frameID = 123ULL;
                 params.markerType = OUT_OF_BAND_RENDERSUBMIT_START;
+                REQUIRE(NvAPI_D3D12_SetAsyncFrameMarker(&commandQueue, &params) == NVAPI_OK);
+            }
+
+            SECTION("SetAsyncFrameMarker drops PC_LATENCY_PING and returns OK") {
+                SetupResourceFactory(std::move(dxgiFactory), std::move(vulkan), std::move(nvml), std::move(lfx));
+
+                FORBID_CALL(lowLatencyDevice, SetLatencyMarker(_, _));
+
+                REQUIRE(NvAPI_Initialize() == NVAPI_OK);
+
+                NV_ASYNC_FRAME_MARKER_PARAMS params{};
+                params.version = NV_ASYNC_FRAME_MARKER_PARAMS_VER1;
+                params.frameID = 123ULL;
+                params.markerType = PC_LATENCY_PING;
                 REQUIRE(NvAPI_D3D12_SetAsyncFrameMarker(&commandQueue, &params) == NVAPI_OK);
             }
 


### PR DESCRIPTION
Unfortunately `NV_LATENCY_MARKER_TYPE` doesn't match `VkLatencyMarkerNV`, so we need to convert manually. Silently acknowledge, but ignore, calls with unsupported values.

cc: @esullivan-nvidia 