### PR TITLE
nvapi-d3d: Just error out of GetCurrentSLIState

### DIFF
--- a/src/util/util_statuscode.h
+++ b/src/util/util_statuscode.h
@@ -158,6 +158,12 @@ namespace dxvk {
         return NVAPI_INSUFFICIENT_BUFFER;
     }
 
+    inline NvAPI_Status NoActiveSliTopology(const std::string& logMessage, bool& alreadyLogged) {
+        if (log::tracing() || !std::exchange(alreadyLogged, true))
+            log::info(str::format("<-", logMessage, ": No active SLI topology"));
+        return NVAPI_NO_ACTIVE_SLI_TOPOLOGY;
+    }
+
     inline NV_OF_STATUS Success() {
         return NV_OF_SUCCESS;
     }

--- a/tests/nvapi_d3d.cpp
+++ b/tests/nvapi_d3d.cpp
@@ -35,28 +35,17 @@ TEST_CASE("D3D methods succeed", "[.d3d]") {
     }
 
     SECTION("GetCurrentSLIState succeeds") {
-        SECTION("GetCurrentSLIState (V1) returns OK") {
+        SECTION("GetCurrentSLIState (V1) returns NO_ACTIVE_SLI_TOPOLOGY") {
             NV_GET_CURRENT_SLI_STATE_V1 state;
             state.version = NV_GET_CURRENT_SLI_STATE_VER1;
-            REQUIRE(NvAPI_D3D_GetCurrentSLIState(&unknown, reinterpret_cast<NV_GET_CURRENT_SLI_STATE*>(&state)) == NVAPI_OK);
-            REQUIRE(state.maxNumAFRGroups == 1);
-            REQUIRE(state.numAFRGroups == 1);
-            REQUIRE(state.currentAFRIndex == 0);
-            REQUIRE(state.nextFrameAFRIndex == 0);
-            REQUIRE(state.previousFrameAFRIndex == 0);
-            REQUIRE(state.bIsCurAFRGroupNew == false);
+            REQUIRE(NvAPI_D3D_GetCurrentSLIState(&unknown, reinterpret_cast<NV_GET_CURRENT_SLI_STATE*>(&state)) == NVAPI_NO_ACTIVE_SLI_TOPOLOGY);
         }
 
-        SECTION("GetCurrentSLIState (V2) returns OK") {
+        SECTION("GetCurrentSLIState (V2) returns NO_ACTIVE_SLI_TOPOLOGY") {
             NV_GET_CURRENT_SLI_STATE_V2 state;
+            state.numVRSLIGpus = 0xdeadbeef;
             state.version = NV_GET_CURRENT_SLI_STATE_VER2;
-            REQUIRE(NvAPI_D3D_GetCurrentSLIState(&unknown, &state) == NVAPI_OK);
-            REQUIRE(state.maxNumAFRGroups == 1);
-            REQUIRE(state.numAFRGroups == 1);
-            REQUIRE(state.currentAFRIndex == 0);
-            REQUIRE(state.nextFrameAFRIndex == 0);
-            REQUIRE(state.previousFrameAFRIndex == 0);
-            REQUIRE(state.bIsCurAFRGroupNew == false);
+            REQUIRE(NvAPI_D3D_GetCurrentSLIState(&unknown, &state) == NVAPI_NO_ACTIVE_SLI_TOPOLOGY);
             REQUIRE(state.numVRSLIGpus == 0);
         }
 


### PR DESCRIPTION
Fallout New Vegas seems to think it's running on an SLI system unless we just error out here.

I also tried setting `maxNumAFRGroups` and `numAFRGroups` both to 0 but that didn't fix it either.
Additionally I tried just setting `numAFRGroups` to 0 and keeping `maxNumAFRGroups` at 1 but that didn't work either.

The Nvidia sample suggests what we have right now is a valid implementation:
`bSLIEnabled = (gMaxNumAFRGroups > 1);` but it appears that the check in Fallout isn't particularly robust.

So I suggest we just return an error when the function gets called. Alternatively we could return null pointers for the SLI functions in `QueryInterface`. I don't have a test setup for Nvapi on Windows right now, so I can't check what Nvidia does on Windows these days without a lot of effort.

Fixes: https://github.com/doitsujin/dxvk/issues/4696
https://github.com/ValveSoftware/Proton/issues/356#issuecomment-2665797622