### PR TITLE
nvapi: Allow switching NGX registry settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ The following environment variables tweak DXVK-NVAPI's runtime behavior:
   - `GB200` (Blackwell)
 - `DXVK_NVAPI_LOG_LEVEL` set to `info` prints log statements. The default behavior omits any logging. Please fill an issue if using log servery `info` creates log spam. Setting severity to `trace` logs all entry points enter and exits, this has a severe effect on performance. All other log levels will be interpreted as `none`.
 - `DXVK_NVAPI_LOG_PATH` enables file logging additionally to console output and sets the path where the log file `nvapi.log`/`nvapi64.log`/`nvofapi64.log` should be written to. Log statements are appended to an existing file. Please remove this file once in a while to prevent excessive grow. This requires `DXVK_NVAPI_LOG_LEVEL` set to `info` or `trace`.
+- `DXVK_NVAPI_SET_NGX_DEBUG_OPTIONS` allows to set various NGX debug registry keys with the format `setting1=value1,setting2=value2,…`, whereas values are of type DWORD (u32). Setting the registry keys for enabling DLSS indicators corresponds to `DXVK_NVAPI_SET_NGX_DEBUG_OPTIONS=DLSSIndicator=1024,DLSSGIndicator=2`, hiding the indicators to `DXVK_NVAPI_SET_NGX_DEBUG_OPTIONS=DLSSIndicator=0,DLSSGIndicator=0`. Be aware, this tweak permanently modifies the registry.
 
 The following environment variables tweak DXVK-NVAPI's Vulkan Reflex layer's runtime behavior:
 

--- a/src/nvapi.cpp
+++ b/src/nvapi.cpp
@@ -5,6 +5,7 @@
 #include "util/util_string.h"
 #include "util/util_env.h"
 #include "util/util_log.h"
+#include "util/util_ngx_debug.h"
 #include "../version.h"
 #include "../config.h"
 
@@ -380,6 +381,10 @@ extern "C" {
             --initializationCount;
             return NvidiaDeviceNotFound(n);
         }
+
+#if _WIN64
+        SetNgxDebugOptions(); // NGX is 64-bit only
+#endif
 
         return Ok(n);
     }

--- a/src/util/util_ngx_debug.h
+++ b/src/util/util_ngx_debug.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include "../nvapi_private.h"
+#include "util_log.h"
+#include "util_env.h"
+
+namespace dxvk {
+    inline void SetNgxDebugOptions() {
+        static const auto setNgxIndicatorEnvName = "DXVK_NVAPI_SET_NGX_DEBUG_OPTIONS";
+        static const std::unordered_map<std::string_view, std::string_view> settings = {
+            {"EnableConsoleLogging", "EnableConsoleLogging"},
+            {"LogLevel", "LogLevel"},
+            {"ShowDlssIndicator", "ShowDlssIndicator"},
+            {"DLSSG_IndicatorText", "DLSSG_IndicatorText"},
+            {"Logging", "EnableConsoleLogging"},
+            {"DLSSIndicator", "ShowDlssIndicator"},
+            {"DLSSGIndicator", "DLSSG_IndicatorText"},
+        };
+        static const auto setNgxIndicator = env::getEnvVariable(setNgxIndicatorEnvName);
+
+        if (setNgxIndicator.empty())
+            return;
+
+        std::set<std::string_view, str::CaseInsensitiveCompare<std::string_view>> keys;
+        std::transform(settings.begin(), settings.end(), std::inserter(keys, keys.begin()), [](const auto& s) { return s.first; });
+
+        auto setNgxIndicatorMap = str::parsekeydwords(setNgxIndicator, keys);
+
+        if (setNgxIndicatorMap.empty()) {
+            log::info(str::format(setNgxIndicatorEnvName, " is set to an invalid value, please use the format 'key=value,key=value'"));
+            return;
+        }
+
+        HKEY key{};
+        auto status = RegOpenKeyExW(HKEY_LOCAL_MACHINE, L"SOFTWARE\\NVIDIA Corporation\\Global\\NGXCore", REG_OPTION_NON_VOLATILE, KEY_ALL_ACCESS, &key);
+        if (status != NO_ERROR || !key) {
+            log::info(str::format(R"(Failed to open SOFTWARE\NVIDIA Corporation\Global\NGXCore registry key: )", status));
+            return;
+        }
+
+        std::for_each(settings.begin(), settings.end(),
+            [&](const auto& pair) {
+                if (!setNgxIndicatorMap.contains(pair.first))
+                    return;
+
+                auto value = setNgxIndicatorMap.at(pair.first);
+                log::info(str::format("Set ", pair.second, " in registry to 0x", std::hex, value));
+
+                std::wstring name = std::wstring(pair.second.begin(), pair.second.end());
+                if (RegSetValueExW(key, name.c_str(), 0, REG_DWORD, reinterpret_cast<const BYTE*>(&value), sizeof(DWORD)) != NO_ERROR)
+                    log::info(str::format("Failed to set ", pair.second, " registry key"));
+            });
+
+        RegCloseKey(key);
+    }
+}

