### PR TITLE
nvapi-d3d12: Add SM version fallback

### DIFF
--- a/src/nvapi/nvapi_adapter.cpp
+++ b/src/nvapi/nvapi_adapter.cpp
@@ -293,8 +293,14 @@ namespace dxvk {
         return NV_GPU_ARCHITECTURE_GK100;
     }
 
-    std::pair<uint32_t, uint32_t> NvapiAdapter::GetComputeCapability() const {
-        return std::make_pair(m_vkCudaKernelLaunchProperties.computeCapabilityMajor, m_vkCudaKernelLaunchProperties.computeCapabilityMinor);
+    std::optional<std::pair<uint32_t, uint32_t>> NvapiAdapter::GetComputeCapability() const {
+        if (!IsVkDeviceExtensionSupported(VK_NV_CUDA_KERNEL_LAUNCH_EXTENSION_NAME))
+            return {};
+
+        return std::make_optional(
+            std::make_pair(
+                m_vkCudaKernelLaunchProperties.computeCapabilityMajor,
+                m_vkCudaKernelLaunchProperties.computeCapabilityMinor));
     }
 
     bool NvapiAdapter::IsVkDeviceExtensionSupported(const std::string& name) const {

--- a/src/nvapi/nvapi_adapter.h
+++ b/src/nvapi/nvapi_adapter.h
@@ -38,7 +38,7 @@ namespace dxvk {
         [[nodiscard]] uint32_t GetBoardId() const;
         [[nodiscard]] std::optional<LUID> GetLuid() const;
         [[nodiscard]] NV_GPU_ARCHITECTURE_ID GetArchitectureId() const;
-        [[nodiscard]] std::pair<uint32_t, uint32_t> GetComputeCapability() const;
+        [[nodiscard]] std::optional<std::pair<uint32_t, uint32_t>> GetComputeCapability() const;
         [[nodiscard]] bool IsVkDeviceExtensionSupported(const std::string& name) const;
         [[nodiscard]] const MemoryInfo& GetMemoryInfo() const;
         [[nodiscard]] MemoryBudgetInfo GetCurrentMemoryBudgetInfo() const;

--- a/tests/nvapi_d3d12.cpp
+++ b/tests/nvapi_d3d12.cpp
@@ -245,7 +245,7 @@ TEST_CASE("D3D12 methods succeed", "[.d3d12]") {
             };
             auto args = GENERATE(
                 Data{VK_DRIVER_ID_NVIDIA_PROPRIETARY, 0x2000, {VK_KHR_FRAGMENT_SHADING_RATE_EXTENSION_NAME, VK_NV_CUDA_KERNEL_LAUNCH_EXTENSION_NAME}, 8, 6, true},
-                Data{VK_DRIVER_ID_NVIDIA_PROPRIETARY, 0x2000, {VK_KHR_FRAGMENT_SHADING_RATE_EXTENSION_NAME}, 0, 0, true},
+                Data{VK_DRIVER_ID_NVIDIA_PROPRIETARY, 0x2000, {VK_KHR_FRAGMENT_SHADING_RATE_EXTENSION_NAME}, 8, 6, true},
                 Data{VK_DRIVER_ID_NVIDIA_PROPRIETARY, 0x2000, {}, 0, 0, false},
                 Data{VK_DRIVER_ID_MESA_NVK, 0x2600, {VK_KHR_FRAGMENT_SHADING_RATE_EXTENSION_NAME}, 0, 0, true},
                 Data{VK_DRIVER_ID_MESA_NVK, 0x2600, {}, 0, 0, false},
@@ -270,6 +270,8 @@ TEST_CASE("D3D12 methods succeed", "[.d3d12]") {
                             vkProps.idProps->deviceLUIDValid = VK_TRUE;
                             vkProps.driverProps->driverID = args.driverId;
                             vkProps.props->deviceID = args.deviceId;
+                            if (args.extensionNames.contains(VK_KHR_FRAGMENT_SHADING_RATE_EXTENSION_NAME))
+                                vkProps.fragmentShadingRateProps->primitiveFragmentShadingRateWithMultipleViewports = VK_TRUE;
                             if (args.extensionNames.contains(VK_NV_CUDA_KERNEL_LAUNCH_EXTENSION_NAME)) {
                                 vkProps.cudaKernelLaunchProperties->computeCapabilityMajor = 8;
                                 vkProps.cudaKernelLaunchProperties->computeCapabilityMinor = 6;


### PR DESCRIPTION
Lets be prepared for wine versions that don't support VK_NV_cuda_kernel_launch, see https://gitlab.winehq.org/wine/wine/-/merge_requests/7743

BW version taken from https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/34331
