### PR TITLE
nvapi-d3d11/12: Check for VK_NVX_image_view_handle

### DIFF
--- a/src/nvapi/nvapi_d3d11_device.cpp
+++ b/src/nvapi/nvapi_d3d11_device.cpp
@@ -63,6 +63,7 @@ namespace dxvk {
         m_supportsExtDepthBounds = m_dxvkDevice->GetExtensionSupport(D3D11_VK_EXT_DEPTH_BOUNDS);
         m_supportsNvxBinaryImport = m_dxvkDevice->GetExtensionSupport(D3D11_VK_NVX_BINARY_IMPORT);
         m_supportsExtBarrierControl = m_dxvkDevice->GetExtensionSupport(D3D11_VK_EXT_BARRIER_CONTROL);
+        m_supportsNvxImageViewHandle = m_dxvkDevice->GetExtensionSupport(D3D11_VK_NVX_IMAGE_VIEW_HANDLE);
         m_supportsExtMultiDrawIndirect = m_dxvkDevice->GetExtensionSupport(D3D11_VK_EXT_MULTI_DRAW_INDIRECT);
 
         Com<ID3D11VkExtDevice1> dxvkDevice1;
@@ -140,41 +141,41 @@ namespace dxvk {
     }
 
     bool NvapiD3d11Device::GetResourceHandleGPUVirtualAddressAndSize(NVDX_ObjectHandle hObject, NvU64* gpuVAStart, NvU64* gpuVASize) const {
-        if (!m_supportsExtDevice1)
+        if (!m_supportsExtDevice1 || !m_supportsNvxImageViewHandle)
             return false;
 
-        return m_dxvkDevice->GetResourceHandleGPUVirtualAddressAndSizeNVX(reinterpret_cast<void*>(hObject), reinterpret_cast<uint64_t*>(gpuVAStart), reinterpret_cast<uint64_t*>(gpuVASize));
+        return m_dxvkDevice->GetResourceHandleGPUVirtualAddressAndSizeNVX(hObject, gpuVAStart, gpuVASize);
     }
 
     bool NvapiD3d11Device::CreateUnorderedAccessViewAndGetDriverHandle(ID3D11Resource* pResource, const D3D11_UNORDERED_ACCESS_VIEW_DESC* pDesc, ID3D11UnorderedAccessView** ppUAV, NvU32* pDriverHandle) const {
-        if (!m_supportsExtDevice1)
+        if (!m_supportsExtDevice1 || !m_supportsNvxImageViewHandle)
             return false;
 
         return m_dxvkDevice->CreateUnorderedAccessViewAndGetDriverHandleNVX(pResource, pDesc, ppUAV, reinterpret_cast<uint32_t*>(pDriverHandle));
     }
 
     bool NvapiD3d11Device::CreateShaderResourceViewAndGetDriverHandle(ID3D11Resource* pResource, const D3D11_SHADER_RESOURCE_VIEW_DESC* pDesc, ID3D11ShaderResourceView** ppSRV, NvU32* pDriverHandle) const {
-        if (!m_supportsExtDevice1)
+        if (!m_supportsExtDevice1 || !m_supportsNvxImageViewHandle)
             return false;
 
         return m_dxvkDevice->CreateShaderResourceViewAndGetDriverHandleNVX(pResource, pDesc, ppSRV, reinterpret_cast<uint32_t*>(pDriverHandle));
     }
 
     bool NvapiD3d11Device::GetCudaTextureObject(uint32_t srvDriverHandle, uint32_t samplerDriverHandle, uint32_t* pCudaTextureHandle) const {
-        if (!m_supportsExtDevice1)
+        if (!m_supportsExtDevice1 || !m_supportsNvxImageViewHandle)
             return false;
 
-        return m_dxvkDevice->GetCudaTextureObjectNVX(srvDriverHandle, samplerDriverHandle, reinterpret_cast<uint32_t*>(pCudaTextureHandle));
+        return m_dxvkDevice->GetCudaTextureObjectNVX(srvDriverHandle, samplerDriverHandle, pCudaTextureHandle);
     }
 
     bool NvapiD3d11Device::CreateSamplerStateAndGetDriverHandle(const D3D11_SAMPLER_DESC* pSamplerDesc, ID3D11SamplerState** ppSamplerState, uint32_t* pDriverHandle) const {
-        if (!m_supportsExtDevice1)
+        if (!m_supportsExtDevice1 || !m_supportsNvxImageViewHandle)
             return false;
 
         return m_dxvkDevice->CreateSamplerStateAndGetDriverHandleNVX(pSamplerDesc, ppSamplerState, pDriverHandle);
     }
 
     bool NvapiD3d11Device::IsFatbinPTXSupported() const {
-        return m_supportsExtDevice1 && m_supportsExtContext1 && m_supportsNvxBinaryImport;
+        return m_supportsExtDevice1 && m_supportsExtContext1 && m_supportsNvxBinaryImport && m_supportsNvxImageViewHandle;
     }
 }

