### PR TITLE
Allow multiple of the same latency marker for a given frameID

### DIFF
--- a/src/nvapi/low_latency_frame_id_generator.cpp
+++ b/src/nvapi/low_latency_frame_id_generator.cpp
@@ -4,7 +4,6 @@ namespace dxvk {
     LowLatencyFrameIdGenerator::LowLatencyFrameIdGenerator()
         : m_nextLowLatencyDeviceFrameId(1),
           m_applicationIdList({0}) {
-        m_lastFrameId.fill(std::numeric_limits<uint64_t>::max());
     }
 
     LowLatencyFrameIdGenerator::~LowLatencyFrameIdGenerator() = default;
@@ -40,10 +39,5 @@ namespace dxvk {
             return 0;
 
         return m_applicationIdList[((lowLatencyDeviceFrameId - 1) % applicationIdListSize)];
-    }
-
-    bool LowLatencyFrameIdGenerator::IsRepeatedFrame(uint64_t frameID, uint32_t markerType) {
-        // Should always be within bounds since we drop unsupported marker types in the entrypoints
-        return std::exchange(m_lastFrameId[markerType], frameID) == frameID;
     }
 }

--- a/src/nvapi/low_latency_frame_id_generator.h
+++ b/src/nvapi/low_latency_frame_id_generator.h
@@ -11,7 +11,6 @@ namespace dxvk {
         [[nodiscard]] bool LowLatencyDeviceFrameIdInWindow(uint64_t lowLatencyDeviceFrameId) const;
         uint64_t GetLowLatencyDeviceFrameId(uint64_t applicationFrameId);
         uint64_t GetApplicationFrameId(uint64_t lowLatencyDeviceFrameId);
-        [[nodiscard]] bool IsRepeatedFrame(uint64_t frameID, uint32_t markerType);
 
       private:
         std::mutex m_frameIdGeneratorMutex;
@@ -21,7 +20,5 @@ namespace dxvk {
 
         static constexpr uint32_t applicationIdListSize = 1000;
         std::array<uint64_t, applicationIdListSize> m_applicationIdList;
-
-        std::array<uint64_t, 13> m_lastFrameId;
     };
 }

--- a/src/nvapi/nvapi_d3d_low_latency_device.cpp
+++ b/src/nvapi/nvapi_d3d_low_latency_device.cpp
@@ -137,9 +137,6 @@ namespace dxvk {
     }
 
     HRESULT NvapiD3dLowLatencyDevice::SetLatencyMarker(uint64_t frameID, uint32_t markerType) {
-        if (m_frameIdGenerator.IsRepeatedFrame(frameID, markerType))
-            return S_OK; // Silently drop repeated frame IDs
-
         return m_d3dLowLatencyDevice->SetLatencyMarker(
             m_frameIdGenerator.GetLowLatencyDeviceFrameId(frameID), markerType);
     }

--- a/tests/nvapi_d3d.cpp
+++ b/tests/nvapi_d3d.cpp
@@ -413,20 +413,20 @@ TEST_CASE("D3D Reflex depending methods succeed", "[.d3d]") {
                 REQUIRE(NvAPI_D3D_SetLatencyMarker(reinterpret_cast<IUnknown*>(&d3d11Device), &latencyMarkerParams) == NVAPI_OK);
             }
 
-            SECTION("SetLatencyMarker drops repeated frame IDs and returns OK") {
+            SECTION("SetLatencyMarker passes through repeated frame IDs and returns OK") {
                 sequence seq1, seq2, seq3;
 
                 REQUIRE_CALL(lowLatencyDevice, SetLatencyMarker(1ULL, VK_LATENCY_MARKER_PRESENT_START_NV))
                     .IN_SEQUENCE(seq1)
-                    .TIMES(1)
+                    .TIMES(2)
                     .RETURN(S_OK);
                 REQUIRE_CALL(lowLatencyDevice, SetLatencyMarker(2ULL, VK_LATENCY_MARKER_PRESENT_START_NV))
                     .IN_SEQUENCE(seq2)
-                    .TIMES(1)
+                    .TIMES(2)
                     .RETURN(S_OK);
                 REQUIRE_CALL(lowLatencyDevice, SetLatencyMarker(2ULL, VK_LATENCY_MARKER_PRESENT_END_NV))
                     .IN_SEQUENCE(seq3)
-                    .TIMES(1)
+                    .TIMES(2)
                     .RETURN(S_OK);
 
                 REQUIRE(NvAPI_Initialize() == NVAPI_OK);


### PR DESCRIPTION
With frame generation apps will send multiple OUT_OF_BAND_PRESENT markers for a given frameID. This lets the Nvidia driver know that frame gen is happening.

dxvk-nvapi currently discards all but the first OUT_OF_BAND_PRESENT marker. This change removes that logic and passes through all of the app's markers.

Tested by running Cyberpunk 2077 with 4x frame generation and logging the markers received by the Nvidia driver. Originally we only saw one VK_LATENCY_MARKER_OUT_OF_BAND_PRESENT_START_NV marker per frameID. With this change we see four.