### PR TITLE
util: Log build target name

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -26,7 +26,9 @@ nvapi_src = files([
   'nvapi_interface.cpp',
 ])
 
-nvapi_dll = shared_library('nvapi'+target_suffix, [ nvapi_src, dxvk_nvapi_version ],
+target_name = 'nvapi'+target_suffix
+nvapi_dll = shared_library(target_name, [ nvapi_src, dxvk_nvapi_version ],
+  cpp_args            : '-DDXVK_NVAPI_TARGET_NAME="'+target_name+'"',
   name_prefix         : '',
   dependencies        : [ lib_dxgi, lib_d3d11, lib_version ],
   include_directories : [ nvapi_headers, vk_headers ],
@@ -47,7 +49,9 @@ nvofapi_src = files([
 
 # Only build 64-bit versions of nvofapi
 if dxvk_cpu_family == 'x86_64'
-  nvofapi_dll = shared_library('nvofapi'+target_suffix, [ nvofapi_src, dxvk_nvapi_version ],
+  target_name = 'nvofapi'+target_suffix
+  nvofapi_dll = shared_library(target_name, [ nvofapi_src, dxvk_nvapi_version ],
+    cpp_args            : '-DDXVK_NVAPI_TARGET_NAME="'+target_name+'"',
     name_prefix         : '',
     dependencies        : [ lib_version ],
     include_directories : [ nvapi_headers, vk_headers ],

--- a/src/util/util_log.cpp
+++ b/src/util/util_log.cpp
@@ -82,7 +82,7 @@ namespace dxvk::log {
             std::setfill('0'), std::setw(4), std::hex, ::GetCurrentProcessId(), ":",
             std::setfill('0'), std::setw(4), std::hex, ::GetCurrentThreadId(), ":",
             level, ":",
-            "dxvk-nvapi:",
+            DXVK_NVAPI_TARGET_NAME, ":",
             message);
 
         print(logMessage);

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -42,7 +42,9 @@ nvapi_tests_src = files([
   'util.cpp',
 ])
 
-nvapi_exe = executable('nvapi'+target_suffix+'-tests', [ nvapi_src, catch2_src, nvapi_tests_src, dxvk_nvapi_version ],
+target_name = 'nvapi'+target_suffix+'-tests'
+nvapi_exe = executable(target_name, [ nvapi_src, catch2_src, nvapi_tests_src, dxvk_nvapi_version ],
+  cpp_args            : '-DDXVK_NVAPI_TARGET_NAME="'+target_name+'"',
   dependencies        : [ lib_dxgi, lib_d3d11, lib_version ],
   include_directories : [ nvapi_headers, vk_headers ],
   install             : true)


### PR DESCRIPTION
Running the tests produces:

```
6627.084:011c:0120:info:nvapi64-tests:DXVK-NVAPI v0.7.1-101-gee9c8fd+ NVAPI gcc 13.1.0 x86_64 release (nvapi64-tests.exe)
```