### PR TITLE
nvapi-d3d: Make GetCurrentSLIState more accurate

### DIFF
--- a/src/nvapi_private.h
+++ b/src/nvapi_private.h
@@ -32,6 +32,7 @@
 #include <utility>
 #include <vector>
 
+#include <d3d9.h>
 #include <dxgi1_6.h>
 #include <d3d11_1.h>
 #ifdef _MSC_VER


### PR DESCRIPTION
The gift that keeps on giving.

My previous PR apparently breaks DLSS in D3D11 games.
It turns out that what my previous PR does is only correct if the device passed in is a D3D9 device.

D3D9:
![image](https://github.com/user-attachments/assets/c460ea0c-f3eb-4c43-b7e7-3af5c28deb0d)

D3D11:
![image](https://github.com/user-attachments/assets/74e42105-573b-4635-b43e-d4952d2d8329)

In addition to that, Fallout doesn't even pass its D3D9 device to this function. Instead it passes `IDirect3D9`. In that case the function returns `INVALID_ARGUMENT` which means that this SLI optimization, that we were getting, doesn't even work on Windows. The game is just broken.

cc @adamdmoss 