### PR TITLE
util: Avoid using std::string_view::starts_with

### DIFF
--- a/src/util/util_string.cpp
+++ b/src/util/util_string.cpp
@@ -50,7 +50,7 @@ namespace dxvk::str {
             return false;
 
         auto end = str.data() + str.size();
-        auto result = str.starts_with("0x") || str.starts_with("0X")
+        auto result = str.size() > 2 && str[0] == '0' && (str[1] == 'x' || str[1] == 'X')
             ? std::from_chars(str.data() + 2, end, value, 16)
             : std::from_chars(str.data(), end, value, 10);
 


### PR DESCRIPTION
Weird how GitHub Actions didn't catch it…