### PR TITLE
nvofapi: NvOFAPICreateInstanceCuda - stub

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -51,6 +51,7 @@ nvofapi_src = files([
   'nvofapi.cpp',
   'nvofapi_d3d12.cpp',
   'nvofapi_vk.cpp',
+  'nvofapi_cuda.cpp',
 ])
 
 # Only build 64-bit versions of nvofapi

--- a/src/nvofapi_cuda.cpp
+++ b/src/nvofapi_cuda.cpp
@@ -1,0 +1,17 @@
+#include "nvofapi_private.h"
+#include "util/util_log.h"
+#include "util/util_statuscode.h"
+
+extern "C" {
+
+    using namespace dxvk;
+
+    NV_OF_STATUS __cdecl NvOFAPICreateInstanceCuda(uint32_t apiVer, void* functionList) {
+        constexpr auto n = __func__;
+
+        if (log::tracing())
+            log::trace(n, apiVer, log::fmt::ptr(functionList));
+
+        return OFNotAvailable(n);
+    }
+}

--- a/src/nvofapi_entrypoints.h
+++ b/src/nvofapi_entrypoints.h
@@ -34,4 +34,7 @@ extern "C" {
     NV_OF_STATUS NVOFAPI OFSessionGetLastError(NvOFHandle hOf, char lastError[], uint32_t* size);
 
     NV_OF_STATUS NVOFAPI OFSessionGetCaps(NvOFHandle hOf, NV_OF_CAPS capsParam, uint32_t* capsVal, uint32_t* size);
+
+    // Overwrite CUDA entrypoint to avoid dependency to cuda.h
+    NV_OF_STATUS NVOFAPI NvOFAPICreateInstanceCuda(uint32_t apiVer, void* functionList);
 }

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -67,12 +67,14 @@ nvofapi_src = files([
   '../src/nvofapi.cpp',
   '../src/nvofapi_d3d12.cpp',
   '../src/nvofapi_vk.cpp',
+  '../src/nvofapi_cuda.cpp',
 ])
 
 nvofapi_tests_src = files([
   'nvofapi_main.cpp',
   'nvofapi_d3d12.cpp',
   'nvofapi_vk.cpp',
+  'nvofapi_cuda.cpp',
 ])
 
 target_name = 'nvofapi'+target_suffix+'-tests'

--- a/tests/nvofapi_cuda.cpp
+++ b/tests/nvofapi_cuda.cpp
@@ -1,0 +1,10 @@
+#include "nvofapi_tests_private.h"
+#include "nvofapi/mock_factory.h"
+
+using namespace trompeloeil;
+
+TEST_CASE("CreateInstanceVk returns not-available", "[.cuda]") {
+    struct NV_OF_CUDA_API_FUNCTION_LIST {
+    } functionList;
+    REQUIRE(NvOFAPICreateInstanceCuda(80, &functionList) == NV_OF_ERR_OF_NOT_AVAILABLE);
+}

--- a/tests/nvofapi_main.cpp
+++ b/tests/nvofapi_main.cpp
@@ -2,7 +2,7 @@
 #include "../inc/catch_amalgamated.hpp"
 #include "nvofapi/section_listener.h"
 
-CATCH_REGISTER_TAG_ALIAS("[@unit-tests]", "[d3d12],[vk]")
-CATCH_REGISTER_TAG_ALIAS("[@all]", "[d3d12],[vk]")
+CATCH_REGISTER_TAG_ALIAS("[@unit-tests]", "[d3d12],[vk],[cuda]")
+CATCH_REGISTER_TAG_ALIAS("[@all]", "[d3d12],[vk],[cuda]")
 
 CATCH_REGISTER_LISTENER(SectionListener)

--- a/tests/nvofapi_tests_private.h
+++ b/tests/nvofapi_tests_private.h
@@ -5,6 +5,7 @@
 #endif // defined(__GNUC__) || defined(__clang__)
 
 #include "../src/nvofapi_private.h"
+#include "../src/nvofapi_entrypoints.h"
 #include "../src/nvofapi_globals.h"
 
 #include "../inc/catch_amalgamated.hpp"


### PR DESCRIPTION
This will return an error with a logtext indicating to upgrade DLSS version since the new DLSS4 version do not use opticalflow for DLSS anymore ref NVIDIA