### PR TITLE
util: Use build target name as log file name

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -27,7 +27,7 @@ Please describe your issue as accurately as possible including expected and actu
 ### Log files
 
 Please attach DXVK-NVAPI log files as a text file :
-- When using Proton, set the Steam launch options for your game to `DXVK_NVAPI_LOG_PATH=/tmp/ DXVK_NVAPI_LOG_LEVEL=info %command%` and attach the corresponding `dxvk-nvapi.log` file in your `/tmp/` directory.
+- When using Proton, set the Steam launch options for your game to `DXVK_NVAPI_LOG_PATH=/tmp/ DXVK_NVAPI_LOG_LEVEL=info %command%` and attach the corresponding `nvapi.log`/`nvapi64.log`/`nvofapi64.log` file in your `/tmp/` directory.
 - See [Tweaks, debugging and troubleshooting](https://github.com/jp7677/dxvk-nvapi/blob/master/README.md#tweaks-debugging-and-troubleshooting) for general information.
 
 Alternatively attach Proton logs as a text file:

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ The following environment variables tweak DXVK-NVAPI's runtime behavior:
   - `GA100` (Ampere)
   - `AD100` (Ada)
 - `DXVK_NVAPI_LOG_LEVEL` set to `info` prints log statements. The default behavior omits any logging. Please fill an issue if using log servery `info` creates log spam. Setting severity to `trace` logs all entry points enter and exits, this has a severe effect on performance. All other log levels will be interpreted as `none`.
-- `DXVK_NVAPI_LOG_PATH` enables file logging additionally to console output and sets the path where the log file `dxvk-nvapi.log` should be written to. Log statements are appended to an existing file. Please remove this file once in a while to prevent excessive grow. This requires `DXVK_NVAPI_LOG_LEVEL` set to `info` or `trace`.
+- `DXVK_NVAPI_LOG_PATH` enables file logging additionally to console output and sets the path where the log file `nvapi.log`/`nvapi64.log`/`nvofapi64.log` should be written to. Log statements are appended to an existing file. Please remove this file once in a while to prevent excessive grow. This requires `DXVK_NVAPI_LOG_LEVEL` set to `info` or `trace`.
 
 Additionally, GitHub Actions provide build artifacts from different toolchains. In very rare situations a non-gcc build might provide better results.
 

--- a/src/util/util_log.cpp
+++ b/src/util/util_log.cpp
@@ -26,7 +26,7 @@ namespace dxvk::log {
 
         constexpr auto logLevelEnvName = "DXVK_NVAPI_LOG_LEVEL";
         constexpr auto logPathEnvName = "DXVK_NVAPI_LOG_PATH";
-        constexpr auto logFileName = "dxvk-nvapi.log";
+        constexpr auto logFileName = DXVK_NVAPI_TARGET_NAME ".log";
 
         auto logLevel = env::getEnvVariable(logLevelEnvName);
         if (logLevel != "info" && logLevel != "trace") {
@@ -81,8 +81,7 @@ namespace dxvk::log {
             std::setfill('0'), std::setw(3), milliseconds, ":",
             std::setfill('0'), std::setw(4), std::hex, ::GetCurrentProcessId(), ":",
             std::setfill('0'), std::setw(4), std::hex, ::GetCurrentThreadId(), ":",
-            level, ":",
-            DXVK_NVAPI_TARGET_NAME, ":",
+            level, ":" DXVK_NVAPI_TARGET_NAME ":",
             message);
 
         print(logMessage);


### PR DESCRIPTION
So write to nvapi.log, nvapi64.log and nvofapi64.log separately.