### PR TITLE
nvapi-d3d12: Respect DXVK_NVAPI_D3D12_NV_SHADER_EXTN in reordering cap query

### DIFF
--- a/src/nvapi_d3d12.cpp
+++ b/src/nvapi_d3d12.cpp
@@ -664,7 +664,7 @@ extern "C" {
                 auto adapterSupport = adapter && adapter->GetReorderingHint() == VK_RAY_TRACING_INVOCATION_REORDER_MODE_REORDER_NV;
                 auto deviceSupport = device && device->IsNvShaderExtnOpCodeSupported(NV_EXTN_OP_HIT_OBJECT_REORDER_THREAD);
 
-                *static_cast<NVAPI_D3D12_RAYTRACING_THREAD_REORDERING_CAPS*>(pData) = adapterSupport && deviceSupport
+                *static_cast<NVAPI_D3D12_RAYTRACING_THREAD_REORDERING_CAPS*>(pData) = adapterSupport && deviceSupport && env::isD3d12NvShaderExtnEnabled()
                     ? NVAPI_D3D12_RAYTRACING_THREAD_REORDERING_CAP_STANDARD
                     : NVAPI_D3D12_RAYTRACING_THREAD_REORDERING_CAP_NONE;
                 break;


### PR DESCRIPTION
Derp. Cyberpunk 2077 strikes again.