### PR TITLE
util: Remove Pascal spoofing for War Thunder

### DIFF
--- a/src/util/util_env.cpp
+++ b/src/util/util_env.cpp
@@ -136,11 +136,6 @@ namespace dxvk::env {
             return true;
         }
 
-        if (architectureId >= NV_GPU_ARCHITECTURE_TU100 && getExecutableName() == std::string("aces.exe")) {
-            log::info("Spoofing Pascal for Turing and later due to detecting aces.exe (War Thunder)");
-            return true;
-        }
-
         return false;
     }
 


### PR DESCRIPTION
Looks like the earlier crashes with D3D11 i.c.w. DLSS have been fixed in the meantime.

<img width="802" height="829" alt="Screenshot From 2026-06-03 20-20-52" src="https://github.com/user-attachments/assets/f6b1052b-d603-435a-8d52-aa2aac68519c" />

Originally added in https://github.com/jp7677/dxvk-nvapi/pull/172 based on https://github.com/jp7677/dxvk-nvapi/issues/171