### PR TITLE
nvapi: Guard interface registry lookups with a mutex

### DIFF
--- a/src/interfaces/dxvk_interfaces.h
+++ b/src/interfaces/dxvk_interfaces.h
@@ -102,7 +102,7 @@ ID3D11VkExtDevice1 : public ID3D11VkExtDevice {
     virtual bool STDMETHODCALLTYPE GetCudaTextureObjectNVX(
         uint32_t srvDriverHandle,
         uint32_t samplerDriverHandle,
-        uint32_t * pCudaTextureHandle) = 0;
+        uint32_t* pCudaTextureHandle) = 0;
 };
 
 MIDL_INTERFACE("fd0bca13-5cb6-4c3a-987e-4750de2ca791")

--- a/src/nvapi_interface.cpp
+++ b/src/nvapi_interface.cpp
@@ -39,9 +39,11 @@ extern "C" {
             log::info(str::format("NvAPI_QueryInterface: Ignoring unrecognized entrypoints from ", disabledEnvName, ": ", str::implode(", ", unrecognized)));
     }
 
-    static std::unordered_map<NvU32, void*> registry;
-
     __declspec(dllexport) void* __cdecl nvapi_QueryInterface(NvU32 id) {
+        static std::unordered_map<NvU32, void*> registry;
+        static std::mutex registryMutex;
+        std::scoped_lock lock(registryMutex);
+
         auto entry = registry.find(id);
         if (entry != registry.end())
             return entry->second;


### PR DESCRIPTION
Might be a bit heavy-handed but `insert`s can cause rehashing to occur and (afaiu) because of it it's not safe to read from the map during this time on another thread.

Maybe some rwlock would make more sense? Not sure. To be reconsidered it it causes performance problems.