### PR TITLE
nvapi: Use NVAPI_SDK_VERSION

### DIFF
--- a/src/nvapi.cpp
+++ b/src/nvapi.cpp
@@ -140,7 +140,7 @@ extern "C" {
         auto adapter = nvapiAdapterRegistry->GetFirstAdapter();
         pVersion->drvVersion = adapter->GetDriverVersion();
         pVersion->bldChangeListNum = 0;
-        str::tonvss(pVersion->szBuildBranchString, str::format(NVAPI_VERSION, "_", DXVK_NVAPI_VERSION));
+        str::tonvss(pVersion->szBuildBranchString, str::format("r", NVAPI_SDK_VERSION, "_", DXVK_NVAPI_VERSION));
         str::tonvss(pVersion->szAdapterString, adapter->GetDeviceName());
 
         return Ok(n);

--- a/src/nvapi_sys.cpp
+++ b/src/nvapi_sys.cpp
@@ -40,7 +40,7 @@ extern "C" {
             return InvalidArgument(n);
 
         *pDriverVersion = nvapiAdapterRegistry->GetFirstAdapter()->GetDriverVersion();
-        str::tonvss(szBuildBranchString, str::format(NVAPI_VERSION, "_", DXVK_NVAPI_VERSION));
+        str::tonvss(szBuildBranchString, str::format("r", NVAPI_SDK_VERSION, "_", DXVK_NVAPI_VERSION));
 
         return Ok(n);
     }
@@ -64,7 +64,7 @@ extern "C" {
             case NV_DISPLAY_DRIVER_INFO_VER1: {
                 auto pDriverInfoV1 = reinterpret_cast<NV_DISPLAY_DRIVER_INFO_V1*>(pDriverInfo);
                 pDriverInfoV1->driverVersion = nvapiAdapterRegistry->GetFirstAdapter()->GetDriverVersion();
-                str::tonvss(pDriverInfoV1->szBuildBranch, str::format(NVAPI_VERSION, "_", DXVK_NVAPI_VERSION));
+                str::tonvss(pDriverInfoV1->szBuildBranch, str::format("r", NVAPI_SDK_VERSION, "_", DXVK_NVAPI_VERSION));
                 pDriverInfoV1->bIsDCHDriver = 1;              // Assume DCH driver for Windows
                 pDriverInfoV1->bIsNVIDIAStudioPackage = 0;    // Lets not support "Studio Package"
                 pDriverInfoV1->bIsNVIDIAGameReadyPackage = 1; // GameReady Package should be "safe" even if other packages is used
@@ -74,13 +74,13 @@ extern "C" {
             }
             case NV_DISPLAY_DRIVER_INFO_VER2: {
                 pDriverInfo->driverVersion = nvapiAdapterRegistry->GetFirstAdapter()->GetDriverVersion();
-                str::tonvss(pDriverInfo->szBuildBranch, str::format(NVAPI_VERSION, "_", DXVK_NVAPI_VERSION));
+                str::tonvss(pDriverInfo->szBuildBranch, str::format("r", NVAPI_SDK_VERSION, "_", DXVK_NVAPI_VERSION));
                 pDriverInfo->bIsDCHDriver = 1;              // Assume DCH driver for Windows
                 pDriverInfo->bIsNVIDIAStudioPackage = 0;    // Lets not support "Studio Package"
                 pDriverInfo->bIsNVIDIAGameReadyPackage = 1; // GameReady Package should be "safe" even if other packages is used
                 pDriverInfo->bIsNVIDIARTXProductionBranchPackage = 0;
                 pDriverInfo->bIsNVIDIARTXNewFeatureBranchPackage = 0;
-                str::tonvss(pDriverInfo->szBuildBaseBranch, NVAPI_VERSION);
+                str::tonvss(pDriverInfo->szBuildBaseBranch, str::format("r", NVAPI_SDK_VERSION));
                 break;
             }
             default:

--- a/version.h.in
+++ b/version.h.in
@@ -1,4 +1,3 @@
 #pragma once
 
-#define NVAPI_VERSION "r570"
 #define DXVK_NVAPI_VERSION "@VCS_TAG@"


### PR DESCRIPTION
Only place I ever saw this being used in an actual title:

 
![Screenshot](https://github.com/user-attachments/assets/ba6377ef-54e8-40dd-a0cd-6af3df7317d7)
