### PR TITLE
nvofapi: Only export used symbols

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -63,5 +63,6 @@ if dxvk_cpu_family == 'x86_64'
     name_prefix         : '',
     dependencies        : [ lib_version ],
     include_directories : [ nvapi_headers, vk_headers ],
+    vs_module_defs      : target_name+'.def',
     install             : true)
 endif

--- a/src/nvofapi64.def
+++ b/src/nvofapi64.def
@@ -1,0 +1,7 @@
+LIBRARY nvofapi.dll
+EXPORTS
+    NvOFAPICreateInstanceCuda @1
+    NvOFAPICreateInstanceD3D11 @2
+    NvOFAPICreateInstanceD3D12 @3
+    NvOFAPICreateInstanceVk @4
+    NvOFGetMaxSupportedApiVersion @5

--- a/src/nvofapi_cuda.cpp
+++ b/src/nvofapi_cuda.cpp
@@ -6,7 +6,7 @@ extern "C" {
 
     using namespace dxvk;
 
-    NV_OF_STATUS __cdecl NvOFAPICreateInstanceCuda(uint32_t apiVer, void* functionList) {
+    NV_OF_STATUS NVOFAPI NvOFAPICreateInstanceCuda(uint32_t apiVer, void* functionList) {
         constexpr auto n = __func__;
 
         if (log::tracing())

--- a/src/nvofapi_d3d11.cpp
+++ b/src/nvofapi_d3d11.cpp
@@ -6,7 +6,7 @@ extern "C" {
 
     using namespace dxvk;
 
-    NV_OF_STATUS __cdecl NvOFAPICreateInstanceD3D11(uint32_t apiVer, NV_OF_D3D11_API_FUNCTION_LIST* functionList) {
+    NV_OF_STATUS NVOFAPI NvOFAPICreateInstanceD3D11(uint32_t apiVer, NV_OF_D3D11_API_FUNCTION_LIST* functionList) {
         constexpr auto n = __func__;
 
         if (log::tracing())

--- a/src/nvofapi_d3d12.cpp
+++ b/src/nvofapi_d3d12.cpp
@@ -126,7 +126,7 @@ extern "C" {
     }
 
     // ETBLs
-    NV_OF_STATUS __stdcall NvOFAPICreateInstanceD3D12(uint32_t apiVer, NV_OF_D3D12_API_FUNCTION_LIST* functionList) {
+    NV_OF_STATUS NVOFAPI NvOFAPICreateInstanceD3D12(uint32_t apiVer, NV_OF_D3D12_API_FUNCTION_LIST* functionList) {
         uint32_t apiVerMajor = (apiVer & 0xfffffff0) >> 4;
         uint32_t apiVerMinor = (apiVer & 0xf);
         constexpr auto n = __func__;


### PR DESCRIPTION
This will make the nvofapi64.dll binary export only the used symbols, and make it similar to the windows version.

The usage of __cdecl for the calls SHOULD not be needed, as the `nvOpticalFlowCommon.h` header spesifically sets this:

```
#ifdef _WIN32
#define NVOFAPI __stdcall
#else
#define NVOFAPI
#endif
```

Testing on the OpticalFlow SDK samples, it seems to work as intended. Lets have a talk about that :+1: 

The exported symbols is then like this when using winedump -j export

```
  Name:            nvofapi64.dll
  Characteristics: 00000000
  TimeDateStamp:   679FAE1F Sun Feb  2 18:40:47 2025
  Version:         0.00
  Ordinal base:    1
  # of functions:  5
  # of Names:      5
  Functions RVA:   0014B028
  Ordinals RVA:    0014B050
  Names RVA:       0014B03C

  Entry Pt  Ordn  Name
  00029DF0     1  NvOFAPICreateInstanceCuda
  00017150     2  NvOFAPICreateInstanceD3D11
  0001B250     3  NvOFAPICreateInstanceD3D12
  00027EF0     4  NvOFAPICreateInstanceVk
  00013B30     5  NvOFGetMaxSupportedApiVersion
```
