### PR TITLE
nvapi: Rename Vulkan → Vk and rework its construction

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -11,7 +11,7 @@ nvapi_src = files([
   'nvapi/nvapi_adapter_registry.cpp',
   'nvapi/nvapi_adapter.cpp',
   'nvapi/nvapi_output.cpp',
-  'nvapi/vulkan.cpp',
+  'nvapi/vk.cpp',
   'nvapi/nvml.cpp',
   'nvapi_globals.cpp',
   'nvapi.cpp',

--- a/src/nvapi/nvapi_adapter.cpp
+++ b/src/nvapi/nvapi_adapter.cpp
@@ -6,8 +6,8 @@
 #include "../util/util_version.h"
 
 namespace dxvk {
-    NvapiAdapter::NvapiAdapter(Vulkan& vulkan, Nvml& nvml, Com<IDXGIAdapter3> dxgiAdapter)
-        : m_vulkan(vulkan), m_nvml(nvml), m_dxgiAdapter(std::move(dxgiAdapter)) {}
+    NvapiAdapter::NvapiAdapter(Vk& vk, Nvml& nvml, Com<IDXGIAdapter3> dxgiAdapter)
+        : m_vk(vk), m_nvml(nvml), m_dxgiAdapter(std::move(dxgiAdapter)) {}
 
     NvapiAdapter::~NvapiAdapter() = default;
 
@@ -36,7 +36,7 @@ namespace dxvk {
         VkPhysicalDevice vkDevice = VK_NULL_HANDLE;
         dxgiVkInteropAdapter->GetVulkanHandles(&vkInstance, &vkDevice);
 
-        m_vkExtensions = m_vulkan.GetDeviceExtensions(vkInstance, vkDevice);
+        m_vkExtensions = m_vk.GetDeviceExtensions(vkInstance, vkDevice);
         if (m_vkExtensions.empty())
             return false;
 
@@ -70,7 +70,7 @@ namespace dxvk {
         m_vkIdProperties.pNext = deviceProperties2.pNext;
         deviceProperties2.pNext = &m_vkIdProperties;
 
-        m_vulkan.GetPhysicalDeviceProperties2(vkInstance, vkDevice, &deviceProperties2);
+        m_vk.GetPhysicalDeviceProperties2(vkInstance, vkDevice, &deviceProperties2);
         m_vkProperties = deviceProperties2.properties;
 
         auto allowOtherDrivers = env::getEnvVariable(allowOtherDriversEnvName);
@@ -183,7 +183,7 @@ namespace dxvk {
     }
 
     NV_GPU_TYPE NvapiAdapter::GetGpuType() const {
-        return Vulkan::ToNvGpuType(m_vkProperties.deviceType);
+        return Vk::ToNvGpuType(m_vkProperties.deviceType);
     }
 
     uint32_t NvapiAdapter::GetPciBusId() const {

--- a/src/nvapi/nvapi_adapter.h
+++ b/src/nvapi/nvapi_adapter.h
@@ -2,7 +2,7 @@
 
 #include "../nvapi_private.h"
 #include "../util/com_pointer.h"
-#include "vulkan.h"
+#include "vk.h"
 #include "nvml.h"
 #include "nvapi_output.h"
 
@@ -10,7 +10,7 @@ namespace dxvk {
     class NvapiAdapter {
 
       public:
-        explicit NvapiAdapter(Vulkan& vulkan, Nvml& nvml, Com<IDXGIAdapter3> dxgiAdapter);
+        explicit NvapiAdapter(Vk& vk, Nvml& nvml, Com<IDXGIAdapter3> dxgiAdapter);
         ~NvapiAdapter();
 
         struct MemoryInfo {
@@ -57,7 +57,7 @@ namespace dxvk {
         [[nodiscard]] nvmlReturn_t GetNvmlDeviceDynamicPstatesInfo(nvmlGpuDynamicPstatesInfo_t* pDynamicPstatesInfo) const;
 
       private:
-        Vulkan& m_vulkan;
+        Vk& m_vk;
         Nvml& m_nvml;
         Com<IDXGIAdapter3> m_dxgiAdapter;
 

--- a/src/nvapi/nvapi_adapter_registry.cpp
+++ b/src/nvapi/nvapi_adapter_registry.cpp
@@ -29,8 +29,8 @@ namespace dxvk {
         if (m_dxgiFactory == nullptr)
             return false;
 
-        m_vulkan = m_resourceFactory.CreateVulkan(m_dxgiFactory);
-        if (m_vulkan == nullptr || !m_vulkan->IsAvailable())
+        m_vk = m_resourceFactory.CreateVulkan(m_dxgiFactory);
+        if (m_vk == nullptr || !m_vk->IsAvailable())
             return false;
 
         m_nvml = m_resourceFactory.CreateNvml();
@@ -48,7 +48,7 @@ namespace dxvk {
             if (FAILED(dxgiAdapter->QueryInterface(IID_PPV_ARGS(&dxgiAdapter3))))
                 continue;
 
-            auto nvapiAdapter = new NvapiAdapter(*m_vulkan, *m_nvml, dxgiAdapter3);
+            auto nvapiAdapter = new NvapiAdapter(*m_vk, *m_nvml, dxgiAdapter3);
             if (nvapiAdapter->Initialize(i, m_nvapiOutputs))
                 m_nvapiAdapters.push_back(nvapiAdapter);
             else

--- a/src/nvapi/nvapi_adapter_registry.h
+++ b/src/nvapi/nvapi_adapter_registry.h
@@ -4,7 +4,7 @@
 #include "resource_factory.h"
 #include "nvapi_adapter.h"
 #include "nvapi_output.h"
-#include "vulkan.h"
+#include "vk.h"
 #include "nvml.h"
 #include "../interfaces/dxvk_interfaces.h"
 
@@ -37,7 +37,7 @@ namespace dxvk {
         ResourceFactory& m_resourceFactory;
         Com<IDXGIFactory1> m_dxgiFactory;
         Com<IDXGIVkInteropFactory1> m_dxgiVkInterop;
-        std::unique_ptr<Vulkan> m_vulkan;
+        std::unique_ptr<Vk> m_vk;
         std::unique_ptr<Nvml> m_nvml;
         std::vector<NvapiAdapter*> m_nvapiAdapters;
         std::vector<NvapiOutput*> m_nvapiOutputs;

--- a/src/nvapi/resource_factory.h
+++ b/src/nvapi/resource_factory.h
@@ -2,7 +2,7 @@
 
 #include "../nvapi_private.h"
 #include "../util/com_pointer.h"
-#include "vulkan.h"
+#include "vk.h"
 #include "nvml.h"
 #include "lfx.h"
 
@@ -14,7 +14,8 @@ namespace dxvk {
         virtual ~ResourceFactory();
 
         virtual Com<IDXGIFactory1> CreateDXGIFactory1();
-        virtual std::unique_ptr<Vulkan> CreateVulkan(Com<IDXGIFactory1>& dxgiFactory);
+        virtual std::unique_ptr<Vk> CreateVulkan(Com<IDXGIFactory1>& dxgiFactory);
+        virtual std::unique_ptr<Vk> CreateVulkan(const char* moduleName);
         virtual std::unique_ptr<Nvml> CreateNvml();
         virtual std::unique_ptr<Lfx> CreateLfx();
     };

--- a/src/nvapi/vk.cpp
+++ b/src/nvapi/vk.cpp
@@ -1,17 +1,31 @@
-#include "vulkan.h"
+#include "vk.h"
+#include "../util/util_log.h"
 
 namespace dxvk {
-    Vulkan::Vulkan() = default;
-    Vulkan::Vulkan(Com<IDXGIFactory1> dxgiFactory, PFN_vkGetInstanceProcAddr vkGetInstanceProcAddr)
-        : m_dxgiFactory(std::move(dxgiFactory)), m_vkGetInstanceProcAddr(vkGetInstanceProcAddr) {}
+    Vk::Vk() = default;
 
-    Vulkan::~Vulkan() = default;
+    Vk::Vk(Com<IDXGIVkInteropFactory>&& dxgiVkInteropFactory)
+        : m_dxgiVkInteropFactory(dxgiVkInteropFactory) {
+        VkInstance vkInstance;
+        m_dxgiVkInteropFactory->GetVulkanInstance(&vkInstance, &m_vkGetInstanceProcAddr);
 
-    bool Vulkan::IsAvailable() const {
-        return m_vkGetInstanceProcAddr != nullptr;
+        if (vkInstance && m_vkGetInstanceProcAddr) {
+            log::info(str::format("Successfully acquired Vulkan vkGetInstanceProcAddr @ 0x", std::hex, reinterpret_cast<uintptr_t>(m_vkGetInstanceProcAddr)));
+
+            m_vkGetDeviceProcAddr = GetInstanceProcAddress<PFN_vkGetDeviceProcAddr>(vkInstance, "vkGetDeviceProcAddr");
+        }
     }
 
-    std::set<std::string> Vulkan::GetDeviceExtensions(VkInstance vkInstance, VkPhysicalDevice vkDevice) const {
+    Vk::Vk(PFN_vkGetInstanceProcAddr vkGetInstanceProcAddr, PFN_vkGetDeviceProcAddr vkGetDeviceProcAddr)
+        : m_vkGetInstanceProcAddr(vkGetInstanceProcAddr), m_vkGetDeviceProcAddr(vkGetDeviceProcAddr) {}
+
+    Vk::~Vk() = default;
+
+    bool Vk::IsAvailable() const {
+        return m_vkGetInstanceProcAddr != nullptr && m_vkGetDeviceProcAddr != nullptr;
+    }
+
+    std::set<std::string> Vk::GetDeviceExtensions(VkInstance vkInstance, VkPhysicalDevice vkDevice) const {
         auto vkEnumerateDeviceExtensionProperties =
             GetInstanceProcAddress<PFN_vkEnumerateDeviceExtensionProperties>(
                 vkInstance, "vkEnumerateDeviceExtensionProperties");
@@ -33,7 +47,7 @@ namespace dxvk {
         return deviceExtensions;
     }
 
-    void Vulkan::GetPhysicalDeviceProperties2(VkInstance vkInstance, VkPhysicalDevice vkDevice, VkPhysicalDeviceProperties2* deviceProperties2) const {
+    void Vk::GetPhysicalDeviceProperties2(VkInstance vkInstance, VkPhysicalDevice vkDevice, VkPhysicalDeviceProperties2* deviceProperties2) const {
         auto vkGetPhysicalDeviceProperties2 =
             GetInstanceProcAddress<PFN_vkGetPhysicalDeviceProperties2>(
                 vkInstance, "vkGetPhysicalDeviceProperties2");
@@ -41,7 +55,7 @@ namespace dxvk {
         vkGetPhysicalDeviceProperties2(vkDevice, deviceProperties2);
     }
 
-    NV_GPU_TYPE Vulkan::ToNvGpuType(VkPhysicalDeviceType vkDeviceType) {
+    NV_GPU_TYPE Vk::ToNvGpuType(VkPhysicalDeviceType vkDeviceType) {
         // Assert enum value equality between Vulkan and NVAPI at compile time
         static_assert(static_cast<int>(VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU) == static_cast<int>(NV_SYSTEM_TYPE_DGPU));
         static_assert(static_cast<int>(VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU) == static_cast<int>(NV_SYSTEM_TYPE_IGPU));
@@ -53,7 +67,7 @@ namespace dxvk {
     }
 
     template <typename T>
-    T Vulkan::GetInstanceProcAddress(VkInstance vkInstance, const char* name) const {
+    T Vk::GetInstanceProcAddress(VkInstance vkInstance, const char* name) const {
         return reinterpret_cast<T>(m_vkGetInstanceProcAddr(vkInstance, name));
     }
 }

--- a/src/nvapi/vk.h
+++ b/src/nvapi/vk.h
@@ -1,15 +1,17 @@
 #pragma once
 
 #include "../nvapi_private.h"
+#include "../interfaces/dxvk_interfaces.h"
 #include "../util/com_pointer.h"
 
 namespace dxvk {
-    class Vulkan {
+    class Vk {
 
       public:
-        Vulkan();
-        explicit Vulkan(Com<IDXGIFactory1> dxgiFactory, PFN_vkGetInstanceProcAddr vkGetInstanceProcAddr);
-        virtual ~Vulkan();
+        Vk();
+        explicit Vk(Com<IDXGIVkInteropFactory>&& dxgiVkInteropFactory);
+        explicit Vk(PFN_vkGetInstanceProcAddr vkGetInstanceProcAddr, PFN_vkGetDeviceProcAddr vkGetDeviceProcAddr);
+        virtual ~Vk();
 
         [[nodiscard]] virtual bool IsAvailable() const;
         [[nodiscard]] virtual std::set<std::string> GetDeviceExtensions(VkInstance vkInstance, VkPhysicalDevice vkDevice) const;
@@ -18,8 +20,9 @@ namespace dxvk {
         [[nodiscard]] static NV_GPU_TYPE ToNvGpuType(VkPhysicalDeviceType vkDeviceType);
 
       private:
-        Com<IDXGIFactory1> m_dxgiFactory;
+        Com<IDXGIVkInteropFactory> m_dxgiVkInteropFactory;
         PFN_vkGetInstanceProcAddr m_vkGetInstanceProcAddr{};
+        PFN_vkGetDeviceProcAddr m_vkGetDeviceProcAddr{};
 
         template <typename T>
         T GetInstanceProcAddress(VkInstance vkInstance, const char* name) const;

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -3,7 +3,7 @@ nvapi_src = files([
   '../src/util/util_env.cpp',
   '../src/util/util_log.cpp',
   '../src/nvapi/resource_factory.cpp',
-  '../src/nvapi/vulkan.cpp',
+  '../src/nvapi/vk.cpp',
   '../src/nvapi/nvml.cpp',
   '../src/nvapi/lfx.cpp',
   '../src/nvapi/nvapi_d3d_instance.cpp',

--- a/tests/mock_factory.h
+++ b/tests/mock_factory.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "nvapi_tests_private.h"
+#include "nvapi_d3d_mocks.h"
+#include "nvapi_sysinfo_mocks.h"
 #include "../src/nvapi/resource_factory.h"
 
 using namespace trompeloeil;
@@ -10,11 +12,11 @@ class MockFactory : public dxvk::ResourceFactory {
   public:
     MockFactory(
         std::unique_ptr<DXGIDxvkFactoryMock> dxgiFactory1Mock,
-        std::unique_ptr<VulkanMock> vulkanMock,
+        std::unique_ptr<VkMock> vkMock,
         std::unique_ptr<NvmlMock> nvmlMock,
         std::unique_ptr<LfxMock> lfxMock)
         : m_dxgiFactoryMock(std::move(dxgiFactory1Mock)),
-          m_vulkanMock(std::move(vulkanMock)),
+          m_vkMock(std::move(vkMock)),
           m_nvmlMock(std::move(nvmlMock)),
           m_lfxMock(std::move(lfxMock)) {};
 
@@ -22,8 +24,8 @@ class MockFactory : public dxvk::ResourceFactory {
         return m_dxgiFactoryMock.get();
     };
 
-    std::unique_ptr<dxvk::Vulkan> CreateVulkan(dxvk::Com<IDXGIFactory1>& dxgiFactory) override {
-        return std::move(m_vulkanMock);
+    std::unique_ptr<dxvk::Vk> CreateVulkan(dxvk::Com<IDXGIFactory1>& dxgiFactory) override {
+        return std::move(m_vkMock);
     }
 
     std::unique_ptr<dxvk::Nvml> CreateNvml() override {
@@ -40,7 +42,7 @@ class MockFactory : public dxvk::ResourceFactory {
 
   private:
     std::unique_ptr<DXGIDxvkFactoryMock> m_dxgiFactoryMock;
-    std::unique_ptr<VulkanMock> m_vulkanMock;
+    std::unique_ptr<VkMock> m_vkMock;
     std::unique_ptr<NvmlMock> m_nvmlMock;
     std::unique_ptr<LfxMock> m_lfxMock;
 };

--- a/tests/nvapi_d3d.cpp
+++ b/tests/nvapi_d3d.cpp
@@ -113,7 +113,7 @@ TEST_CASE("D3D methods succeed", "[.d3d]") {
 TEST_CASE("D3D Reflex/LatencyFleX depending methods succeed", "[.d3d]") {
     UnknownMock unknown;
     auto dxgiFactory = std::make_unique<DXGIDxvkFactoryMock>();
-    auto vulkan = std::make_unique<VulkanMock>();
+    auto vk = std::make_unique<VkMock>();
     auto nvml = std::make_unique<NvmlMock>();
     auto lfx = std::make_unique<LfxMock>();
     D3DLowLatencyDeviceMock lowLatencyDevice;
@@ -121,7 +121,7 @@ TEST_CASE("D3D Reflex/LatencyFleX depending methods succeed", "[.d3d]") {
     DXGIOutput6Mock* output = CreateDXGIOutput6Mock();
     auto lowLatencyDeviceRefCount = 0;
 
-    auto e = ConfigureDefaultTestEnvironment(*dxgiFactory, *vulkan, *nvml, *lfx, *adapter, *output);
+    auto e = ConfigureDefaultTestEnvironment(*dxgiFactory, *vk, *nvml, *lfx, *adapter, *output);
 
     ALLOW_CALL(unknown, QueryInterface(__uuidof(ID3DLowLatencyDevice), _))
         .RETURN(E_NOINTERFACE);
@@ -130,7 +130,7 @@ TEST_CASE("D3D Reflex/LatencyFleX depending methods succeed", "[.d3d]") {
         .RETURN(false);
 
     SECTION("Reflex methods fail when given null device") {
-        SetupResourceFactory(std::move(dxgiFactory), std::move(vulkan), std::move(nvml), std::move(lfx));
+        SetupResourceFactory(std::move(dxgiFactory), std::move(vk), std::move(nvml), std::move(lfx));
         REQUIRE(NvAPI_Initialize() == NVAPI_OK);
 
         SECTION("GetSleepStatus returns invalid-argument") {
@@ -167,7 +167,7 @@ TEST_CASE("D3D Reflex/LatencyFleX depending methods succeed", "[.d3d]") {
             .RETURN(true);
 
         SECTION("GetSleepStatus returns OK") {
-            SetupResourceFactory(std::move(dxgiFactory), std::move(vulkan), std::move(nvml), std::move(lfx));
+            SetupResourceFactory(std::move(dxgiFactory), std::move(vk), std::move(nvml), std::move(lfx));
             REQUIRE(NvAPI_Initialize() == NVAPI_OK);
 
             NV_GET_SLEEP_STATUS_PARAMS_V1 params{};
@@ -178,7 +178,7 @@ TEST_CASE("D3D Reflex/LatencyFleX depending methods succeed", "[.d3d]") {
         SECTION("SetSleepMode returns OK") {
             REQUIRE_CALL(*lfx, SetTargetFrameTime(250ULL * 1000));
 
-            SetupResourceFactory(std::move(dxgiFactory), std::move(vulkan), std::move(nvml), std::move(lfx));
+            SetupResourceFactory(std::move(dxgiFactory), std::move(vk), std::move(nvml), std::move(lfx));
             REQUIRE(NvAPI_Initialize() == NVAPI_OK);
 
             NV_SET_SLEEP_MODE_PARAMS_V1 params{};
@@ -192,7 +192,7 @@ TEST_CASE("D3D Reflex/LatencyFleX depending methods succeed", "[.d3d]") {
             REQUIRE_CALL(*lfx, SetTargetFrameTime(500ULL * 1000));
             REQUIRE_CALL(*lfx, WaitAndBeginFrame());
 
-            SetupResourceFactory(std::move(dxgiFactory), std::move(vulkan), std::move(nvml), std::move(lfx));
+            SetupResourceFactory(std::move(dxgiFactory), std::move(vk), std::move(nvml), std::move(lfx));
             REQUIRE(NvAPI_Initialize() == NVAPI_OK);
 
             NV_SET_SLEEP_MODE_PARAMS params{};
@@ -204,7 +204,7 @@ TEST_CASE("D3D Reflex/LatencyFleX depending methods succeed", "[.d3d]") {
         }
 
         SECTION("GetSleepStatus with unknown struct version returns incompatible-struct-version") {
-            SetupResourceFactory(std::move(dxgiFactory), std::move(vulkan), std::move(nvml), std::move(lfx));
+            SetupResourceFactory(std::move(dxgiFactory), std::move(vk), std::move(nvml), std::move(lfx));
             REQUIRE(NvAPI_Initialize() == NVAPI_OK);
 
             NV_GET_SLEEP_STATUS_PARAMS params{};
@@ -214,7 +214,7 @@ TEST_CASE("D3D Reflex/LatencyFleX depending methods succeed", "[.d3d]") {
 
         SECTION("GetSleepStatus with current struct version returns not incompatible-struct-version") {
             // This test should fail when a header update provides a newer not yet implemented struct version
-            SetupResourceFactory(std::move(dxgiFactory), std::move(vulkan), std::move(nvml), std::move(lfx));
+            SetupResourceFactory(std::move(dxgiFactory), std::move(vk), std::move(nvml), std::move(lfx));
             REQUIRE(NvAPI_Initialize() == NVAPI_OK);
 
             NV_GET_SLEEP_STATUS_PARAMS params{};
@@ -223,7 +223,7 @@ TEST_CASE("D3D Reflex/LatencyFleX depending methods succeed", "[.d3d]") {
         }
 
         SECTION("SetSleepMode with unknown struct version returns incompatible-struct-version") {
-            SetupResourceFactory(std::move(dxgiFactory), std::move(vulkan), std::move(nvml), std::move(lfx));
+            SetupResourceFactory(std::move(dxgiFactory), std::move(vk), std::move(nvml), std::move(lfx));
             REQUIRE(NvAPI_Initialize() == NVAPI_OK);
 
             NV_SET_SLEEP_MODE_PARAMS params{};
@@ -233,7 +233,7 @@ TEST_CASE("D3D Reflex/LatencyFleX depending methods succeed", "[.d3d]") {
 
         SECTION("SetSleepMode with current struct version returns not incompatible-struct-version") {
             // This test should fail when a header update provides a newer not yet implemented struct version
-            SetupResourceFactory(std::move(dxgiFactory), std::move(vulkan), std::move(nvml), std::move(lfx));
+            SetupResourceFactory(std::move(dxgiFactory), std::move(vk), std::move(nvml), std::move(lfx));
             REQUIRE(NvAPI_Initialize() == NVAPI_OK);
 
             NV_SET_SLEEP_MODE_PARAMS params{};
@@ -243,7 +243,7 @@ TEST_CASE("D3D Reflex/LatencyFleX depending methods succeed", "[.d3d]") {
     }
 
     SECTION("LatencyFleX depending methods succeed when LFX is unavailable") {
-        SetupResourceFactory(std::move(dxgiFactory), std::move(vulkan), std::move(nvml), std::move(lfx));
+        SetupResourceFactory(std::move(dxgiFactory), std::move(vk), std::move(nvml), std::move(lfx));
         REQUIRE(NvAPI_Initialize() == NVAPI_OK);
 
         SECTION("GetSleepStatus returns NoImplementation") {
@@ -291,7 +291,7 @@ TEST_CASE("D3D Reflex/LatencyFleX depending methods succeed", "[.d3d]") {
             .RETURN(false);
 
         SECTION("D3DLowLatencyDevice does not support low latency") {
-            SetupResourceFactory(std::move(dxgiFactory), std::move(vulkan), std::move(nvml), std::move(lfx));
+            SetupResourceFactory(std::move(dxgiFactory), std::move(vk), std::move(nvml), std::move(lfx));
             REQUIRE(NvAPI_Initialize() == NVAPI_OK);
 
             SECTION("GetSleepStatus returns NoImplementation") {
@@ -334,7 +334,7 @@ TEST_CASE("D3D Reflex/LatencyFleX depending methods succeed", "[.d3d]") {
                 REQUIRE_CALL(lowLatencyDevice, SupportsLowLatency())
                     .RETURN(true);
 
-                SetupResourceFactory(std::move(dxgiFactory), std::move(vulkan), std::move(nvml), std::move(lfx));
+                SetupResourceFactory(std::move(dxgiFactory), std::move(vk), std::move(nvml), std::move(lfx));
                 REQUIRE(NvAPI_Initialize() == NVAPI_OK);
 
                 NV_GET_SLEEP_STATUS_PARAMS_V1 params{};
@@ -348,7 +348,7 @@ TEST_CASE("D3D Reflex/LatencyFleX depending methods succeed", "[.d3d]") {
                 REQUIRE_CALL(lowLatencyDevice, SetLatencySleepMode(true, false, 250U))
                     .RETURN(S_OK);
 
-                SetupResourceFactory(std::move(dxgiFactory), std::move(vulkan), std::move(nvml), std::move(lfx));
+                SetupResourceFactory(std::move(dxgiFactory), std::move(vk), std::move(nvml), std::move(lfx));
                 REQUIRE(NvAPI_Initialize() == NVAPI_OK);
 
                 NV_SET_SLEEP_MODE_PARAMS_V1 params{};
@@ -367,7 +367,7 @@ TEST_CASE("D3D Reflex/LatencyFleX depending methods succeed", "[.d3d]") {
                 REQUIRE_CALL(lowLatencyDevice, LatencySleep())
                     .RETURN(S_OK);
 
-                SetupResourceFactory(std::move(dxgiFactory), std::move(vulkan), std::move(nvml), std::move(lfx));
+                SetupResourceFactory(std::move(dxgiFactory), std::move(vk), std::move(nvml), std::move(lfx));
                 REQUIRE(NvAPI_Initialize() == NVAPI_OK);
 
                 NV_SET_SLEEP_MODE_PARAMS sleepModeParams{};
@@ -386,7 +386,7 @@ TEST_CASE("D3D Reflex/LatencyFleX depending methods succeed", "[.d3d]") {
                 REQUIRE_CALL(lowLatencyDevice, SetLatencyMarker(1ULL, VK_LATENCY_MARKER_SIMULATION_START_NV))
                     .RETURN(S_OK);
 
-                SetupResourceFactory(std::move(dxgiFactory), std::move(vulkan), std::move(nvml), std::move(lfx));
+                SetupResourceFactory(std::move(dxgiFactory), std::move(vk), std::move(nvml), std::move(lfx));
                 REQUIRE(NvAPI_Initialize() == NVAPI_OK);
 
                 NV_SET_SLEEP_MODE_PARAMS sleepModeParams{};
@@ -405,7 +405,7 @@ TEST_CASE("D3D Reflex/LatencyFleX depending methods succeed", "[.d3d]") {
             SECTION("SetLatencyMarker drops PC_LATENCY_PING and returns OK") {
                 FORBID_CALL(lowLatencyDevice, SetLatencyMarker(_, _));
 
-                SetupResourceFactory(std::move(dxgiFactory), std::move(vulkan), std::move(nvml), std::move(lfx));
+                SetupResourceFactory(std::move(dxgiFactory), std::move(vk), std::move(nvml), std::move(lfx));
                 REQUIRE(NvAPI_Initialize() == NVAPI_OK);
 
                 NV_LATENCY_MARKER_PARAMS latencyMarkerParams{};
@@ -419,7 +419,7 @@ TEST_CASE("D3D Reflex/LatencyFleX depending methods succeed", "[.d3d]") {
                 REQUIRE_CALL(lowLatencyDevice, SetLatencySleepMode(true, false, 750U))
                     .RETURN(S_OK);
 
-                SetupResourceFactory(std::move(dxgiFactory), std::move(vulkan), std::move(nvml), std::move(lfx));
+                SetupResourceFactory(std::move(dxgiFactory), std::move(vk), std::move(nvml), std::move(lfx));
                 REQUIRE(NvAPI_Initialize() == NVAPI_OK);
 
                 NV_SET_SLEEP_MODE_PARAMS sleepModeParams{};
@@ -462,7 +462,7 @@ TEST_CASE("D3D Reflex/LatencyFleX depending methods succeed", "[.d3d]") {
                 REQUIRE_CALL(lowLatencyDevice, SetLatencySleepMode(true, false, 750U))
                     .RETURN(S_OK);
 
-                SetupResourceFactory(std::move(dxgiFactory), std::move(vulkan), std::move(nvml), std::move(lfx));
+                SetupResourceFactory(std::move(dxgiFactory), std::move(vk), std::move(nvml), std::move(lfx));
                 REQUIRE(NvAPI_Initialize() == NVAPI_OK);
 
                 NV_SET_SLEEP_MODE_PARAMS sleepModeParams{};
@@ -513,7 +513,7 @@ TEST_CASE("D3D Reflex/LatencyFleX depending methods succeed", "[.d3d]") {
             }
 
             SECTION("SetLatencyMarker with unknown struct version returns incompatible-struct-version") {
-                SetupResourceFactory(std::move(dxgiFactory), std::move(vulkan), std::move(nvml), std::move(lfx));
+                SetupResourceFactory(std::move(dxgiFactory), std::move(vk), std::move(nvml), std::move(lfx));
 
                 REQUIRE(NvAPI_Initialize() == NVAPI_OK);
 
@@ -523,7 +523,7 @@ TEST_CASE("D3D Reflex/LatencyFleX depending methods succeed", "[.d3d]") {
             }
 
             SECTION("SetLatencyMarker with current struct version returns not incompatible-struct-version") {
-                SetupResourceFactory(std::move(dxgiFactory), std::move(vulkan), std::move(nvml), std::move(lfx));
+                SetupResourceFactory(std::move(dxgiFactory), std::move(vk), std::move(nvml), std::move(lfx));
 
                 ALLOW_CALL(lowLatencyDevice, SetLatencyMarker(_, _))
                     .RETURN(S_OK);
@@ -541,7 +541,7 @@ TEST_CASE("D3D Reflex/LatencyFleX depending methods succeed", "[.d3d]") {
                 REQUIRE_CALL(lowLatencyDevice, GetLatencyInfo(_))
                     .RETURN(S_OK);
 
-                SetupResourceFactory(std::move(dxgiFactory), std::move(vulkan), std::move(nvml), std::move(lfx));
+                SetupResourceFactory(std::move(dxgiFactory), std::move(vk), std::move(nvml), std::move(lfx));
                 REQUIRE(NvAPI_Initialize() == NVAPI_OK);
 
                 NV_SET_SLEEP_MODE_PARAMS sleepModeParams{};
@@ -566,7 +566,7 @@ TEST_CASE("D3D Reflex/LatencyFleX depending methods succeed", "[.d3d]") {
 
                 FORBID_CALL(lowLatencyDevice, SetLatencySleepMode(_, _, _));
 
-                SetupResourceFactory(std::move(dxgiFactory), std::move(vulkan), std::move(nvml), std::move(lfx));
+                SetupResourceFactory(std::move(dxgiFactory), std::move(vk), std::move(nvml), std::move(lfx));
                 REQUIRE(NvAPI_Initialize() == NVAPI_OK);
 
                 NV_SET_SLEEP_MODE_PARAMS_V1 params{};
@@ -583,7 +583,7 @@ TEST_CASE("D3D Reflex/LatencyFleX depending methods succeed", "[.d3d]") {
                 FORBID_CALL(lowLatencyDevice, SetLatencySleepMode(_, _, _));
                 FORBID_CALL(lowLatencyDevice, LatencySleep());
 
-                SetupResourceFactory(std::move(dxgiFactory), std::move(vulkan), std::move(nvml), std::move(lfx));
+                SetupResourceFactory(std::move(dxgiFactory), std::move(vk), std::move(nvml), std::move(lfx));
                 REQUIRE(NvAPI_Initialize() == NVAPI_OK);
 
                 NV_SET_SLEEP_MODE_PARAMS params{};
@@ -595,7 +595,7 @@ TEST_CASE("D3D Reflex/LatencyFleX depending methods succeed", "[.d3d]") {
             }
 
             SECTION("GetLatency returns no-implementation") {
-                SetupResourceFactory(std::move(dxgiFactory), std::move(vulkan), std::move(nvml), std::move(lfx));
+                SetupResourceFactory(std::move(dxgiFactory), std::move(vk), std::move(nvml), std::move(lfx));
                 REQUIRE(NvAPI_Initialize() == NVAPI_OK);
 
                 NV_LATENCY_RESULT_PARAMS params;
@@ -604,7 +604,7 @@ TEST_CASE("D3D Reflex/LatencyFleX depending methods succeed", "[.d3d]") {
             }
 
             SECTION("SetLatencyMarker returns no-implementation") {
-                SetupResourceFactory(std::move(dxgiFactory), std::move(vulkan), std::move(nvml), std::move(lfx));
+                SetupResourceFactory(std::move(dxgiFactory), std::move(vk), std::move(nvml), std::move(lfx));
                 REQUIRE(NvAPI_Initialize() == NVAPI_OK);
 
                 NV_LATENCY_MARKER_PARAMS params;

--- a/tests/nvapi_d3d11.cpp
+++ b/tests/nvapi_d3d11.cpp
@@ -438,15 +438,15 @@ TEST_CASE("D3D11 methods succeed", "[.d3d11]") {
 
 TEST_CASE("D3D11 MultiGPU methods succeed", "[.d3d11]") {
     auto dxgiFactory = std::make_unique<DXGIDxvkFactoryMock>();
-    auto vulkan = std::make_unique<VulkanMock>();
+    auto vk = std::make_unique<VkMock>();
     auto nvml = std::make_unique<NvmlMock>();
     auto lfx = std::make_unique<LfxMock>();
     DXGIDxvkAdapterMock* adapter = CreateDXGIDxvkAdapterMock();
     DXGIOutput6Mock* output = CreateDXGIOutput6Mock();
 
-    auto e = ConfigureDefaultTestEnvironment(*dxgiFactory, *vulkan, *nvml, *lfx, *adapter, *output);
+    auto e = ConfigureDefaultTestEnvironment(*dxgiFactory, *vk, *nvml, *lfx, *adapter, *output);
 
-    SetupResourceFactory(std::move(dxgiFactory), std::move(vulkan), std::move(nvml), std::move(lfx));
+    SetupResourceFactory(std::move(dxgiFactory), std::move(vk), std::move(nvml), std::move(lfx));
     REQUIRE(NvAPI_Initialize() == NVAPI_OK);
 
     SECTION("MultiGPU_GetCaps (V1) returns OK") {

--- a/tests/nvapi_d3d12.cpp
+++ b/tests/nvapi_d3d12.cpp
@@ -184,14 +184,14 @@ TEST_CASE("D3D12 methods succeed", "[.d3d12]") {
 
     SECTION("GetGraphicsCapabilities succeeds") {
         auto dxgiFactory = std::make_unique<DXGIDxvkFactoryMock>();
-        auto vulkan = std::make_unique<VulkanMock>();
+        auto vk = std::make_unique<VkMock>();
         auto nvml = std::make_unique<NvmlMock>();
         auto lfx = std::make_unique<LfxMock>();
         DXGIDxvkAdapterMock* adapter = CreateDXGIDxvkAdapterMock();
         DXGIOutput6Mock* output = CreateDXGIOutput6Mock();
         LUID luid{};
 
-        auto e = ConfigureDefaultTestEnvironment(*dxgiFactory, *vulkan, *nvml, *lfx, *adapter, *output);
+        auto e = ConfigureDefaultTestEnvironment(*dxgiFactory, *vk, *nvml, *lfx, *adapter, *output);
 
         ALLOW_CALL(device, QueryInterface(__uuidof(ID3D12Device), _))
             .LR_SIDE_EFFECT(*_2 = static_cast<ID3D12Device*>(&device))
@@ -214,7 +214,7 @@ TEST_CASE("D3D12 methods succeed", "[.d3d12]") {
 #endif
 
         SECTION("GetGraphicsCapabilities without matching adapter returns OK with sm_0") {
-            SetupResourceFactory(std::move(dxgiFactory), std::move(vulkan), std::move(nvml), std::move(lfx));
+            SetupResourceFactory(std::move(dxgiFactory), std::move(vk), std::move(nvml), std::move(lfx));
             REQUIRE(NvAPI_Initialize() == NVAPI_OK);
 
             NV_D3D12_GRAPHICS_CAPS graphicsCaps{};
@@ -251,9 +251,9 @@ TEST_CASE("D3D12 methods succeed", "[.d3d12]") {
             luid.HighPart = 0x00000002;
             luid.LowPart = 0x00000001;
 
-            ALLOW_CALL(*vulkan, GetDeviceExtensions(_, _))
+            ALLOW_CALL(*vk, GetDeviceExtensions(_, _))
                 .RETURN(std::set<std::string>{VK_KHR_DRIVER_PROPERTIES_EXTENSION_NAME, args.extensionName});
-            ALLOW_CALL(*vulkan, GetPhysicalDeviceProperties2(_, _, _))
+            ALLOW_CALL(*vk, GetPhysicalDeviceProperties2(_, _, _))
                 .SIDE_EFFECT(
                     ConfigureGetPhysicalDeviceProperties2(_3,
                         [&args, &luid](auto props, auto idProps, auto pciBusInfoProps, auto driverProps, auto fragmentShadingRateProps) {
@@ -265,7 +265,7 @@ TEST_CASE("D3D12 methods succeed", "[.d3d12]") {
                                 fragmentShadingRateProps->primitiveFragmentShadingRateWithMultipleViewports = VK_TRUE;
                         }));
 
-            SetupResourceFactory(std::move(dxgiFactory), std::move(vulkan), std::move(nvml), std::move(lfx));
+            SetupResourceFactory(std::move(dxgiFactory), std::move(vk), std::move(nvml), std::move(lfx));
             REQUIRE(NvAPI_Initialize() == NVAPI_OK);
 
             NV_D3D12_GRAPHICS_CAPS graphicsCaps;
@@ -279,7 +279,7 @@ TEST_CASE("D3D12 methods succeed", "[.d3d12]") {
         }
 
         SECTION("GetGraphicsCapabilities with unknown struct version returns incompatible-struct-version") {
-            SetupResourceFactory(std::move(dxgiFactory), std::move(vulkan), std::move(nvml), std::move(lfx));
+            SetupResourceFactory(std::move(dxgiFactory), std::move(vk), std::move(nvml), std::move(lfx));
             REQUIRE(NvAPI_Initialize() == NVAPI_OK);
 
             NV_D3D12_GRAPHICS_CAPS graphicsCaps{};
@@ -288,7 +288,7 @@ TEST_CASE("D3D12 methods succeed", "[.d3d12]") {
 
         SECTION("GetGraphicsCapabilities with current struct version returns not incompatible-struct-version") {
             // This test should fail when a header update provides a newer not yet implemented struct version
-            SetupResourceFactory(std::move(dxgiFactory), std::move(vulkan), std::move(nvml), std::move(lfx));
+            SetupResourceFactory(std::move(dxgiFactory), std::move(vk), std::move(nvml), std::move(lfx));
             REQUIRE(NvAPI_Initialize() == NVAPI_OK);
 
             NV_D3D12_GRAPHICS_CAPS graphicsCaps{};
@@ -800,13 +800,13 @@ TEST_CASE("D3D12 methods succeed", "[.d3d12]") {
 
     SECTION("D3DLowLatencyDevice methods succeed") {
         auto dxgiFactory = std::make_unique<DXGIDxvkFactoryMock>();
-        auto vulkan = std::make_unique<VulkanMock>();
+        auto vk = std::make_unique<VkMock>();
         auto nvml = std::make_unique<NvmlMock>();
         auto lfx = std::make_unique<LfxMock>();
         DXGIDxvkAdapterMock* adapter = CreateDXGIDxvkAdapterMock();
         DXGIOutput6Mock* output = CreateDXGIOutput6Mock();
 
-        auto e = ConfigureDefaultTestEnvironment(*dxgiFactory, *vulkan, *nvml, *lfx, *adapter, *output);
+        auto e = ConfigureDefaultTestEnvironment(*dxgiFactory, *vk, *nvml, *lfx, *adapter, *output);
 
         ALLOW_CALL(commandQueue, GetDevice(__uuidof(ID3DLowLatencyDevice), _))
             .LR_SIDE_EFFECT(*_2 = static_cast<ID3DLowLatencyDevice*>(&lowLatencyDevice))
@@ -828,7 +828,7 @@ TEST_CASE("D3D12 methods succeed", "[.d3d12]") {
 
         SECTION("NotifyOutOfBandCommandQueue succeeds") {
             SECTION("NotifyOutOfBandCommandQueue returns OK") {
-                SetupResourceFactory(std::move(dxgiFactory), std::move(vulkan), std::move(nvml), std::move(lfx));
+                SetupResourceFactory(std::move(dxgiFactory), std::move(vk), std::move(nvml), std::move(lfx));
 
                 REQUIRE_CALL(commandQueue, NotifyOutOfBandCommandQueue(static_cast<D3D12_OUT_OF_BAND_CQ_TYPE>(OUT_OF_BAND_RENDER)))
                     .RETURN(S_OK);
@@ -841,14 +841,14 @@ TEST_CASE("D3D12 methods succeed", "[.d3d12]") {
                 ALLOW_CALL(*lfx, IsAvailable())
                     .RETURN(true);
 
-                SetupResourceFactory(std::move(dxgiFactory), std::move(vulkan), std::move(nvml), std::move(lfx));
+                SetupResourceFactory(std::move(dxgiFactory), std::move(vk), std::move(nvml), std::move(lfx));
 
                 REQUIRE(NvAPI_Initialize() == NVAPI_OK);
                 REQUIRE(NvAPI_D3D12_NotifyOutOfBandCommandQueue(&commandQueue, OUT_OF_BAND_RENDER) == NVAPI_NO_IMPLEMENTATION);
             }
 
             SECTION("NotifyOutOfBandCommandQueue with null command queue returns invalid-pointer") {
-                SetupResourceFactory(std::move(dxgiFactory), std::move(vulkan), std::move(nvml), std::move(lfx));
+                SetupResourceFactory(std::move(dxgiFactory), std::move(vk), std::move(nvml), std::move(lfx));
 
                 REQUIRE(NvAPI_Initialize() == NVAPI_OK);
                 REQUIRE(NvAPI_D3D12_NotifyOutOfBandCommandQueue(nullptr, OUT_OF_BAND_RENDER) == NVAPI_INVALID_POINTER);
@@ -857,7 +857,7 @@ TEST_CASE("D3D12 methods succeed", "[.d3d12]") {
 
         SECTION("SetAsyncFrameMarker succeeds") {
             SECTION("SetAsyncFrameMarker returns OK") {
-                SetupResourceFactory(std::move(dxgiFactory), std::move(vulkan), std::move(nvml), std::move(lfx));
+                SetupResourceFactory(std::move(dxgiFactory), std::move(vk), std::move(nvml), std::move(lfx));
 
                 REQUIRE_CALL(lowLatencyDevice, SetLatencyMarker(1ULL, VK_LATENCY_MARKER_OUT_OF_BAND_RENDERSUBMIT_START_NV))
                     .RETURN(S_OK);
@@ -872,7 +872,7 @@ TEST_CASE("D3D12 methods succeed", "[.d3d12]") {
             }
 
             SECTION("SetAsyncFrameMarker drops PC_LATENCY_PING and returns OK") {
-                SetupResourceFactory(std::move(dxgiFactory), std::move(vulkan), std::move(nvml), std::move(lfx));
+                SetupResourceFactory(std::move(dxgiFactory), std::move(vk), std::move(nvml), std::move(lfx));
 
                 FORBID_CALL(lowLatencyDevice, SetLatencyMarker(_, _));
 
@@ -889,7 +889,7 @@ TEST_CASE("D3D12 methods succeed", "[.d3d12]") {
                 ALLOW_CALL(*lfx, IsAvailable())
                     .RETURN(true);
 
-                SetupResourceFactory(std::move(dxgiFactory), std::move(vulkan), std::move(nvml), std::move(lfx));
+                SetupResourceFactory(std::move(dxgiFactory), std::move(vk), std::move(nvml), std::move(lfx));
 
                 REQUIRE(NvAPI_Initialize() == NVAPI_OK);
 
@@ -899,7 +899,7 @@ TEST_CASE("D3D12 methods succeed", "[.d3d12]") {
             }
 
             SECTION("SetAsyncFrameMarker with unknown struct version returns incompatible-struct-version") {
-                SetupResourceFactory(std::move(dxgiFactory), std::move(vulkan), std::move(nvml), std::move(lfx));
+                SetupResourceFactory(std::move(dxgiFactory), std::move(vk), std::move(nvml), std::move(lfx));
 
                 REQUIRE(NvAPI_Initialize() == NVAPI_OK);
 
@@ -909,7 +909,7 @@ TEST_CASE("D3D12 methods succeed", "[.d3d12]") {
             }
 
             SECTION("SetAsyncFrameMarker with current struct version returns not incompatible-struct-version") {
-                SetupResourceFactory(std::move(dxgiFactory), std::move(vulkan), std::move(nvml), std::move(lfx));
+                SetupResourceFactory(std::move(dxgiFactory), std::move(vk), std::move(nvml), std::move(lfx));
 
                 ALLOW_CALL(lowLatencyDevice, SetLatencyMarker(_, _))
                     .RETURN(S_OK);
@@ -922,7 +922,7 @@ TEST_CASE("D3D12 methods succeed", "[.d3d12]") {
             }
 
             SECTION("SetAsyncFrameMarker with null command queue returns invalid-pointer") {
-                SetupResourceFactory(std::move(dxgiFactory), std::move(vulkan), std::move(nvml), std::move(lfx));
+                SetupResourceFactory(std::move(dxgiFactory), std::move(vk), std::move(nvml), std::move(lfx));
 
                 REQUIRE(NvAPI_Initialize() == NVAPI_OK);
 

--- a/tests/nvapi_sysinfo_hdr.cpp
+++ b/tests/nvapi_sysinfo_hdr.cpp
@@ -7,13 +7,13 @@ using namespace Catch::Matchers;
 
 TEST_CASE("HDR related sysinfo methods succeed", "[.sysinfo-hdr]") {
     auto dxgiFactory = std::make_unique<DXGIDxvkFactoryMock>();
-    auto vulkan = std::make_unique<VulkanMock>();
+    auto vk = std::make_unique<VkMock>();
     auto nvml = std::make_unique<NvmlMock>();
     auto lfx = std::make_unique<LfxMock>();
     DXGIDxvkAdapterMock* adapter = CreateDXGIDxvkAdapterMock();
     DXGIOutput6Mock* output = CreateDXGIOutput6Mock();
 
-    auto e = ConfigureDefaultTestEnvironment(*dxgiFactory, *vulkan, *nvml, *lfx, *adapter, *output);
+    auto e = ConfigureDefaultTestEnvironment(*dxgiFactory, *vk, *nvml, *lfx, *adapter, *output);
     auto primaryDisplayId = 0x00010001;
 
     auto desc1 = DXGI_OUTPUT_DESC1{
@@ -40,7 +40,7 @@ TEST_CASE("HDR related sysinfo methods succeed", "[.sysinfo-hdr]") {
         .RETURN(S_OK);
 
     SECTION("GetHdrCapabilities succeeds") {
-        SetupResourceFactory(std::move(dxgiFactory), std::move(vulkan), std::move(nvml), std::move(lfx));
+        SetupResourceFactory(std::move(dxgiFactory), std::move(vk), std::move(nvml), std::move(lfx));
         REQUIRE(NvAPI_Initialize() == NVAPI_OK);
 
         SECTION("GetHdrCapabilities (V1) returns OK") {
@@ -151,7 +151,7 @@ TEST_CASE("HDR related sysinfo methods succeed", "[.sysinfo-hdr]") {
             })
             .RETURN(S_OK);
 
-        SetupResourceFactory(std::move(dxgiFactory), std::move(vulkan), std::move(nvml), std::move(lfx));
+        SetupResourceFactory(std::move(dxgiFactory), std::move(vk), std::move(nvml), std::move(lfx));
         REQUIRE(NvAPI_Initialize() == NVAPI_OK);
 
         SECTION("HdrColorControl (V1) with get command returns OK") {
@@ -285,7 +285,7 @@ TEST_CASE("HDR related sysinfo methods succeed", "[.sysinfo-hdr]") {
         ALLOW_CALL(*dxgiFactory, GetGlobalHDRState(_, _))
             .RETURN(E_FAIL);
 
-        SetupResourceFactory(std::move(dxgiFactory), std::move(vulkan), std::move(nvml), std::move(lfx));
+        SetupResourceFactory(std::move(dxgiFactory), std::move(vk), std::move(nvml), std::move(lfx));
         REQUIRE(NvAPI_Initialize() == NVAPI_OK);
 
         SECTION("HdrColorControl (V1) with get command returns OK") {
@@ -338,7 +338,7 @@ TEST_CASE("HDR related sysinfo methods succeed", "[.sysinfo-hdr]") {
         ALLOW_CALL(*dxgiFactory, QueryInterface(__uuidof(IDXGIVkInteropFactory1), _))
             .RETURN(E_NOINTERFACE);
 
-        SetupResourceFactory(std::move(dxgiFactory), std::move(vulkan), std::move(nvml), std::move(lfx));
+        SetupResourceFactory(std::move(dxgiFactory), std::move(vk), std::move(nvml), std::move(lfx));
         REQUIRE(NvAPI_Initialize() == NVAPI_OK);
 
         SECTION("HdrColorControl (V1) returns no-implementation") {

--- a/tests/nvapi_sysinfo_mocks.h
+++ b/tests/nvapi_sysinfo_mocks.h
@@ -2,7 +2,7 @@
 
 #include "nvapi_tests_private.h"
 #include "../src/interfaces/dxvk_interfaces.h"
-#include "../src/nvapi/vulkan.h"
+#include "../src/nvapi/vk.h"
 #include "../src/nvapi/nvml.h"
 
 class IDXGIDxvkFactoryMock : public IDXGIFactory1, public IDXGIVkInteropFactory1 {};
@@ -83,7 +83,7 @@ class DXGIOutput6Mock final : public trompeloeil::mock_interface<IDXGIOutput6> {
     IMPLEMENT_MOCK1(CheckHardwareCompositionSupport);
 };
 
-class VulkanMock final : public trompeloeil::mock_interface<dxvk::Vulkan> {
+class VkMock final : public trompeloeil::mock_interface<dxvk::Vk> {
     IMPLEMENT_CONST_MOCK0(IsAvailable);
     IMPLEMENT_CONST_MOCK2(GetDeviceExtensions);
     IMPLEMENT_CONST_MOCK3(GetPhysicalDeviceProperties2);

--- a/tests/nvapi_sysinfo_nvml.cpp
+++ b/tests/nvapi_sysinfo_nvml.cpp
@@ -7,13 +7,13 @@ using namespace Catch::Matchers;
 
 TEST_CASE("NVML related sysinfo methods succeed", "[.sysinfo-nvml]") {
     auto dxgiFactory = std::make_unique<DXGIDxvkFactoryMock>();
-    auto vulkan = std::make_unique<VulkanMock>();
+    auto vk = std::make_unique<VkMock>();
     auto nvml = std::make_unique<NvmlMock>();
     auto lfx = std::make_unique<LfxMock>();
     DXGIDxvkAdapterMock* adapter = CreateDXGIDxvkAdapterMock();
     DXGIOutput6Mock* output = CreateDXGIOutput6Mock();
 
-    auto e = ConfigureDefaultTestEnvironment(*dxgiFactory, *vulkan, *nvml, *lfx, *adapter, *output);
+    auto e = ConfigureDefaultTestEnvironment(*dxgiFactory, *vk, *nvml, *lfx, *adapter, *output);
     auto primaryDisplayId = 0x00010001;
 
     SECTION("NVML depending methods succeed when NVML is available") {
@@ -32,7 +32,7 @@ TEST_CASE("NVML related sysinfo methods succeed", "[.sysinfo-nvml]") {
                 .LR_SIDE_EFFECT(*_2 = linkWidth)
                 .RETURN(NVML_SUCCESS);
 
-            SetupResourceFactory(std::move(dxgiFactory), std::move(vulkan), std::move(nvml), std::move(lfx));
+            SetupResourceFactory(std::move(dxgiFactory), std::move(vk), std::move(nvml), std::move(lfx));
             REQUIRE(NvAPI_Initialize() == NVAPI_OK);
 
             NvPhysicalGpuHandle handle;
@@ -49,7 +49,7 @@ TEST_CASE("NVML related sysinfo methods succeed", "[.sysinfo-nvml]") {
                 .LR_SIDE_EFFECT(*_2 = irqNum)
                 .RETURN(NVML_SUCCESS);
 
-            SetupResourceFactory(std::move(dxgiFactory), std::move(vulkan), std::move(nvml), std::move(lfx));
+            SetupResourceFactory(std::move(dxgiFactory), std::move(vk), std::move(nvml), std::move(lfx));
             REQUIRE(NvAPI_Initialize() == NVAPI_OK);
 
             NvPhysicalGpuHandle handle;
@@ -66,7 +66,7 @@ TEST_CASE("NVML related sysinfo methods succeed", "[.sysinfo-nvml]") {
                 .LR_SIDE_EFFECT(*_2 = cores)
                 .RETURN(NVML_SUCCESS);
 
-            SetupResourceFactory(std::move(dxgiFactory), std::move(vulkan), std::move(nvml), std::move(lfx));
+            SetupResourceFactory(std::move(dxgiFactory), std::move(vk), std::move(nvml), std::move(lfx));
             REQUIRE(NvAPI_Initialize() == NVAPI_OK);
 
             NvPhysicalGpuHandle handle;
@@ -83,7 +83,7 @@ TEST_CASE("NVML related sysinfo methods succeed", "[.sysinfo-nvml]") {
                 .LR_SIDE_EFFECT(_2->pciSubSystemId = id)
                 .RETURN(NVML_SUCCESS);
 
-            SetupResourceFactory(std::move(dxgiFactory), std::move(vulkan), std::move(nvml), std::move(lfx));
+            SetupResourceFactory(std::move(dxgiFactory), std::move(vk), std::move(nvml), std::move(lfx));
             REQUIRE(NvAPI_Initialize() == NVAPI_OK);
 
             NvPhysicalGpuHandle handle;
@@ -100,7 +100,7 @@ TEST_CASE("NVML related sysinfo methods succeed", "[.sysinfo-nvml]") {
                 .LR_SIDE_EFFECT(strcpy(_2, version))
                 .RETURN(NVML_SUCCESS);
 
-            SetupResourceFactory(std::move(dxgiFactory), std::move(vulkan), std::move(nvml), std::move(lfx));
+            SetupResourceFactory(std::move(dxgiFactory), std::move(vk), std::move(nvml), std::move(lfx));
             REQUIRE(NvAPI_Initialize() == NVAPI_OK);
 
             NvPhysicalGpuHandle handle;
@@ -121,7 +121,7 @@ TEST_CASE("NVML related sysinfo methods succeed", "[.sysinfo-nvml]") {
             ALLOW_CALL(*adapter, QueryVideoMemoryInfo(_, _, _))
                 .RETURN(S_OK);
 
-            SetupResourceFactory(std::move(dxgiFactory), std::move(vulkan), std::move(nvml), std::move(lfx));
+            SetupResourceFactory(std::move(dxgiFactory), std::move(vk), std::move(nvml), std::move(lfx));
             REQUIRE(NvAPI_Initialize() == NVAPI_OK);
 
             NvPhysicalGpuHandle handle;
@@ -154,7 +154,7 @@ TEST_CASE("NVML related sysinfo methods succeed", "[.sysinfo-nvml]") {
                 .LR_SIDE_EFFECT(*_2 = args.nvmlBusType)
                 .RETURN(NVML_SUCCESS);
 
-            SetupResourceFactory(std::move(dxgiFactory), std::move(vulkan), std::move(nvml), std::move(lfx));
+            SetupResourceFactory(std::move(dxgiFactory), std::move(vk), std::move(nvml), std::move(lfx));
             REQUIRE(NvAPI_Initialize() == NVAPI_OK);
 
             NvPhysicalGpuHandle handle;
@@ -188,7 +188,7 @@ TEST_CASE("NVML related sysinfo methods succeed", "[.sysinfo-nvml]") {
                 })
                 .RETURN(NVML_SUCCESS);
 
-            SetupResourceFactory(std::move(dxgiFactory), std::move(vulkan), std::move(nvml), std::move(lfx));
+            SetupResourceFactory(std::move(dxgiFactory), std::move(vk), std::move(nvml), std::move(lfx));
             REQUIRE(NvAPI_Initialize() == NVAPI_OK);
 
             NvPhysicalGpuHandle handle;
@@ -222,7 +222,7 @@ TEST_CASE("NVML related sysinfo methods succeed", "[.sysinfo-nvml]") {
                 })
                 .RETURN(NVML_SUCCESS);
 
-            SetupResourceFactory(std::move(dxgiFactory), std::move(vulkan), std::move(nvml), std::move(lfx));
+            SetupResourceFactory(std::move(dxgiFactory), std::move(vk), std::move(nvml), std::move(lfx));
             REQUIRE(NvAPI_Initialize() == NVAPI_OK);
 
             NvPhysicalGpuHandle handle;
@@ -264,7 +264,7 @@ TEST_CASE("NVML related sysinfo methods succeed", "[.sysinfo-nvml]") {
                 .LR_SIDE_EFFECT(*_3 = temp + 1)
                 .RETURN(NVML_SUCCESS);
 
-            SetupResourceFactory(std::move(dxgiFactory), std::move(vulkan), std::move(nvml), std::move(lfx));
+            SetupResourceFactory(std::move(dxgiFactory), std::move(vk), std::move(nvml), std::move(lfx));
             REQUIRE(NvAPI_Initialize() == NVAPI_OK);
 
             NvPhysicalGpuHandle handle;
@@ -316,7 +316,7 @@ TEST_CASE("NVML related sysinfo methods succeed", "[.sysinfo-nvml]") {
                 .LR_SIDE_EFFECT(*_3 = temp)
                 .RETURN(NVML_SUCCESS);
 
-            SetupResourceFactory(std::move(dxgiFactory), std::move(vulkan), std::move(nvml), std::move(lfx));
+            SetupResourceFactory(std::move(dxgiFactory), std::move(vk), std::move(nvml), std::move(lfx));
             REQUIRE(NvAPI_Initialize() == NVAPI_OK);
 
             NvPhysicalGpuHandle handle;
@@ -365,7 +365,7 @@ TEST_CASE("NVML related sysinfo methods succeed", "[.sysinfo-nvml]") {
                 .LR_SIDE_EFFECT(*_2 = NVML_PSTATE_2)
                 .RETURN(NVML_SUCCESS);
 
-            SetupResourceFactory(std::move(dxgiFactory), std::move(vulkan), std::move(nvml), std::move(lfx));
+            SetupResourceFactory(std::move(dxgiFactory), std::move(vk), std::move(nvml), std::move(lfx));
             REQUIRE(NvAPI_Initialize() == NVAPI_OK);
 
             NvPhysicalGpuHandle handle;
@@ -390,7 +390,7 @@ TEST_CASE("NVML related sysinfo methods succeed", "[.sysinfo-nvml]") {
                 .LR_SIDE_EFFECT(*_3 = videoClock)
                 .RETURN(NVML_SUCCESS);
 
-            SetupResourceFactory(std::move(dxgiFactory), std::move(vulkan), std::move(nvml), std::move(lfx));
+            SetupResourceFactory(std::move(dxgiFactory), std::move(vk), std::move(nvml), std::move(lfx));
             REQUIRE(NvAPI_Initialize() == NVAPI_OK);
 
             NvPhysicalGpuHandle handle;
@@ -476,7 +476,7 @@ TEST_CASE("NVML related sysinfo methods succeed", "[.sysinfo-nvml]") {
         ALLOW_CALL(*nvml, IsAvailable())
             .RETURN(false);
 
-        SetupResourceFactory(std::move(dxgiFactory), std::move(vulkan), std::move(nvml), std::move(lfx));
+        SetupResourceFactory(std::move(dxgiFactory), std::move(vk), std::move(nvml), std::move(lfx));
         REQUIRE(NvAPI_Initialize() == NVAPI_OK);
 
         NvPhysicalGpuHandle handle;
@@ -518,7 +518,7 @@ TEST_CASE("NVML related sysinfo methods succeed", "[.sysinfo-nvml]") {
         ALLOW_CALL(*nvml, ErrorString(_))
             .RETURN("error");
 
-        SetupResourceFactory(std::move(dxgiFactory), std::move(vulkan), std::move(nvml), std::move(lfx));
+        SetupResourceFactory(std::move(dxgiFactory), std::move(vk), std::move(nvml), std::move(lfx));
         REQUIRE(NvAPI_Initialize() == NVAPI_OK);
 
         NvPhysicalGpuHandle handle;

--- a/tests/nvapi_sysinfo_topo.cpp
+++ b/tests/nvapi_sysinfo_topo.cpp
@@ -7,7 +7,7 @@ using namespace Catch::Matchers;
 
 TEST_CASE("Topology methods succeed", "[.sysinfo-topo]") {
     auto dxgiFactory = std::make_unique<DXGIDxvkFactoryMock>();
-    auto vulkan = std::make_unique<VulkanMock>();
+    auto vk = std::make_unique<VkMock>();
     auto nvml = std::make_unique<NvmlMock>();
     auto lfx = std::make_unique<LfxMock>();
     DXGIDxvkAdapterMock* adapter1 = CreateDXGIDxvkAdapterMock();
@@ -16,9 +16,9 @@ TEST_CASE("Topology methods succeed", "[.sysinfo-topo]") {
     DXGIOutput6Mock* output2 = CreateDXGIOutput6Mock();
     DXGIOutput6Mock* output3 = CreateDXGIOutput6Mock();
 
-    auto e = ConfigureExtendedTestEnvironment(*dxgiFactory, *vulkan, *nvml, *lfx, *adapter1, *adapter2, *output1, *output2, *output3);
+    auto e = ConfigureExtendedTestEnvironment(*dxgiFactory, *vk, *nvml, *lfx, *adapter1, *adapter2, *output1, *output2, *output3);
 
-    SetupResourceFactory(std::move(dxgiFactory), std::move(vulkan), std::move(nvml), std::move(lfx));
+    SetupResourceFactory(std::move(dxgiFactory), std::move(vk), std::move(nvml), std::move(lfx));
     REQUIRE(NvAPI_Initialize() == NVAPI_OK);
 
     SECTION("EnumLogicalGPUs succeeds") {

--- a/tests/resource_factory_util.h
+++ b/tests/resource_factory_util.h
@@ -3,14 +3,13 @@
 #include "nvapi_tests_private.h"
 #include "nvapi_d3d_mocks.h"
 #include "nvapi_sysinfo_mocks.h"
-#include "mock_factory.h"
 
 DXGIDxvkAdapterMock* CreateDXGIDxvkAdapterMock();
 DXGIOutput6Mock* CreateDXGIOutput6Mock();
 
 void SetupResourceFactory(
     std::unique_ptr<DXGIDxvkFactoryMock> dxgiFactory,
-    std::unique_ptr<VulkanMock> vulkan,
+    std::unique_ptr<VkMock> vk,
     std::unique_ptr<NvmlMock> nvml,
     std::unique_ptr<LfxMock> lfx);
 
@@ -18,7 +17,7 @@ void ResetGlobals();
 
 [[nodiscard]] std::array<std::unique_ptr<trompeloeil::expectation>, 23> ConfigureDefaultTestEnvironment(
     DXGIDxvkFactoryMock& dxgiFactory,
-    VulkanMock& vulkan,
+    VkMock& vk,
     NvmlMock& nvml,
     LfxMock& lfx,
     DXGIDxvkAdapterMock& adapter,
@@ -26,7 +25,7 @@ void ResetGlobals();
 
 [[nodiscard]] std::array<std::unique_ptr<trompeloeil::expectation>, 40> ConfigureExtendedTestEnvironment(
     DXGIDxvkFactoryMock& dxgiFactory,
-    VulkanMock& vulkan,
+    VkMock& vk,
     NvmlMock& nvml,
     LfxMock& lfx,
     DXGIDxvkAdapterMock& adapter1,


### PR DESCRIPTION
Also gets rid of our custom `VkStructure` used in tests in favor of `VkBaseOutStructure` provided by Vulkan headers.

`MockFactory` currently does not override new factory overload, I left this for later, when it's actually used in tests.

Should I also rename `ResourceFactory::CreateVulkan` to `ResourceFactory::CreateVk`?