--- a/src/util/util_string.cpp
+++ b/src/util/util_string.cpp
@@ -84,4 +84,27 @@ namespace dxvk::str {
 
         return result;
     }
+
+    std::unordered_map<std::string_view, NvU32> parsekeydwords(const std::string& str, const std::set<std::string_view, str::CaseInsensitiveCompare<std::string_view>>& keys) {
+        std::unordered_map<std::string_view, NvU32> result;
+        auto entries = str::split<std::vector<std::string_view>>(str, std::regex(","));
+
+        for (auto entry : entries) {
+            auto eq = entry.find('=');
+
+            if (eq == entry.npos || eq == 0 || eq == entry.size() - 1)
+                continue;
+
+            auto key = entry.substr(0, eq);
+            auto it = keys.find(key);
+            if (it == keys.end())
+                continue;
+
+            NvU32 value;
+            if (str::parsedword(entry.substr(eq + 1), value))
+                result[*it] = value;
+        }
+
+        return result;
+    }
 }

--- a/src/util/util_string.h
+++ b/src/util/util_string.h
@@ -122,4 +122,6 @@ namespace dxvk::str {
     bool parsedword(const std::string_view& str, NvU32& value);
 
     std::unordered_map<NvU32, NvU32> parsedwords(const std::string& str);
+
+    std::unordered_map<std::string_view, NvU32> parsekeydwords(const std::string& str, const std::set<std::string_view, str::CaseInsensitiveCompare<std::string_view>>& keys);
 }

--- a/tests/util.cpp
+++ b/tests/util.cpp
@@ -242,6 +242,17 @@ TEST_CASE("String", "[.util]") {
         REQUIRE(dwords.at(0x104d6667) == 3);
         REQUIRE(dwords.at(1) == 2);
     }
+
+    SECTION("parsekeydwords") {
+        std::set<std::string_view, dxvk::str::CaseInsensitiveCompare<std::string_view>> keys = {"Logging", "DLSSIndicator", "DLSSGIndicator"};
+        auto map = dxvk::str::parsekeydwords(",logging=0,dlssindicator=1,DLSSGIndicator=0x2,invalid,,9,=,4=,=5,,0x104D6667=3", keys);
+        keys.clear();
+
+        REQUIRE(map.size() == 3);
+        REQUIRE(map.at("Logging") == 0x0);
+        REQUIRE(map.at("DLSSIndicator") == 0x1);
+        REQUIRE(map.at("DLSSGIndicator") == 0x2);
+    }
 }
 
 TEST_CASE("Version", "[.util]") {


### PR DESCRIPTION
Example:

~`DXVK_NVAPI_SET_DLSS_INDICATOR=1024 DXVK_NVAPI_SET_DLSSG_INDICATOR=2`~

~`DXVK_NVAPI_SET_NGX_INDICATOR=DLSS=1024,DLSSG=2`~

`DXVK_NVAPI_SET_NGX_DEBUG_OPTIONS=DLSSIndicator=1024,DLSSGIndicator=2,Logging=1,LogLevel=1`

Probably out of scope...

Reference:
- https://github.com/NVIDIA/DLSS/tree/main/utils
- https://github.com/NVIDIAGameWorks/Streamline/blob/main/docs/ProgrammingGuideDLSS_G.md#200-dlss-fg-indicator-text