--- a/src/nvapi/nvapi_d3d11_device.h
+++ b/src/nvapi/nvapi_d3d11_device.h
@@ -41,6 +41,7 @@ namespace dxvk {
         bool m_supportsExtDepthBounds;
         bool m_supportsNvxBinaryImport;
         bool m_supportsExtBarrierControl;
+        bool m_supportsNvxImageViewHandle;
         bool m_supportsExtMultiDrawIndirect;
         bool m_supportsExtDevice1;
         bool m_supportsExtContext1;

--- a/src/nvapi/nvapi_d3d12_device.cpp
+++ b/src/nvapi/nvapi_d3d12_device.cpp
@@ -49,6 +49,7 @@ namespace dxvk {
     NvapiD3d12Device::NvapiD3d12Device(ID3D12DeviceExt* vkd3dDevice)
         : m_vkd3dDevice(vkd3dDevice) {
         m_supportsNvxBinaryImport = vkd3dDevice->GetExtensionSupport(D3D12_VK_NVX_BINARY_IMPORT);
+        m_supportsNvxImageViewHandle = vkd3dDevice->GetExtensionSupport(D3D12_VK_NVX_IMAGE_VIEW_HANDLE);
     }
 
     bool NvapiD3d12Device::CreateCubinComputeShaderWithName(const void* cubinData, NvU32 cubinSize, NvU32 blockX, NvU32 blockY, NvU32 blockZ, const char* shaderName, NVDX_ObjectHandle* pShader) {
@@ -80,27 +81,27 @@ namespace dxvk {
     }
 
     bool NvapiD3d12Device::GetCudaTextureObject(D3D12_CPU_DESCRIPTOR_HANDLE srvHandle, D3D12_CPU_DESCRIPTOR_HANDLE samplerHandle, NvU32* cudaTextureHandle) const {
-        if (!m_vkd3dDevice || !m_supportsNvxBinaryImport)
+        if (!m_vkd3dDevice || !m_supportsNvxImageViewHandle)
             return false;
 
         return SUCCEEDED(m_vkd3dDevice->GetCudaTextureObject(srvHandle, samplerHandle, reinterpret_cast<UINT32*>(cudaTextureHandle)));
     }
 
     bool NvapiD3d12Device::GetCudaSurfaceObject(D3D12_CPU_DESCRIPTOR_HANDLE uavHandle, NvU32* cudaSurfaceHandle) const {
-        if (!m_vkd3dDevice || !m_supportsNvxBinaryImport)
+        if (!m_vkd3dDevice || !m_supportsNvxImageViewHandle)
             return false;
 
         return SUCCEEDED(m_vkd3dDevice->GetCudaSurfaceObject(uavHandle, reinterpret_cast<UINT32*>(cudaSurfaceHandle)));
     }
 
     bool NvapiD3d12Device::CaptureUAVInfo(NVAPI_UAV_INFO* pUAVInfo) const {
-        if (!m_vkd3dDevice || !m_supportsNvxBinaryImport)
+        if (!m_vkd3dDevice || !m_supportsNvxImageViewHandle)
             return false;
 
         return SUCCEEDED(m_vkd3dDevice->CaptureUAVInfo(reinterpret_cast<D3D12_UAV_INFO*>(pUAVInfo)));
     }
 
     bool NvapiD3d12Device::IsFatbinPTXSupported() const {
-        return m_vkd3dDevice && m_supportsNvxBinaryImport;
+        return m_vkd3dDevice && m_supportsNvxBinaryImport && m_supportsNvxImageViewHandle;
     }
 }

--- a/src/nvapi/nvapi_d3d12_device.h
+++ b/src/nvapi/nvapi_d3d12_device.h
@@ -32,5 +32,6 @@ namespace dxvk {
 
         ID3D12DeviceExt* m_vkd3dDevice{};
         bool m_supportsNvxBinaryImport = false;
+        bool m_supportsNvxImageViewHandle = false;
     };
 }

--- a/tests/nvapi_d3d11.cpp
+++ b/tests/nvapi_d3d11.cpp
@@ -126,6 +126,8 @@ TEST_CASE("D3D11 methods succeed", "[.d3d11]") {
     SECTION("LaunchCubinShader without DXVK extension support returns error") {
         ALLOW_CALL(device, GetExtensionSupport(D3D11_VK_NVX_BINARY_IMPORT))
             .RETURN(false);
+        ALLOW_CALL(device, GetExtensionSupport(D3D11_VK_NVX_IMAGE_VIEW_HANDLE))
+            .RETURN(false);
         FORBID_CALL(context, LaunchCubinShaderNVX(_, _, _, _, _, _, _, _, _, _));
 
         REQUIRE(NvAPI_D3D11_LaunchCubinShader(static_cast<ID3D11DeviceContext*>(&context), NVDX_ObjectHandle(), 0, 0, 0, nullptr, 0, nullptr, 0, nullptr, 0) == NVAPI_ERROR);
@@ -135,6 +137,8 @@ TEST_CASE("D3D11 methods succeed", "[.d3d11]") {
 
     SECTION("IsFatbinPTXSupported without DXVK extension returns OK but reports unsupported") {
         ALLOW_CALL(device, GetExtensionSupport(D3D11_VK_NVX_BINARY_IMPORT))
+            .RETURN(false);
+        ALLOW_CALL(device, GetExtensionSupport(D3D11_VK_NVX_IMAGE_VIEW_HANDLE))
             .RETURN(false);
 
         bool supported = true;

--- a/tests/nvapi_d3d12.cpp
+++ b/tests/nvapi_d3d12.cpp
@@ -146,6 +146,8 @@ TEST_CASE("D3D12 methods succeed", "[.d3d12]") {
     SECTION("D3D12 methods without cubin extension return error") {
         ALLOW_CALL(device, GetExtensionSupport(D3D12_VK_NVX_BINARY_IMPORT))
             .RETURN(false);
+        ALLOW_CALL(device, GetExtensionSupport(D3D12_VK_NVX_IMAGE_VIEW_HANDLE))
+            .RETURN(false);
 
         FORBID_CALL(device, CreateCubinComputeShaderWithName(_, _, _, _, _, _, _));
         FORBID_CALL(device, DestroyCubinComputeShader(_));


### PR DESCRIPTION
Follow up from earlier D3D11 and D3D12 rework.