### PR TITLE
nvapi-disp: Sanitize hdr metadata input

### DIFF
--- a/src/nvapi_disp.cpp
+++ b/src/nvapi_disp.cpp
@@ -187,6 +187,13 @@ extern "C" {
                     .MaxContentLightLevel = pHDRColorDataV1->mastering_display_data.max_content_light_level,
                     .MaxFrameAverageLightLevel = pHDRColorDataV1->mastering_display_data.max_frame_average_light_level,
                 };
+
+                // Filter invalid input data
+                if (metadata.MinMasteringLuminance != 0 && metadata.MinMasteringLuminance >= metadata.MaxMasteringLuminance * 10000) {
+                    metadata.MaxMasteringLuminance = 0;
+                    metadata.MinMasteringLuminance = 0;
+                }
+
                 if (FAILED(interop->SetGlobalHDRState(colorspace, &metadata)))
                     return InvalidArgument(n);
             }

--- a/tests/nvapi_sysinfo_hdr.cpp
+++ b/tests/nvapi_sysinfo_hdr.cpp
@@ -261,6 +261,19 @@ TEST_CASE("HDR related sysinfo methods succeed", "[.sysinfo-hdr]") {
             REQUIRE(inMetadata.MaxFrameAverageLightLevel == 799);
         }
 
+        SECTION("HdrColorControl (V2) with set command filters invalid input and returns OK") {
+            NV_HDR_COLOR_DATA colorData{};
+            colorData.version = NV_HDR_COLOR_DATA_VER2;
+            colorData.cmd = NV_HDR_CMD_SET;
+            colorData.hdrMode = NV_HDR_MODE_UHDA_PASSTHROUGH;
+            colorData.mastering_display_data.min_display_mastering_luminance = 100;
+            colorData.mastering_display_data.max_display_mastering_luminance = 0;
+
+            REQUIRE(NvAPI_Disp_HdrColorControl(primaryDisplayId, &colorData) == NVAPI_OK);
+            REQUIRE(inMetadata.MinMasteringLuminance == 0);
+            REQUIRE(inMetadata.MaxMasteringLuminance == 0);
+        }
+
         SECTION("HdrColorControl with unknown struct version returns incompatible-struct-version") {
             NV_HDR_COLOR_DATA colorData;
             colorData.version = NV_HDR_COLOR_DATA_VER2 + 1;


### PR DESCRIPTION
~Fallback to the monitor's actual EDID capabilities if the application fails to provide valid luminance boundaries. This mimics Windows NVIDIA driver behavior.~ Amended to just filter out invalid values.

This is not on a hot path and seems to fix a real word issue, so I guess being pragmatic here is fine. Based on https://forums.developer.nvidia.com/t/595-release-feedback-discussion/362561/296 and thus https://github.com/zaxen/dxvk-nvapi/commit/79c4bea12df7f499f8844a38cf48907a07bc9e54 

cc: @zaxen
