### PR TITLE
nvapi: Use .def file for exporting

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -35,6 +35,7 @@ nvapi_dll = shared_library(target_name, [ nvapi_src, dxvk_nvapi_version ],
   name_prefix         : '',
   dependencies        : [ lib_dxgi, lib_d3d11, lib_version ],
   include_directories : [ nvapi_headers, vk_headers ],
+  vs_module_defs      : target_name+'.def',
   install             : true)
 
 nvofapi_src = files([

--- a/src/nvapi.def
+++ b/src/nvapi.def
@@ -1,0 +1,3 @@
+LIBRARY nvapi.dll
+EXPORTS
+    nvapi_QueryInterface @2

--- a/src/nvapi64.def
+++ b/src/nvapi64.def
@@ -1,0 +1,3 @@
+LIBRARY nvapi64.dll
+EXPORTS
+    nvapi_QueryInterface @2

--- a/src/nvapi_interface.cpp
+++ b/src/nvapi_interface.cpp
@@ -39,7 +39,7 @@ extern "C" {
             log::info(str::format("NvAPI_QueryInterface: Ignoring unrecognized entrypoints from ", disabledEnvName, ": ", str::implode(", ", unrecognized)));
     }
 
-    __declspec(dllexport) void* __cdecl nvapi_QueryInterface(NvU32 id) {
+    void* __cdecl nvapi_QueryInterface(NvU32 id) {
         static std::unordered_map<NvU32, void*> registry;
         static std::mutex registryMutex;
         std::scoped_lock lock(registryMutex);


### PR DESCRIPTION
Note the ordinal number 2 here.. as this is consistent with the ordinal used in windows. Windows nvapi has added a new exported function that we do not know much about. `nvapi_Direct_GetMethod` that has ordinal 1.

I do not think we should touch __cdecl here tho?