### PR TITLE
NVAPI support for OMM

### DIFF
--- a/src/interfaces/vkd3d-proton_interfaces.h
+++ b/src/interfaces/vkd3d-proton_interfaces.h
@@ -24,11 +24,17 @@
 #endif // defined(__GNUC__) || defined(__clang__)
 
 enum D3D12_VK_EXTENSION : uint32_t {
+    D3D12_VK_OPACITY_MICROMAP = 0x0,
     D3D12_VK_NVX_BINARY_IMPORT = 0x1,
     D3D12_VK_NVX_IMAGE_VIEW_HANDLE = 0x2,
     D3D12_VK_NV_LOW_LATENCY_2 = 0x3,
     D3D12_VK_NV_OPTICAL_FLOW = 0x4
 };
+
+typedef enum D3D12_VK_EXT_PIPELINE_CREATION_STATE_FLAG {
+    D3D12_VK_EXT_PIPELINE_CREATION_STATE_FLAGS_NONE = 0x0,
+    D3D12_VK_EXT_PIPELINE_CREATION_STATE_FLAGS_ENABLE_OMM_SUPPORT = 0x1
+} D3D12_VK_EXT_PIPELINE_CREATION_STATE_FLAG;
 
 enum D3D12_OUT_OF_BAND_CQ_TYPE : uint32_t {
     D3D_OUT_OF_BAND_RENDER = 0x0,
@@ -163,6 +169,11 @@ ID3D12DeviceExt4 : public ID3D12DeviceExt3 {
     virtual HRESULT SetNvShaderExtnSlotSpace(UINT32 uav_slot, UINT32 uav_space, BOOL local_thread) = 0;
 };
 
+MIDL_INTERFACE("e51323f6-3541-4ddf-894d-8a8c70e3e427")
+ID3D12DeviceExt5 : public ID3D12DeviceExt4 {
+    virtual BOOL SetCreatePipelineStateFlagsNVAPI(D3D12_VK_EXT_PIPELINE_CREATION_STATE_FLAG pipeline_state_flags) = 0;
+};
+
 MIDL_INTERFACE("39da4e09-bd1c-4198-9fae-86bbe3be41fd")
 ID3D12DXVKInteropDevice : public IUnknown {
     virtual HRESULT STDMETHODCALLTYPE GetDXGIAdapter(
@@ -261,6 +272,12 @@ ID3D12GraphicsCommandListExt1 : public ID3D12GraphicsCommandListExt {
         UINT32 raw_params_count) = 0;
 };
 
+MIDL_INTERFACE("3bb8ce38-abef-484f-8f88-d5af90ac19fb")
+ID3D12GraphicsCommandListExt2 : public ID3D12GraphicsCommandListExt1 {
+    virtual BOOL STDMETHODCALLTYPE VerifyOpacityMicromapArrayNVAPI(
+        D3D12_GPU_VIRTUAL_ADDRESS opacity_micromap_array) = 0;
+};
+
 MIDL_INTERFACE("40ed3f96-e773-e9bc-fc0c-e95560c99ad6")
 ID3D12CommandQueueExt : public IUnknown {
     virtual HRESULT STDMETHODCALLTYPE NotifyOutOfBandCommandQueue(
@@ -273,9 +290,11 @@ __CRT_UUID_DECL(ID3D12DeviceExt1, 0x099a73fd, 0x2199, 0x4f45, 0xbf, 0x48, 0x0e, 
 __CRT_UUID_DECL(ID3D12DeviceExt2, 0xe859c4ac, 0xba8f, 0x41c4, 0x8e, 0xac, 0x11, 0x37, 0xfd, 0xe6, 0x15, 0x8d);
 __CRT_UUID_DECL(ID3D12DeviceExt3, 0x3aefa75c, 0xc9f3, 0x4b7f, 0xa1, 0x80, 0x5d, 0xf6, 0x95, 0xd0, 0x83, 0xbf);
 __CRT_UUID_DECL(ID3D12DeviceExt4, 0xa91b5617, 0xa06a, 0x4d6f, 0xb4, 0x37, 0x03, 0xeb, 0xbe, 0xf9, 0x14, 0x15);
+__CRT_UUID_DECL(ID3D12DeviceExt5, 0xe51323f6, 0x3541, 0x4ddf, 0x89, 0x4d, 0x8a, 0x8c, 0x70, 0xe3, 0xe4, 0x27);
 __CRT_UUID_DECL(ID3D12DXVKInteropDevice, 0x39da4e09, 0xbd1c, 0x4198, 0x9f, 0xae, 0x86, 0xbb, 0xe3, 0xbe, 0x41, 0xfd);
 __CRT_UUID_DECL(ID3D12DXVKInteropDevice1, 0x902d8115, 0x59eb, 0x4406, 0x95, 0x18, 0xfe, 0x00, 0xf9, 0x91, 0xee, 0x65);
 __CRT_UUID_DECL(ID3D12GraphicsCommandListExt, 0x77a86b09, 0x2bea, 0x4801, 0xb8, 0x9a, 0x37, 0x64, 0x8e, 0x10, 0x4a, 0xf1);
 __CRT_UUID_DECL(ID3D12GraphicsCommandListExt1, 0xd53b0028, 0xafb4, 0x4b65, 0xa4, 0xf1, 0x7b, 0x0d, 0xaa, 0xa6, 0x5b, 0x4f);
+__CRT_UUID_DECL(ID3D12GraphicsCommandListExt2, 0x3bb8ce38, 0xabef, 0x484f, 0x8f, 0x88, 0xd5, 0xaf, 0x90, 0xac, 0x19, 0xfb);
 __CRT_UUID_DECL(ID3D12CommandQueueExt, 0x40ed3f96, 0xe773, 0xe9bc, 0xfc, 0x0c, 0xe9, 0x55, 0x60, 0xc9, 0x9a, 0xd6);
 #endif

--- a/src/meson.build
+++ b/src/meson.build
@@ -17,6 +17,7 @@ nvapi_src = files([
   'nvapi/nvapi_d3d12_device.cpp',
   'nvapi/nvapi_d3d12_graphics_command_list.cpp',
   'nvapi/nvapi_d3d12_command_queue.cpp',
+  'nvapi/nvapi_as_convert.cpp',
   'nvapi_globals.cpp',
   'nvapi.cpp',
   'nvapi_d3d.cpp',

--- a/src/nvapi/nvapi_as_convert.cpp
+++ b/src/nvapi/nvapi_as_convert.cpp
@@ -1,0 +1,246 @@
+#include "nvapi_as_convert.h"
+#include "../util/util_log.h"
+#include "../util/util_statuscode.h"
+
+namespace dxvk {
+
+    NvAPI_Status BuildFlagsToD3d12(D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAGS& d3d12Flags,
+        NVAPI_D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAGS_EX nvapiFlags,
+        bool supportsOmm) {
+        constexpr auto n = __func__;
+        /* All currently known flags */
+        const NVAPI_D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAGS_EX allFlags =
+            static_cast<NVAPI_D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAGS_EX>(
+                NVAPI_D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_UPDATE_EX | NVAPI_D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_COMPACTION_EX | NVAPI_D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_PREFER_FAST_TRACE_EX | NVAPI_D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_PREFER_FAST_BUILD_EX | NVAPI_D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_MINIMIZE_MEMORY_EX | NVAPI_D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_PERFORM_UPDATE_EX | NVAPI_D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_OMM_UPDATE_EX | NVAPI_D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_DISABLE_OMMS_EX | NVAPI_D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_OMM_OPACITY_STATES_UPDATE_EX | NVAPI_D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_DATA_ACCESS_EX);
+
+        // D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_DATA_ACCESS is only
+        // defined in DirectX-Headers preview-tag releases (added in v1.717.0-preview).
+        // The vendored submodule tracks stable tags only, so we don't pull from preview,
+        // and we carry this provisional 0x100 (the value the preview header defines) until
+        // the flag ships in a stable DirectX-Headers tag and the submodule bump pulls it in.
+        static constexpr D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAGS
+            D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_DATA_ACCESS_PROVISIONAL =
+                static_cast<D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAGS>(0x100);
+
+        if (nvapiFlags & ~allFlags) {
+            log::info(str::format("Unsupported NVAPI build flags: ", nvapiFlags));
+            return InvalidArgument(n);
+        }
+
+        d3d12Flags = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_NONE;
+
+        if (nvapiFlags & NVAPI_D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_UPDATE_EX)
+            d3d12Flags |= D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_UPDATE;
+        if (nvapiFlags & NVAPI_D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_COMPACTION_EX)
+            d3d12Flags |= D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_COMPACTION;
+        if (nvapiFlags & NVAPI_D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_PREFER_FAST_TRACE_EX)
+            d3d12Flags |= D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_PREFER_FAST_TRACE;
+        if (nvapiFlags & NVAPI_D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_PREFER_FAST_BUILD_EX)
+            d3d12Flags |= D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_PREFER_FAST_BUILD;
+        if (nvapiFlags & NVAPI_D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_MINIMIZE_MEMORY_EX)
+            d3d12Flags |= D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_MINIMIZE_MEMORY;
+        if (nvapiFlags & NVAPI_D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_PERFORM_UPDATE_EX)
+            d3d12Flags |= D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_PERFORM_UPDATE;
+        if (nvapiFlags & NVAPI_D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_OMM_UPDATE_EX) {
+            if (!supportsOmm)
+                log::info("Ignoring NVAPI_D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_OMM_UPDATE_EX OMM not supported");
+            else
+                d3d12Flags |= D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_OMM_UPDATE;
+        }
+        if (nvapiFlags & NVAPI_D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_DISABLE_OMMS_EX) {
+            if (!supportsOmm)
+                log::info("Ignoring NVAPI_D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_DISABLE_OMMS_EX OMM not supported");
+            else
+                d3d12Flags |= D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_DISABLE_OMMS;
+        }
+        if (nvapiFlags & NVAPI_D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_OMM_OPACITY_STATES_UPDATE_EX) {
+            /* OPACITY_STATES_UPDATE_EX is a narrower data-only variant of ALLOW_OMM_UPDATE_EX. D3D12 only has the wide
+             * ALLOW_OMM_UPDATE, so widen rather than drop. */
+            if (!supportsOmm)
+                log::info("Ignoring NVAPI_D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_OMM_OPACITY_STATES_UPDATE_EX OMM not supported");
+            else
+                d3d12Flags |= D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_OMM_UPDATE;
+        }
+        if (nvapiFlags & NVAPI_D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_DATA_ACCESS_EX)
+            d3d12Flags |= D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_DATA_ACCESS_PROVISIONAL;
+
+        return Ok(n);
+    }
+
+    NvAPI_Status GeomDescTypeToD3d12(D3D12_RAYTRACING_GEOMETRY_TYPE& d3d12Type,
+        NVAPI_D3D12_RAYTRACING_GEOMETRY_TYPE_EX nvapiType) {
+        constexpr auto n = __func__;
+        switch (nvapiType) {
+            case NVAPI_D3D12_RAYTRACING_GEOMETRY_TYPE_TRIANGLES_EX:
+                d3d12Type = D3D12_RAYTRACING_GEOMETRY_TYPE_TRIANGLES;
+                return Ok(n);
+            case NVAPI_D3D12_RAYTRACING_GEOMETRY_TYPE_PROCEDURAL_PRIMITIVE_AABBS_EX:
+                d3d12Type = D3D12_RAYTRACING_GEOMETRY_TYPE_PROCEDURAL_PRIMITIVE_AABBS;
+                return Ok(n);
+            case NVAPI_D3D12_RAYTRACING_GEOMETRY_TYPE_OMM_TRIANGLES_EX:
+                d3d12Type = D3D12_RAYTRACING_GEOMETRY_TYPE_OMM_TRIANGLES;
+                return Ok(n);
+            case NVAPI_D3D12_RAYTRACING_GEOMETRY_TYPE_DMM_TRIANGLES_EX:
+                log::info("Unsupported NVAPI_D3D12_RAYTRACING_GEOMETRY_TYPE_DMM_TRIANGLES_EX");
+                return NotSupported(n);
+            case NVAPI_D3D12_RAYTRACING_GEOMETRY_TYPE_SPHERES_EX:
+                log::info("Unsupported NVAPI_D3D12_RAYTRACING_GEOMETRY_TYPE_SPHERES_EX");
+                return NotSupported(n);
+            case NVAPI_D3D12_RAYTRACING_GEOMETRY_TYPE_LSS_EX:
+                log::info("Unsupported NVAPI_D3D12_RAYTRACING_GEOMETRY_TYPE_LSS_EX");
+                return NotSupported(n);
+            default:
+                log::info(str::format("Unsupported NVAPI_D3D12_RAYTRACING_GEOMETRY_TYPE_ ", nvapiType));
+                return InvalidArgument(n);
+        }
+    }
+
+    const NVAPI_D3D12_RAYTRACING_GEOMETRY_DESC_EX& GeomDesc(
+        const NVAPI_D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS_EX& nvapiDesc, NvU32 index) {
+        if (nvapiDesc.descsLayout == D3D12_ELEMENTS_LAYOUT_ARRAY_OF_POINTERS)
+            return *nvapiDesc.ppGeometryDescs[index];
+        return *reinterpret_cast<const NVAPI_D3D12_RAYTRACING_GEOMETRY_DESC_EX*>(
+            reinterpret_cast<const uint8_t*>(nvapiDesc.pGeometryDescs) + nvapiDesc.geometryDescStrideInBytes * index);
+    }
+
+    NvAPI_Status OmmArrayBuildFlagsToD3d12(D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAGS& d3d12Flags,
+        NVAPI_D3D12_RAYTRACING_OPACITY_MICROMAP_ARRAY_BUILD_FLAGS nvapiFlags) {
+        constexpr auto n = __func__;
+        const NVAPI_D3D12_RAYTRACING_OPACITY_MICROMAP_ARRAY_BUILD_FLAGS allFlags =
+            static_cast<NVAPI_D3D12_RAYTRACING_OPACITY_MICROMAP_ARRAY_BUILD_FLAGS>(
+                NVAPI_D3D12_RAYTRACING_OPACITY_MICROMAP_ARRAY_BUILD_FLAG_PREFER_FAST_TRACE | NVAPI_D3D12_RAYTRACING_OPACITY_MICROMAP_ARRAY_BUILD_FLAG_PREFER_FAST_BUILD);
+
+        if (nvapiFlags & ~allFlags) {
+            log::info(str::format("Unsupported NVAPI OMM-Array build flags: ", nvapiFlags));
+            return InvalidArgument(n);
+        }
+
+        d3d12Flags = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_NONE;
+
+        if (nvapiFlags & NVAPI_D3D12_RAYTRACING_OPACITY_MICROMAP_ARRAY_BUILD_FLAG_PREFER_FAST_TRACE)
+            d3d12Flags |= D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_PREFER_FAST_TRACE;
+        if (nvapiFlags & NVAPI_D3D12_RAYTRACING_OPACITY_MICROMAP_ARRAY_BUILD_FLAG_PREFER_FAST_BUILD)
+            d3d12Flags |= D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_PREFER_FAST_BUILD;
+
+        return Ok(n);
+    }
+
+    NvAPI_Status OmmArrayInputsToD3d12(D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS& d3d12Inputs,
+        D3D12_RAYTRACING_OPACITY_MICROMAP_ARRAY_DESC& arrayDesc,
+        const NVAPI_D3D12_BUILD_RAYTRACING_OPACITY_MICROMAP_ARRAY_INPUTS& nvapiInputs) {
+        constexpr auto n = __func__;
+
+        memset(&d3d12Inputs, 0x00, sizeof(d3d12Inputs));
+        memset(&arrayDesc, 0x00, sizeof(arrayDesc));
+
+        /* NVAPI_..._USAGE_COUNT and D3D12_..._HISTOGRAM_ENTRY are byte-compatible:
+         * { UINT count, UINT subdivisionLevel, OMM_FORMAT format }. Field sizes
+         * match (NvU32 == UINT == 4 bytes) and OMM_FORMAT enum values match
+         * (OC1_2_STATE=0x1, OC1_4_STATE=0x2 in both). Cast directly. */
+        arrayDesc.NumOmmHistogramEntries = nvapiInputs.numOMMUsageCounts;
+        arrayDesc.pOmmHistogram = reinterpret_cast<const D3D12_RAYTRACING_OPACITY_MICROMAP_HISTOGRAM_ENTRY*>(
+            nvapiInputs.pOMMUsageCounts);
+        arrayDesc.InputBuffer = nvapiInputs.inputBuffer;
+        arrayDesc.PerOmmDescs = nvapiInputs.perOMMDescs;
+
+        d3d12Inputs.Type = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_OPACITY_MICROMAP_ARRAY;
+        d3d12Inputs.NumDescs = 1;
+        d3d12Inputs.DescsLayout = D3D12_ELEMENTS_LAYOUT_ARRAY;
+        d3d12Inputs.pOpacityMicromapArrayDesc = &arrayDesc;
+
+        if (NvAPI_Status status = OmmArrayBuildFlagsToD3d12(d3d12Inputs.Flags, nvapiInputs.flags); status != NVAPI_OK)
+            return status;
+
+        return Ok(n);
+    }
+
+    NvAPI_Status NvapiAsConverter::Convert(D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS& d3d12Desc,
+        const NVAPI_D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS_EX& nvapiDesc,
+        bool supportsOmm) {
+        constexpr auto n = __func__;
+        memset(&d3d12Desc, 0x00, sizeof(d3d12Desc));
+
+        d3d12Desc.Type = nvapiDesc.type;
+        d3d12Desc.NumDescs = nvapiDesc.numDescs;
+
+        if (NvAPI_Status status = BuildFlagsToD3d12(d3d12Desc.Flags, nvapiDesc.flags, supportsOmm); status != NVAPI_OK)
+            return status;
+
+        if (nvapiDesc.type == D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL) {
+            d3d12Desc.DescsLayout = nvapiDesc.descsLayout;
+            d3d12Desc.InstanceDescs = nvapiDesc.instanceDescs;
+        } else {
+            const bool usesStride = nvapiDesc.descsLayout != D3D12_ELEMENTS_LAYOUT_ARRAY_OF_POINTERS;
+
+            Reserve(nvapiDesc.numDescs);
+
+            d3d12Desc.DescsLayout = D3D12_ELEMENTS_LAYOUT_ARRAY;
+            d3d12Desc.pGeometryDescs = m_geometryDescs;
+
+            for (auto i = 0U; i < nvapiDesc.numDescs; i++) {
+                const NVAPI_D3D12_RAYTRACING_GEOMETRY_DESC_EX& nvapiGeomDesc = GeomDesc(nvapiDesc, i);
+                D3D12_RAYTRACING_GEOMETRY_DESC& d3d12GeomDesc = m_geometryDescs[i];
+                D3D12_RAYTRACING_GEOMETRY_OMM_LINKAGE_DESC& d3d12OpacityMicromapLinkageDesc =
+                    m_opacityMicromapLinkageDescs[i];
+
+                d3d12GeomDesc.Flags = nvapiGeomDesc.flags;
+                if (NvAPI_Status status = GeomDescTypeToD3d12(d3d12GeomDesc.Type, nvapiGeomDesc.type); status != NVAPI_OK)
+                    return status;
+
+                switch (nvapiGeomDesc.type) {
+                    case NVAPI_D3D12_RAYTRACING_GEOMETRY_TYPE_TRIANGLES_EX:
+                        if (usesStride && nvapiDesc.geometryDescStrideInBytes < offsetof(NVAPI_D3D12_RAYTRACING_GEOMETRY_DESC_EX, triangles) + sizeof(D3D12_RAYTRACING_GEOMETRY_TRIANGLES_DESC)) {
+                            log::info(str::format("geometryDescStrideInBytes ", nvapiDesc.geometryDescStrideInBytes,
+                                " too small for TRIANGLES geometry."));
+                            return InvalidArgument(n);
+                        }
+
+                        d3d12GeomDesc.Triangles = nvapiGeomDesc.triangles;
+                        break;
+
+                    case NVAPI_D3D12_RAYTRACING_GEOMETRY_TYPE_PROCEDURAL_PRIMITIVE_AABBS_EX:
+                        if (usesStride && nvapiDesc.geometryDescStrideInBytes < offsetof(NVAPI_D3D12_RAYTRACING_GEOMETRY_DESC_EX, aabbs) + sizeof(D3D12_RAYTRACING_GEOMETRY_AABBS_DESC)) {
+                            log::info(str::format("geometryDescStrideInBytes ", nvapiDesc.geometryDescStrideInBytes,
+                                " too small for AABBS geometry."));
+                            return InvalidArgument(n);
+                        }
+
+                        d3d12GeomDesc.AABBs = nvapiGeomDesc.aabbs;
+                        break;
+
+                    case NVAPI_D3D12_RAYTRACING_GEOMETRY_TYPE_OMM_TRIANGLES_EX:
+                        if (!supportsOmm) {
+                            log::info("Triangles with OMM attachment passed to acceleration structure build when OMM is not supported");
+                            return NotSupported(n);
+                        }
+                        if (usesStride && nvapiDesc.geometryDescStrideInBytes < offsetof(NVAPI_D3D12_RAYTRACING_GEOMETRY_DESC_EX, ommTriangles) + sizeof(NVAPI_D3D12_RAYTRACING_GEOMETRY_OMM_TRIANGLES_DESC)) {
+                            log::info(str::format("geometryDescStrideInBytes ", nvapiDesc.geometryDescStrideInBytes,
+                                " too small for OMM_TRIANGLES geometry."));
+                            return InvalidArgument(n);
+                        }
+
+                        d3d12GeomDesc.OmmTriangles.pTriangles = &nvapiGeomDesc.ommTriangles.triangles;
+                        d3d12GeomDesc.OmmTriangles.pOmmLinkage = &d3d12OpacityMicromapLinkageDesc;
+
+                        d3d12OpacityMicromapLinkageDesc.OpacityMicromapIndexBuffer =
+                            nvapiGeomDesc.ommTriangles.ommAttachment.opacityMicromapIndexBuffer;
+                        d3d12OpacityMicromapLinkageDesc.OpacityMicromapIndexFormat =
+                            nvapiGeomDesc.ommTriangles.ommAttachment.opacityMicromapIndexFormat;
+                        d3d12OpacityMicromapLinkageDesc.OpacityMicromapBaseLocation =
+                            nvapiGeomDesc.ommTriangles.ommAttachment.opacityMicromapBaseLocation;
+                        d3d12OpacityMicromapLinkageDesc.OpacityMicromapArray =
+                            nvapiGeomDesc.ommTriangles.ommAttachment.opacityMicromapArray;
+
+                        break;
+
+                    default:
+                        log::info(str::format("Unsupported geometry type ", nvapiGeomDesc.type));
+                        return InvalidArgument(n);
+                }
+            }
+        }
+
+        return Ok(n);
+    }
+
+} // ~namespace dxvk

--- a/src/nvapi/nvapi_as_convert.h
+++ b/src/nvapi/nvapi_as_convert.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "../nvapi_private.h"
+
+namespace dxvk {
+    [[nodiscard]] NvAPI_Status OmmArrayInputsToD3d12(D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS& d3d12Inputs,
+        D3D12_RAYTRACING_OPACITY_MICROMAP_ARRAY_DESC& arrayDesc,
+        const NVAPI_D3D12_BUILD_RAYTRACING_OPACITY_MICROMAP_ARRAY_INPUTS& nvapiInputs);
+
+    class NvapiAsConverter {
+      public:
+        NvapiAsConverter() {
+            m_reserved = StackReserve;
+            m_geometryDescs = m_geometryDescsStack;
+            m_opacityMicromapLinkageDescs = m_opacityMicromapLinkageDescsStack;
+        }
+        ~NvapiAsConverter() {
+            if (m_geometryDescs != m_geometryDescsStack)
+                delete[] m_geometryDescs;
+            if (m_opacityMicromapLinkageDescs != m_opacityMicromapLinkageDescsStack)
+                delete[] m_opacityMicromapLinkageDescs;
+        }
+        NvapiAsConverter(const NvapiAsConverter&) = delete;
+        NvapiAsConverter& operator=(const NvapiAsConverter&) = delete;
+
+        [[nodiscard]] NvAPI_Status Convert(D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS& d3d12Desc,
+            const NVAPI_D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS_EX& nvapiDesc,
+            bool supportsOmm);
+
+      private:
+        static constexpr size_t StackReserve = 16;
+
+        // Convert is destructive.
+        void Reserve(size_t reserveSize) {
+            if (reserveSize > m_reserved) {
+                if (m_geometryDescs != m_geometryDescsStack)
+                    delete[] m_geometryDescs;
+                if (m_opacityMicromapLinkageDescs != m_opacityMicromapLinkageDescsStack)
+                    delete[] m_opacityMicromapLinkageDescs;
+                m_geometryDescs = new D3D12_RAYTRACING_GEOMETRY_DESC[reserveSize];
+                m_opacityMicromapLinkageDescs = new D3D12_RAYTRACING_GEOMETRY_OMM_LINKAGE_DESC[reserveSize];
+                m_reserved = reserveSize;
+            }
+        }
+
+        size_t m_reserved;
+        D3D12_RAYTRACING_GEOMETRY_DESC m_geometryDescsStack[StackReserve];
+        D3D12_RAYTRACING_GEOMETRY_OMM_LINKAGE_DESC m_opacityMicromapLinkageDescsStack[StackReserve];
+        D3D12_RAYTRACING_GEOMETRY_DESC* m_geometryDescs;
+        D3D12_RAYTRACING_GEOMETRY_OMM_LINKAGE_DESC* m_opacityMicromapLinkageDescs;
+    };
+}

--- a/src/nvapi/nvapi_d3d11_device.cpp
+++ b/src/nvapi/nvapi_d3d11_device.cpp
@@ -67,10 +67,8 @@ namespace dxvk {
         m_supportsNvxImageViewHandle = m_dxvkDevice->GetExtensionSupport(D3D11_VK_NVX_IMAGE_VIEW_HANDLE);
         m_supportsExtMultiDrawIndirect = m_dxvkDevice->GetExtensionSupport(D3D11_VK_EXT_MULTI_DRAW_INDIRECT);
 
-        Com<ID3D11VkExtDevice1> dxvkDevice1;
-        Com<ID3D11VkExtContext1> dxvkContext1;
-        m_supportsExtDevice1 = SUCCEEDED(dxvkDevice->QueryInterface(IID_PPV_ARGS(&dxvkDevice1)));
-        m_supportsExtContext1 = SUCCEEDED(dxvkContext->QueryInterface(IID_PPV_ARGS(&dxvkContext1)));
+        m_supportsExtDevice1 = probeInterfaceChain(dxvkDevice, {__uuidof(ID3D11VkExtDevice1)}) >= 1;
+        m_supportsExtContext1 = probeInterfaceChain(dxvkContext, {__uuidof(ID3D11VkExtContext1)}) >= 1;
     }
 
     HRESULT NvapiD3d11Device::SetDepthBoundsTest(const bool enable, const float minDepth, const float maxDepth) const {

--- a/src/nvapi/nvapi_d3d12_device.cpp
+++ b/src/nvapi/nvapi_d3d12_device.cpp
@@ -77,19 +77,21 @@ namespace dxvk {
     }
 
     NvapiD3d12Device::NvapiD3d12Device(ID3D12DeviceExt* vkd3dDevice)
-        : m_vkd3dDevice(static_cast<ID3D12DeviceExt4*>(vkd3dDevice)) {
+        : m_vkd3dDevice(static_cast<ID3D12DeviceExt4*>(vkd3dDevice)) { // NOLINT(*-pro-type-static-cast-downcast)
+        uint32_t deviceExtTier = probeInterfaceChain(vkd3dDevice, {
+                                                                      __uuidof(ID3D12DeviceExt1),
+                                                                      __uuidof(ID3D12DeviceExt2),
+                                                                      __uuidof(ID3D12DeviceExt3),
+                                                                      __uuidof(ID3D12DeviceExt4),
+                                                                  });
+
         m_supportsNvxBinaryImport = vkd3dDevice->GetExtensionSupport(D3D12_VK_NVX_BINARY_IMPORT);
         m_supportsNvxImageViewHandle = vkd3dDevice->GetExtensionSupport(D3D12_VK_NVX_IMAGE_VIEW_HANDLE);
 
-        if (m_supportsNvxBinaryImport && m_supportsNvxImageViewHandle) {
-            if (Com<ID3D12DeviceExt2> deviceExt2; SUCCEEDED(m_vkd3dDevice->QueryInterface(IID_PPV_ARGS(&deviceExt2)))) {
-                m_supportsCubin64bit = deviceExt2->SupportsCubin64bit();
-            }
-        }
-
-        if (Com<ID3D12DeviceExt4> deviceExt4; SUCCEEDED(m_vkd3dDevice->QueryInterface(IID_PPV_ARGS(&deviceExt4)))) {
+        if (deviceExtTier >= 2 && m_supportsNvxBinaryImport && m_supportsNvxImageViewHandle)
+            m_supportsCubin64bit = m_vkd3dDevice->SupportsCubin64bit();
+        if (deviceExtTier >= 4)
             m_supportsNvShaderExtn = true;
-        }
     }
 
     HRESULT NvapiD3d12Device::CreateCubinComputeShaderWithName(const void* cubinData, NvU32 cubinSize, NvU32 blockX, NvU32 blockY, NvU32 blockZ, const char* shaderName, NVDX_ObjectHandle* pShader) {

--- a/src/nvapi/nvapi_d3d12_device.cpp
+++ b/src/nvapi/nvapi_d3d12_device.cpp
@@ -191,6 +191,10 @@ namespace dxvk {
         return m_vkd3dDevice->SetNvShaderExtnSlotSpace(uavSlot, uavSpace, localThread);
     }
 
+    bool NvapiD3d12Device::SetCreatePipelineStateFlagsNVAPI(D3D12_VK_EXT_PIPELINE_CREATION_STATE_FLAG pipeline_state_flags) {
+        return m_vkd3dDevice->SetCreatePipelineStateFlagsNVAPI(pipeline_state_flags);
+    }
+
     bool NvapiD3d12Device::IsOpacityMicromapSupported() const {
         return m_vkd3dDevice && m_supportsOpacityMicromap;
     }

--- a/src/nvapi/nvapi_d3d12_device.cpp
+++ b/src/nvapi/nvapi_d3d12_device.cpp
@@ -1,5 +1,4 @@
 #include "nvapi_d3d12_device.h"
-#include "../util/com_pointer.h"
 #include "../util/util_log.h"
 
 namespace dxvk {
@@ -88,6 +87,7 @@ namespace dxvk {
 
         m_supportsNvxBinaryImport = vkd3dDevice->GetExtensionSupport(D3D12_VK_NVX_BINARY_IMPORT);
         m_supportsNvxImageViewHandle = vkd3dDevice->GetExtensionSupport(D3D12_VK_NVX_IMAGE_VIEW_HANDLE);
+        m_supportsOpacityMicromap = deviceExtTier >= 5 && vkd3dDevice->GetExtensionSupport(D3D12_VK_OPACITY_MICROMAP);
 
         if (deviceExtTier >= 2 && m_supportsNvxBinaryImport && m_supportsNvxImageViewHandle)
             m_supportsCubin64bit = m_vkd3dDevice->SupportsCubin64bit();
@@ -189,5 +189,17 @@ namespace dxvk {
             return E_NOTIMPL;
 
         return m_vkd3dDevice->SetNvShaderExtnSlotSpace(uavSlot, uavSpace, localThread);
+    }
+
+    bool NvapiD3d12Device::IsOpacityMicromapSupported() const {
+        return m_vkd3dDevice && m_supportsOpacityMicromap;
+    }
+
+    bool NvapiD3d12Device::IsOpacityMicromapSupported(ID3D12Device* d3dDevice) {
+        auto device = GetOrCreate(d3dDevice);
+        if (!device)
+            return false;
+
+        return device->IsOpacityMicromapSupported();
     }
 }

--- a/src/nvapi/nvapi_d3d12_device.cpp
+++ b/src/nvapi/nvapi_d3d12_device.cpp
@@ -77,12 +77,13 @@ namespace dxvk {
     }
 
     NvapiD3d12Device::NvapiD3d12Device(ID3D12DeviceExt* vkd3dDevice)
-        : m_vkd3dDevice(static_cast<ID3D12DeviceExt4*>(vkd3dDevice)) { // NOLINT(*-pro-type-static-cast-downcast)
+        : m_vkd3dDevice(static_cast<ID3D12DeviceExt5*>(vkd3dDevice)) { // NOLINT(*-pro-type-static-cast-downcast)
         uint32_t deviceExtTier = probeInterfaceChain(vkd3dDevice, {
                                                                       __uuidof(ID3D12DeviceExt1),
                                                                       __uuidof(ID3D12DeviceExt2),
                                                                       __uuidof(ID3D12DeviceExt3),
                                                                       __uuidof(ID3D12DeviceExt4),
+                                                                      __uuidof(ID3D12DeviceExt5),
                                                                   });
 
         m_supportsNvxBinaryImport = vkd3dDevice->GetExtensionSupport(D3D12_VK_NVX_BINARY_IMPORT);

--- a/src/nvapi/nvapi_d3d12_device.h
+++ b/src/nvapi/nvapi_d3d12_device.h
@@ -38,6 +38,7 @@ namespace dxvk {
 
         [[nodiscard]] static bool IsOpacityMicromapSupported(ID3D12Device* device);
         [[nodiscard]] bool IsOpacityMicromapSupported() const;
+        [[nodiscard]] bool SetCreatePipelineStateFlagsNVAPI(D3D12_VK_EXT_PIPELINE_CREATION_STATE_FLAG pipeline_state_flags);
 
       private:
         static std::unordered_map<ID3D12Device*, NvapiD3d12Device> m_nvapiDeviceMap;

--- a/src/nvapi/nvapi_d3d12_device.h
+++ b/src/nvapi/nvapi_d3d12_device.h
@@ -31,6 +31,9 @@ namespace dxvk {
         [[nodiscard]] bool IsNvShaderExtnOpCodeSupported(UINT32 opCode) const;
         [[nodiscard]] HRESULT SetNvShaderExtnSlotSpace(UINT32 uavSlot, UINT32 uavSpace, bool localThread) const;
 
+        [[nodiscard]] static bool IsOpacityMicromapSupported(ID3D12Device* device);
+        [[nodiscard]] bool IsOpacityMicromapSupported() const;
+
       private:
         static std::unordered_map<ID3D12Device*, NvapiD3d12Device> m_nvapiDeviceMap;
         static std::mutex m_mutex;
@@ -45,5 +48,6 @@ namespace dxvk {
         bool m_supportsNvShaderExtn = false;
         bool m_supportsNvxBinaryImport = false;
         bool m_supportsNvxImageViewHandle = false;
+        bool m_supportsOpacityMicromap = false;
     };
 }

--- a/src/nvapi/nvapi_d3d12_device.h
+++ b/src/nvapi/nvapi_d3d12_device.h
@@ -5,7 +5,7 @@
 #include "../interfaces/vkd3d-proton_interfaces.h"
 
 namespace dxvk {
-    class NvapiD3d12Device {
+    class NvapiD3d12Device final {
 
       public:
         static void Reset();
@@ -40,7 +40,7 @@ namespace dxvk {
 
         static std::optional<bool> m_cubin64bitSupportAvailable;
 
-        ID3D12DeviceExt4* m_vkd3dDevice{};
+        ID3D12DeviceExt5* m_vkd3dDevice{};
         bool m_supportsCubin64bit = false;
         bool m_supportsNvShaderExtn = false;
         bool m_supportsNvxBinaryImport = false;

--- a/src/nvapi/nvapi_d3d12_device.h
+++ b/src/nvapi/nvapi_d3d12_device.h
@@ -15,6 +15,11 @@ namespace dxvk {
 
         explicit NvapiD3d12Device(ID3D12DeviceExt* vkd3dDevice);
 
+        // Prevent default construction and copy semantics.
+        NvapiD3d12Device() = delete;
+        NvapiD3d12Device(const NvapiD3d12Device&) = delete;
+        NvapiD3d12Device& operator=(const NvapiD3d12Device&) = delete;
+
         [[nodiscard]] HRESULT CreateCubinComputeShaderWithName(const void* cubinData, NvU32 cubinSize, NvU32 blockX, NvU32 blockY, NvU32 blockZ, const char* shaderName, NVDX_ObjectHandle* pShader);
         [[nodiscard]] HRESULT CreateCubinComputeShaderEx(const void* cubinData, NvU32 cubinSize, NvU32 blockX, NvU32 blockY, NvU32 blockZ, NvU32 smemSize, const char* shaderName, NVDX_ObjectHandle* pShader);
         [[nodiscard]] HRESULT DestroyCubinComputeShader(NVDX_ObjectHandle shader);

--- a/src/nvapi/nvapi_d3d12_graphics_command_list.cpp
+++ b/src/nvapi/nvapi_d3d12_graphics_command_list.cpp
@@ -41,6 +41,15 @@ namespace dxvk {
                                                                              __uuidof(ID3D12GraphicsCommandListExt2),
                                                                          });
         m_supportsCubin64bit = commandListTier >= 1;
+
+        Com<ID3D12GraphicsCommandList> d3d12CommandList;
+        if (SUCCEEDED(vkd3dCommandList->QueryInterface(IID_PPV_ARGS(&d3d12CommandList)))) {
+            Com<ID3D12Device> device;
+            if (SUCCEEDED(d3d12CommandList->GetDevice(IID_PPV_ARGS(&device)))) {
+                if (auto nvapiDevice = NvapiD3d12Device::GetOrCreate(device.ptr()))
+                    m_supportsOpacityMicromap = nvapiDevice->IsOpacityMicromapSupported();
+            }
+        }
     }
 
     HRESULT NvapiD3d12GraphicsCommandList::LaunchCubinShader(NVDX_ObjectHandle pShader, NvU32 blockX, NvU32 blockY, NvU32 blockZ, const void* params, NvU32 paramSize) const {

--- a/src/nvapi/nvapi_d3d12_graphics_command_list.cpp
+++ b/src/nvapi/nvapi_d3d12_graphics_command_list.cpp
@@ -36,8 +36,10 @@ namespace dxvk {
 
     NvapiD3d12GraphicsCommandList::NvapiD3d12GraphicsCommandList(ID3D12GraphicsCommandListExt* vkd3dCommandList)
         : m_vkd3dGraphicsCommandList(static_cast<ID3D12GraphicsCommandListExt1*>(vkd3dCommandList)) { // NOLINT(*-pro-type-static-cast-downcast)
-        Com<ID3D12GraphicsCommandListExt1> commandListExt1;
-        m_supportsExtGraphicsCommandList1 = SUCCEEDED(vkd3dCommandList->QueryInterface(IID_PPV_ARGS(&commandListExt1)));
+        uint32_t commandListTier = probeInterfaceChain(vkd3dCommandList, {
+                                                                             __uuidof(ID3D12GraphicsCommandListExt1),
+                                                                         });
+        m_supportsCubin64bit = commandListTier >= 1;
     }
 
     HRESULT NvapiD3d12GraphicsCommandList::LaunchCubinShader(NVDX_ObjectHandle pShader, NvU32 blockX, NvU32 blockY, NvU32 blockZ, const void* params, NvU32 paramSize) const {
@@ -46,7 +48,7 @@ namespace dxvk {
 
         auto smem = NvapiD3d12Device::FindCubinSmem(pShader);
 
-        if (m_supportsExtGraphicsCommandList1)
+        if (m_supportsCubin64bit)
             return m_vkd3dGraphicsCommandList->LaunchCubinShaderEx(reinterpret_cast<D3D12_CUBIN_DATA_HANDLE*>(pShader), blockX, blockY, blockZ, smem, params, paramSize, nullptr, 0);
 
         if (smem != 0)

--- a/src/nvapi/nvapi_d3d12_graphics_command_list.cpp
+++ b/src/nvapi/nvapi_d3d12_graphics_command_list.cpp
@@ -35,9 +35,10 @@ namespace dxvk {
     }
 
     NvapiD3d12GraphicsCommandList::NvapiD3d12GraphicsCommandList(ID3D12GraphicsCommandListExt* vkd3dCommandList)
-        : m_vkd3dGraphicsCommandList(static_cast<ID3D12GraphicsCommandListExt1*>(vkd3dCommandList)) { // NOLINT(*-pro-type-static-cast-downcast)
+        : m_vkd3dGraphicsCommandList(static_cast<ID3D12GraphicsCommandListExt2*>(vkd3dCommandList)) { // NOLINT(*-pro-type-static-cast-downcast)
         uint32_t commandListTier = probeInterfaceChain(vkd3dCommandList, {
                                                                              __uuidof(ID3D12GraphicsCommandListExt1),
+                                                                             __uuidof(ID3D12GraphicsCommandListExt2),
                                                                          });
         m_supportsCubin64bit = commandListTier >= 1;
     }

--- a/src/nvapi/nvapi_d3d12_graphics_command_list.cpp
+++ b/src/nvapi/nvapi_d3d12_graphics_command_list.cpp
@@ -66,4 +66,8 @@ namespace dxvk {
 
         return m_vkd3dGraphicsCommandList->LaunchCubinShader(reinterpret_cast<D3D12_CUBIN_DATA_HANDLE*>(pShader), blockX, blockY, blockZ, params, paramSize);
     }
+
+    bool NvapiD3d12GraphicsCommandList::VerifyOpacityMicromapArrayNVAPI(D3D12_GPU_VIRTUAL_ADDRESS opacity_micromap_array) const {
+        return m_vkd3dGraphicsCommandList->VerifyOpacityMicromapArrayNVAPI(opacity_micromap_array);
+    }
 }

--- a/src/nvapi/nvapi_d3d12_graphics_command_list.h
+++ b/src/nvapi/nvapi_d3d12_graphics_command_list.h
@@ -19,6 +19,6 @@ namespace dxvk {
         static std::mutex m_mutex;
 
         ID3D12GraphicsCommandListExt1* m_vkd3dGraphicsCommandList{};
-        bool m_supportsExtGraphicsCommandList1 = false;
+        bool m_supportsCubin64bit = false;
     };
 }

--- a/src/nvapi/nvapi_d3d12_graphics_command_list.h
+++ b/src/nvapi/nvapi_d3d12_graphics_command_list.h
@@ -4,8 +4,7 @@
 #include "../interfaces/vkd3d-proton_interfaces.h"
 
 namespace dxvk {
-    class NvapiD3d12GraphicsCommandList {
-
+    class NvapiD3d12GraphicsCommandList final {
       public:
         static void Reset();
         [[nodiscard]] static NvapiD3d12GraphicsCommandList* GetOrCreate(ID3D12GraphicsCommandList* device);
@@ -14,11 +13,16 @@ namespace dxvk {
 
         [[nodiscard]] HRESULT LaunchCubinShader(NVDX_ObjectHandle shader, NvU32 blockX, NvU32 blockY, NvU32 blockZ, const void* params, NvU32 paramSize) const;
 
+        bool IsOpacityMicromapSupported() const {
+            return m_supportsOpacityMicromap;
+        }
+
       private:
         static std::unordered_map<ID3D12GraphicsCommandList*, NvapiD3d12GraphicsCommandList> m_nvapiDeviceMap;
         static std::mutex m_mutex;
 
         ID3D12GraphicsCommandListExt2* m_vkd3dGraphicsCommandList{};
         bool m_supportsCubin64bit = false;
+        bool m_supportsOpacityMicromap = false;
     };
 }

--- a/src/nvapi/nvapi_d3d12_graphics_command_list.h
+++ b/src/nvapi/nvapi_d3d12_graphics_command_list.h
@@ -22,6 +22,8 @@ namespace dxvk {
             return m_asConverter;
         }
 
+        [[nodiscard]] bool VerifyOpacityMicromapArrayNVAPI(D3D12_GPU_VIRTUAL_ADDRESS opacity_micromap_array) const;
+
       private:
         static std::unordered_map<ID3D12GraphicsCommandList*, NvapiD3d12GraphicsCommandList> m_nvapiDeviceMap;
         static std::mutex m_mutex;

--- a/src/nvapi/nvapi_d3d12_graphics_command_list.h
+++ b/src/nvapi/nvapi_d3d12_graphics_command_list.h
@@ -18,7 +18,7 @@ namespace dxvk {
         static std::unordered_map<ID3D12GraphicsCommandList*, NvapiD3d12GraphicsCommandList> m_nvapiDeviceMap;
         static std::mutex m_mutex;
 
-        ID3D12GraphicsCommandListExt1* m_vkd3dGraphicsCommandList{};
+        ID3D12GraphicsCommandListExt2* m_vkd3dGraphicsCommandList{};
         bool m_supportsCubin64bit = false;
     };
 }

--- a/src/nvapi/nvapi_d3d12_graphics_command_list.h
+++ b/src/nvapi/nvapi_d3d12_graphics_command_list.h
@@ -2,12 +2,13 @@
 
 #include "../nvapi_private.h"
 #include "../interfaces/vkd3d-proton_interfaces.h"
+#include "nvapi_as_convert.h"
 
 namespace dxvk {
     class NvapiD3d12GraphicsCommandList final {
       public:
         static void Reset();
-        [[nodiscard]] static NvapiD3d12GraphicsCommandList* GetOrCreate(ID3D12GraphicsCommandList* device);
+        [[nodiscard]] static NvapiD3d12GraphicsCommandList* GetOrCreate(ID3D12GraphicsCommandList* commandList);
 
         explicit NvapiD3d12GraphicsCommandList(ID3D12GraphicsCommandListExt* vkd3dCommandList);
 
@@ -17,6 +18,10 @@ namespace dxvk {
             return m_supportsOpacityMicromap;
         }
 
+        NvapiAsConverter& GetAsConverter() {
+            return m_asConverter;
+        }
+
       private:
         static std::unordered_map<ID3D12GraphicsCommandList*, NvapiD3d12GraphicsCommandList> m_nvapiDeviceMap;
         static std::mutex m_mutex;
@@ -24,5 +29,9 @@ namespace dxvk {
         ID3D12GraphicsCommandListExt2* m_vkd3dGraphicsCommandList{};
         bool m_supportsCubin64bit = false;
         bool m_supportsOpacityMicromap = false;
+
+        // Reused across calls so the per-build geometry-desc scratch settles at
+        // its max-N and stops hitting the heap. Per-instance state - not thread-safe.
+        NvapiAsConverter m_asConverter;
     };
 }

--- a/src/nvapi_d3d12.cpp
+++ b/src/nvapi_d3d12.cpp
@@ -4,6 +4,7 @@
 #include "nvapi/nvapi_d3d12_device.h"
 #include "nvapi/nvapi_d3d12_graphics_command_list.h"
 #include "nvapi/nvapi_d3d12_command_queue.h"
+#include "nvapi/nvapi_as_convert.h"
 #include "util/com_pointer.h"
 #include "util/util_statuscode.h"
 #include "util/util_op_code.h"
@@ -810,26 +811,32 @@ inline static bool ConvertBuildRaytracingAccelerationStructureInputs(const NVAPI
 NVAPI_FUNCTION NvAPI_D3D12_GetRaytracingAccelerationStructurePrebuildInfoEx(ID3D12Device5* pDevice, NVAPI_GET_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO_EX_PARAMS* pParams) {
     constexpr auto n = __func__;
     thread_local bool alreadyLoggedOk = false;
+    thread_local bool alreadyLoggedNoImplementation = false;
 
     if (log::tracing())
         log::trace(n, log::fmt::ptr(pDevice), log::fmt::ptr(pParams));
 
     if (!pDevice || !pParams)
         return InvalidArgument(n);
-
     if (pParams->version != NVAPI_GET_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO_EX_PARAMS_VER1)
         return IncompatibleStructVersion(n, pParams->version);
-
     if (!pParams->pDesc || !pParams->pInfo)
         return InvalidArgument(n);
 
-    std::vector<D3D12_RAYTRACING_GEOMETRY_DESC> geometryDescs{};
-    D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS desc{};
+    auto device = NvapiD3d12Device::GetOrCreate(pDevice);
+    if (!device)
+        return NoImplementation(n, alreadyLoggedNoImplementation);
 
-    if (!ConvertBuildRaytracingAccelerationStructureInputs(pParams->pDesc, geometryDescs, &desc))
-        return NotSupported(n);
+    const bool supportsOmm = device->IsOpacityMicromapSupported();
 
-    pDevice->GetRaytracingAccelerationStructurePrebuildInfo(&desc, pParams->pInfo);
+    D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS inputs;
+    /* Cannot cache the NvapiAsConverter per device, as device doesn't have to be thread safe, and NvapiAsConverter
+     * is destructive */
+    NvapiAsConverter asConverter;
+    if (auto status = asConverter.Convert(inputs, *pParams->pDesc, supportsOmm); status != NVAPI_OK)
+        return status;
+
+    pDevice->GetRaytracingAccelerationStructurePrebuildInfo(&inputs, pParams->pInfo);
 
     return Ok(n, alreadyLoggedOk);
 }

--- a/src/nvapi_d3d12.cpp
+++ b/src/nvapi_d3d12.cpp
@@ -735,26 +735,45 @@ NVAPI_FUNCTION NvAPI_D3D12_GetRaytracingCaps(ID3D12Device* pDevice, NVAPI_D3D12_
 }
 
 inline static bool ConvertBuildRaytracingAccelerationStructureInputs(const NVAPI_D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS_EX* nvDesc, std::vector<D3D12_RAYTRACING_GEOMETRY_DESC>& geometryDescs, D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS* d3dDesc) {
+    // assume that micromaps are not supported, allow only standard stuff to be passed
+    if ((nvDesc->flags & ~0x3f) != 0) {
+        log::info(str::format("Nonstandard flags passed to acceleration structure build: ", nvDesc->flags));
+        return false;
+    }
+
     d3dDesc->Type = nvDesc->type;
-    // assume that OMM via VK_EXT_opacity_micromap and DMM via VK_NV_displacement_micromap are not supported, allow only standard flags to be passed
-    d3dDesc->Flags = static_cast<D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAGS>(nvDesc->flags & 0x3f);
+    d3dDesc->Flags = static_cast<D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAGS>(nvDesc->flags);
     d3dDesc->NumDescs = nvDesc->numDescs;
     d3dDesc->DescsLayout = nvDesc->descsLayout;
 
-    if (d3dDesc->Type == D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL) {
+    if (nvDesc->type == D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL) {
         d3dDesc->InstanceDescs = nvDesc->instanceDescs;
         return true;
-    }
+    } else if (nvDesc->type == D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL && nvDesc->descsLayout == D3D12_ELEMENTS_LAYOUT_ARRAY_OF_POINTERS) {
+        for (unsigned i = 0; i < nvDesc->numDescs; ++i) {
+            switch (auto type = nvDesc->ppGeometryDescs[i]->type) {
+                case NVAPI_D3D12_RAYTRACING_GEOMETRY_TYPE_TRIANGLES_EX:
+                case NVAPI_D3D12_RAYTRACING_GEOMETRY_TYPE_PROCEDURAL_PRIMITIVE_AABBS_EX:
+                    // Supported as is.
+                    break;
+                case NVAPI_D3D12_RAYTRACING_GEOMETRY_TYPE_OMM_TRIANGLES_EX: // GetRaytracingCaps reports no OMM caps, we shouldn't reach this
+                    log::info("Triangles with OMM attachment passed to acceleration structure build when OMM is not supported");
+                    return false;
+                case NVAPI_D3D12_RAYTRACING_GEOMETRY_TYPE_DMM_TRIANGLES_EX: // GetRaytracingCaps reports no DMM caps, we shouldn't reach this
+                    log::info("Triangles with DMM attachment passed to acceleration structure build when DMM is not supported");
+                    return false;
+                default:
+                    log::info(str::format("Unknown NVAPI_D3D12_RAYTRACING_GEOMETRY_TYPE_EX: ", type));
+                    return false;
+            }
+        }
 
-    if (d3dDesc->Type == D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL && d3dDesc->DescsLayout == D3D12_ELEMENTS_LAYOUT_ARRAY_OF_POINTERS) {
         d3dDesc->ppGeometryDescs = reinterpret_cast<const D3D12_RAYTRACING_GEOMETRY_DESC* const*>(nvDesc->ppGeometryDescs);
         return true;
-    }
+    } else if (nvDesc->type == D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL && nvDesc->descsLayout == D3D12_ELEMENTS_LAYOUT_ARRAY) {
+        geometryDescs.resize(nvDesc->numDescs);
 
-    if (d3dDesc->Type == D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL && d3dDesc->DescsLayout == D3D12_ELEMENTS_LAYOUT_ARRAY) {
-        geometryDescs.resize(d3dDesc->NumDescs);
-
-        for (unsigned i = 0; i < d3dDesc->NumDescs; ++i) {
+        for (unsigned i = 0; i < nvDesc->numDescs; ++i) {
             auto& d3dGeoDesc = geometryDescs[i];
             auto& nvGeoDesc = *reinterpret_cast<const NVAPI_D3D12_RAYTRACING_GEOMETRY_DESC_EX*>(reinterpret_cast<const std::byte*>(nvDesc->pGeometryDescs) + (i * nvDesc->geometryDescStrideInBytes));
 
@@ -808,7 +827,7 @@ NVAPI_FUNCTION NvAPI_D3D12_GetRaytracingAccelerationStructurePrebuildInfoEx(ID3D
     D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS desc{};
 
     if (!ConvertBuildRaytracingAccelerationStructureInputs(pParams->pDesc, geometryDescs, &desc))
-        return InvalidArgument(n);
+        return NotSupported(n);
 
     pDevice->GetRaytracingAccelerationStructurePrebuildInfo(&desc, pParams->pInfo);
 
@@ -840,7 +859,7 @@ NVAPI_FUNCTION NvAPI_D3D12_BuildRaytracingAccelerationStructureEx(ID3D12Graphics
     };
 
     if (!ConvertBuildRaytracingAccelerationStructureInputs(&pParams->pDesc->inputs, geometryDescs, &desc.Inputs))
-        return InvalidArgument(n);
+        return NotSupported(n);
 
     pCommandList->BuildRaytracingAccelerationStructure(&desc, pParams->numPostbuildInfoDescs, pParams->pPostbuildInfoDescs);
 

--- a/src/nvapi_d3d12.cpp
+++ b/src/nvapi_d3d12.cpp
@@ -1006,6 +1006,47 @@ NVAPI_FUNCTION NvAPI_D3D12_RelocateRaytracingOpacityMicromapArray(ID3D12Graphics
     return Ok(n, alreadyLoggedOk);
 }
 
+NVAPI_FUNCTION NvAPI_D3D12_EmitRaytracingOpacityMicromapArrayPostbuildInfo(ID3D12GraphicsCommandList4* pCommandList, const NVAPI_EMIT_RAYTRACING_OPACITY_MICROMAP_ARRAY_POSTBUILD_INFO_PARAMS* pParams) {
+    constexpr auto n = __func__;
+    thread_local bool alreadyLoggedNoImplementation = false;
+    thread_local bool alreadyLoggedOk = false;
+
+    if (log::tracing())
+        log::trace(n, log::fmt::ptr(pCommandList), log::fmt::ptr(pParams));
+
+    if (!pCommandList || !pParams)
+        return InvalidArgument(n);
+    if (pParams->version != NVAPI_EMIT_RAYTRACING_OPACITY_MICROMAP_ARRAY_POSTBUILD_INFO_PARAMS_VER1)
+        return IncompatibleStructVersion(n, pParams->version);
+    if (!pParams->pDesc || (pParams->numSources && !pParams->pSources))
+        return InvalidArgument(n);
+
+    auto commandList = NvapiD3d12GraphicsCommandList::GetOrCreate(pCommandList);
+    if (!commandList)
+        return NoImplementation(n, alreadyLoggedNoImplementation);
+    if (!commandList->IsOpacityMicromapSupported())
+        return NotSupported(n);
+
+    D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_DESC d3d12Desc;
+    d3d12Desc.DestBuffer = pParams->pDesc->destBuffer;
+    switch (pParams->pDesc->infoType) {
+        case NVAPI_D3D12_RAYTRACING_OPACITY_MICROMAP_ARRAY_POSTBUILD_INFO_CURRENT_SIZE:
+            d3d12Desc.InfoType = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_CURRENT_SIZE;
+            break;
+        default:
+            log::info(str::format("Unsupported NVAPI OMM-Array postbuild info type: ",
+                static_cast<int>(pParams->pDesc->infoType)));
+            return InvalidArgument(n);
+    }
+
+    pCommandList->EmitRaytracingAccelerationStructurePostbuildInfo(
+        &d3d12Desc,
+        pParams->numSources,
+        pParams->pSources);
+
+    return Ok(n, alreadyLoggedOk);
+}
+
 NVAPI_FUNCTION NvAPI_D3D12_NotifyOutOfBandCommandQueue(ID3D12CommandQueue* pCommandQueue, NV_OUT_OF_BAND_CQ_TYPE cqType) {
     constexpr auto n = __func__;
     thread_local bool alreadyLoggedOk = false;

--- a/src/nvapi_d3d12.cpp
+++ b/src/nvapi_d3d12.cpp
@@ -879,6 +879,43 @@ NVAPI_FUNCTION NvAPI_D3D12_SetCreatePipelineStateOptions(ID3D12Device5* pDevice,
     return Ok(n, alreadyLoggedOk);
 }
 
+NVAPI_FUNCTION NvAPI_D3D12_CheckDriverMatchingIdentifierEx(ID3D12Device5* pDevice, NVAPI_CHECK_DRIVER_MATCHING_IDENTIFIER_EX_PARAMS* pParams) {
+    constexpr auto n = __func__;
+    thread_local bool alreadyLoggedOk = false;
+    thread_local bool alreadyLoggedNoImplementation = false;
+
+    if (log::tracing())
+        log::trace(n, log::fmt::ptr(pDevice), log::fmt::ptr(pParams));
+
+    if (!pDevice || !pParams)
+        return InvalidArgument(n);
+
+    if (pParams->version != NVAPI_CHECK_DRIVER_MATCHING_IDENTIFIER_EX_PARAMS_VER1)
+        return IncompatibleStructVersion(n, pParams->version);
+
+    auto device = NvapiD3d12Device::GetOrCreate(pDevice);
+    if (!device)
+        return NoImplementation(n, alreadyLoggedNoImplementation);
+
+    D3D12_SERIALIZED_DATA_TYPE d3d12Type;
+    switch (pParams->serializedDataType) {
+        case NVAPI_D3D12_SERIALIZED_DATA_RAYTRACING_ACCELERATION_STRUCTURE_EX:
+        case NVAPI_D3D12_SERIALIZED_DATA_RAYTRACING_OPACITY_MICROMAP_ARRAY_EX:
+            d3d12Type = D3D12_SERIALIZED_DATA_RAYTRACING_ACCELERATION_STRUCTURE;
+            break;
+        default:
+            pParams->checkStatus = D3D12_DRIVER_MATCHING_IDENTIFIER_UNSUPPORTED_TYPE;
+            return Ok(n, alreadyLoggedOk);
+    }
+
+    if (!pParams->pIdentifierToCheck)
+        return InvalidArgument(n);
+
+    pParams->checkStatus = pDevice->CheckDriverMatchingIdentifier(d3d12Type, pParams->pIdentifierToCheck);
+
+    return Ok(n, alreadyLoggedOk);
+}
+
 NVAPI_FUNCTION NvAPI_D3D12_NotifyOutOfBandCommandQueue(ID3D12CommandQueue* pCommandQueue, NV_OUT_OF_BAND_CQ_TYPE cqType) {
     constexpr auto n = __func__;
     thread_local bool alreadyLoggedOk = false;

--- a/src/nvapi_d3d12.cpp
+++ b/src/nvapi_d3d12.cpp
@@ -735,79 +735,6 @@ NVAPI_FUNCTION NvAPI_D3D12_GetRaytracingCaps(ID3D12Device* pDevice, NVAPI_D3D12_
     return Ok(str::format(n, " (", type, "/", fromRaytracingCaps(type), ")"));
 }
 
-inline static bool ConvertBuildRaytracingAccelerationStructureInputs(const NVAPI_D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS_EX* nvDesc, std::vector<D3D12_RAYTRACING_GEOMETRY_DESC>& geometryDescs, D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS* d3dDesc) {
-    // assume that micromaps are not supported, allow only standard stuff to be passed
-    if ((nvDesc->flags & ~0x3f) != 0) {
-        log::info(str::format("Nonstandard flags passed to acceleration structure build: ", nvDesc->flags));
-        return false;
-    }
-
-    d3dDesc->Type = nvDesc->type;
-    d3dDesc->Flags = static_cast<D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAGS>(nvDesc->flags);
-    d3dDesc->NumDescs = nvDesc->numDescs;
-    d3dDesc->DescsLayout = nvDesc->descsLayout;
-
-    if (nvDesc->type == D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL) {
-        d3dDesc->InstanceDescs = nvDesc->instanceDescs;
-        return true;
-    } else if (nvDesc->type == D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL && nvDesc->descsLayout == D3D12_ELEMENTS_LAYOUT_ARRAY_OF_POINTERS) {
-        for (unsigned i = 0; i < nvDesc->numDescs; ++i) {
-            switch (auto type = nvDesc->ppGeometryDescs[i]->type) {
-                case NVAPI_D3D12_RAYTRACING_GEOMETRY_TYPE_TRIANGLES_EX:
-                case NVAPI_D3D12_RAYTRACING_GEOMETRY_TYPE_PROCEDURAL_PRIMITIVE_AABBS_EX:
-                    // Supported as is.
-                    break;
-                case NVAPI_D3D12_RAYTRACING_GEOMETRY_TYPE_OMM_TRIANGLES_EX: // GetRaytracingCaps reports no OMM caps, we shouldn't reach this
-                    log::info("Triangles with OMM attachment passed to acceleration structure build when OMM is not supported");
-                    return false;
-                case NVAPI_D3D12_RAYTRACING_GEOMETRY_TYPE_DMM_TRIANGLES_EX: // GetRaytracingCaps reports no DMM caps, we shouldn't reach this
-                    log::info("Triangles with DMM attachment passed to acceleration structure build when DMM is not supported");
-                    return false;
-                default:
-                    log::info(str::format("Unknown NVAPI_D3D12_RAYTRACING_GEOMETRY_TYPE_EX: ", type));
-                    return false;
-            }
-        }
-
-        d3dDesc->ppGeometryDescs = reinterpret_cast<const D3D12_RAYTRACING_GEOMETRY_DESC* const*>(nvDesc->ppGeometryDescs);
-        return true;
-    } else if (nvDesc->type == D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL && nvDesc->descsLayout == D3D12_ELEMENTS_LAYOUT_ARRAY) {
-        geometryDescs.resize(nvDesc->numDescs);
-
-        for (unsigned i = 0; i < nvDesc->numDescs; ++i) {
-            auto& d3dGeoDesc = geometryDescs[i];
-            auto& nvGeoDesc = *reinterpret_cast<const NVAPI_D3D12_RAYTRACING_GEOMETRY_DESC_EX*>(reinterpret_cast<const std::byte*>(nvDesc->pGeometryDescs) + (i * nvDesc->geometryDescStrideInBytes));
-
-            d3dGeoDesc.Flags = nvGeoDesc.flags;
-
-            switch (nvGeoDesc.type) {
-                case NVAPI_D3D12_RAYTRACING_GEOMETRY_TYPE_TRIANGLES_EX:
-                    d3dGeoDesc.Type = D3D12_RAYTRACING_GEOMETRY_TYPE_TRIANGLES;
-                    d3dGeoDesc.Triangles = nvGeoDesc.triangles;
-                    break;
-                case NVAPI_D3D12_RAYTRACING_GEOMETRY_TYPE_PROCEDURAL_PRIMITIVE_AABBS_EX:
-                    d3dGeoDesc.Type = D3D12_RAYTRACING_GEOMETRY_TYPE_PROCEDURAL_PRIMITIVE_AABBS;
-                    d3dGeoDesc.AABBs = nvGeoDesc.aabbs;
-                    break;
-                case NVAPI_D3D12_RAYTRACING_GEOMETRY_TYPE_OMM_TRIANGLES_EX: // GetRaytracingCaps reports no OMM caps, we shouldn't reach this
-                    log::info("Triangles with OMM attachment passed to acceleration structure build when OMM is not supported");
-                    return false;
-                case NVAPI_D3D12_RAYTRACING_GEOMETRY_TYPE_DMM_TRIANGLES_EX: // GetRaytracingCaps reports no DMM caps, we shouldn't reach this
-                    log::info("Triangles with DMM attachment passed to acceleration structure build when DMM is not supported");
-                    return false;
-                default:
-                    log::info(str::format("Unknown NVAPI_D3D12_RAYTRACING_GEOMETRY_TYPE_EX: ", nvGeoDesc.type));
-                    return false;
-            }
-        }
-
-        d3dDesc->pGeometryDescs = geometryDescs.data();
-        return true;
-    }
-
-    return false;
-}
-
 NVAPI_FUNCTION NvAPI_D3D12_GetRaytracingAccelerationStructurePrebuildInfoEx(ID3D12Device5* pDevice, NVAPI_GET_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO_EX_PARAMS* pParams) {
     constexpr auto n = __func__;
     thread_local bool alreadyLoggedOk = false;
@@ -844,31 +771,36 @@ NVAPI_FUNCTION NvAPI_D3D12_GetRaytracingAccelerationStructurePrebuildInfoEx(ID3D
 NVAPI_FUNCTION NvAPI_D3D12_BuildRaytracingAccelerationStructureEx(ID3D12GraphicsCommandList4* pCommandList, const NVAPI_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_EX_PARAMS* pParams) {
     constexpr auto n = __func__;
     thread_local bool alreadyLoggedOk = false;
+    thread_local bool alreadyLoggedNoImplementation = false;
 
     if (log::tracing())
         log::trace(n, log::fmt::ptr(pCommandList), log::fmt::ptr(pParams));
 
     if (!pCommandList || !pParams)
         return InvalidArgument(n);
-
     if (pParams->version != NVAPI_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_EX_PARAMS_VER1)
         return IncompatibleStructVersion(n, pParams->version);
-
-    if (!pParams->pDesc || (pParams->numPostbuildInfoDescs != 0 && !pParams->pPostbuildInfoDescs))
+    if (!pParams->pDesc)
+        return InvalidArgument(n);
+    if (pParams->numPostbuildInfoDescs && !pParams->pPostbuildInfoDescs)
         return InvalidArgument(n);
 
-    std::vector<D3D12_RAYTRACING_GEOMETRY_DESC> geometryDescs{};
-    D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC desc = {
-        .DestAccelerationStructureData = pParams->pDesc->destAccelerationStructureData,
-        .Inputs = {},
-        .SourceAccelerationStructureData = pParams->pDesc->sourceAccelerationStructureData,
-        .ScratchAccelerationStructureData = pParams->pDesc->scratchAccelerationStructureData,
-    };
+    auto commandList = NvapiD3d12GraphicsCommandList::GetOrCreate(pCommandList);
+    if (!commandList)
+        return NoImplementation(n, alreadyLoggedNoImplementation);
 
-    if (!ConvertBuildRaytracingAccelerationStructureInputs(&pParams->pDesc->inputs, geometryDescs, &desc.Inputs))
-        return NotSupported(n);
+    const bool supportsOmm = commandList->IsOpacityMicromapSupported();
 
-    pCommandList->BuildRaytracingAccelerationStructure(&desc, pParams->numPostbuildInfoDescs, pParams->pPostbuildInfoDescs);
+    D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC buildDesc;
+    buildDesc.SourceAccelerationStructureData = pParams->pDesc->sourceAccelerationStructureData;
+    buildDesc.ScratchAccelerationStructureData = pParams->pDesc->scratchAccelerationStructureData;
+    buildDesc.DestAccelerationStructureData = pParams->pDesc->destAccelerationStructureData;
+    if (auto status = commandList->GetAsConverter().Convert(buildDesc.Inputs, pParams->pDesc->inputs, supportsOmm);
+        status != NVAPI_OK)
+        return status;
+
+    pCommandList->BuildRaytracingAccelerationStructure(&buildDesc, pParams->numPostbuildInfoDescs,
+        pParams->pPostbuildInfoDescs);
 
     return Ok(n, alreadyLoggedOk);
 }

--- a/src/nvapi_d3d12.cpp
+++ b/src/nvapi_d3d12.cpp
@@ -916,6 +916,69 @@ NVAPI_FUNCTION NvAPI_D3D12_CheckDriverMatchingIdentifierEx(ID3D12Device5* pDevic
     return Ok(n, alreadyLoggedOk);
 }
 
+NVAPI_FUNCTION NvAPI_D3D12_BuildRaytracingOpacityMicromapArray(ID3D12GraphicsCommandList4* pCommandList, NVAPI_BUILD_RAYTRACING_OPACITY_MICROMAP_ARRAY_PARAMS* pParams) {
+    constexpr auto n = __func__;
+    thread_local bool alreadyLoggedNoImplementation = false;
+    thread_local bool alreadyLoggedOk = false;
+
+    if (log::tracing())
+        log::trace(n, log::fmt::ptr(pCommandList), log::fmt::ptr(pParams));
+
+    if (!pCommandList || !pParams)
+        return InvalidArgument(n);
+    if (pParams->version != NVAPI_BUILD_RAYTRACING_OPACITY_MICROMAP_ARRAY_PARAMS_VER1)
+        return IncompatibleStructVersion(n, pParams->version);
+    if (!pParams->pDesc)
+        return InvalidArgument(n);
+    if (pParams->numPostbuildInfoDescs && !pParams->pPostbuildInfoDescs)
+        return InvalidArgument(n);
+
+    auto commandList = NvapiD3d12GraphicsCommandList::GetOrCreate(pCommandList);
+    if (!commandList)
+        return NoImplementation(n, alreadyLoggedNoImplementation);
+
+    if (!commandList->IsOpacityMicromapSupported())
+        return NotSupported(n);
+
+    D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC buildDesc{};
+    D3D12_RAYTRACING_OPACITY_MICROMAP_ARRAY_DESC arrayDesc;
+    buildDesc.DestAccelerationStructureData = pParams->pDesc->destOpacityMicromapArrayData;
+    buildDesc.ScratchAccelerationStructureData = pParams->pDesc->scratchOpacityMicromapArrayData;
+
+    constexpr NvU32 postbuildStackCapacity = 16;
+    D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_DESC postbuildStack[postbuildStackCapacity];
+    std::unique_ptr<D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_DESC[]> postbuildHeap;
+    D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_DESC* postbuildDescs = postbuildStack;
+    if (pParams->numPostbuildInfoDescs > postbuildStackCapacity) {
+        postbuildHeap = std::make_unique<D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_DESC[]>(pParams->numPostbuildInfoDescs);
+        postbuildDescs = postbuildHeap.get();
+    }
+    for (auto i = 0U; i < pParams->numPostbuildInfoDescs; ++i) {
+        auto& src = pParams->pPostbuildInfoDescs[i];
+        auto& dst = postbuildDescs[i];
+        dst = {};
+        dst.DestBuffer = src.destBuffer;
+        switch (src.infoType) {
+            case NVAPI_D3D12_RAYTRACING_OPACITY_MICROMAP_ARRAY_POSTBUILD_INFO_CURRENT_SIZE:
+                dst.InfoType = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_CURRENT_SIZE;
+                break;
+            default:
+                return InvalidArgument(n);
+        }
+    }
+
+    if (auto status = OmmArrayInputsToD3d12(buildDesc.Inputs, arrayDesc, pParams->pDesc->inputs);
+        status != NVAPI_OK)
+        return status;
+
+    pCommandList->BuildRaytracingAccelerationStructure(
+        &buildDesc,
+        pParams->numPostbuildInfoDescs,
+        pParams->numPostbuildInfoDescs ? postbuildDescs : nullptr);
+
+    return Ok(n, alreadyLoggedOk);
+}
+
 NVAPI_FUNCTION NvAPI_D3D12_NotifyOutOfBandCommandQueue(ID3D12CommandQueue* pCommandQueue, NV_OUT_OF_BAND_CQ_TYPE cqType) {
     constexpr auto n = __func__;
     thread_local bool alreadyLoggedOk = false;

--- a/src/nvapi_d3d12.cpp
+++ b/src/nvapi_d3d12.cpp
@@ -979,6 +979,33 @@ NVAPI_FUNCTION NvAPI_D3D12_BuildRaytracingOpacityMicromapArray(ID3D12GraphicsCom
     return Ok(n, alreadyLoggedOk);
 }
 
+NVAPI_FUNCTION NvAPI_D3D12_RelocateRaytracingOpacityMicromapArray(ID3D12GraphicsCommandList4* pCommandList, const NVAPI_RELOCATE_RAYTRACING_OPACITY_MICROMAP_ARRAY_PARAMS* pParams) {
+    constexpr auto n = __func__;
+    thread_local bool alreadyLoggedNoImplementation = false;
+    thread_local bool alreadyLoggedError = false;
+    thread_local bool alreadyLoggedOk = false;
+
+    if (log::tracing())
+        log::trace(n, log::fmt::ptr(pCommandList), log::fmt::ptr(pParams));
+
+    if (!pCommandList || !pParams)
+        return InvalidArgument(n);
+
+    if (pParams->version != NVAPI_RELOCATE_RAYTRACING_OPACITY_MICROMAP_ARRAY_PARAMS_VER1)
+        return IncompatibleStructVersion(n, pParams->version);
+
+    auto commandList = NvapiD3d12GraphicsCommandList::GetOrCreate(pCommandList);
+    if (!commandList)
+        return NoImplementation(n, alreadyLoggedNoImplementation);
+    if (!commandList->IsOpacityMicromapSupported())
+        return NotSupported(n);
+
+    if (!commandList->VerifyOpacityMicromapArrayNVAPI(pParams->opacityMicromapArray))
+        return Error(n, alreadyLoggedError);
+
+    return Ok(n, alreadyLoggedOk);
+}
+
 NVAPI_FUNCTION NvAPI_D3D12_NotifyOutOfBandCommandQueue(ID3D12CommandQueue* pCommandQueue, NV_OUT_OF_BAND_CQ_TYPE cqType) {
     constexpr auto n = __func__;
     thread_local bool alreadyLoggedOk = false;

--- a/src/nvapi_d3d12.cpp
+++ b/src/nvapi_d3d12.cpp
@@ -843,6 +843,42 @@ NVAPI_FUNCTION NvAPI_D3D12_GetRaytracingOpacityMicromapArrayPrebuildInfo(ID3D12D
     return Ok(n, alreadyLoggedOk);
 }
 
+NVAPI_FUNCTION NvAPI_D3D12_SetCreatePipelineStateOptions(ID3D12Device5* pDevice, const NVAPI_D3D12_SET_CREATE_PIPELINE_STATE_OPTIONS_PARAMS* pState) {
+    constexpr auto n = __func__;
+    thread_local bool alreadyLoggedNoImplementation = false;
+    thread_local bool alreadyLoggedOk = false;
+
+    if (log::tracing())
+        log::trace(n, log::fmt::ptr(pDevice), log::fmt::ptr(pState));
+
+    if (!pDevice || !pState)
+        return InvalidArgument(n);
+
+    if (pState->version != NVAPI_D3D12_SET_CREATE_PIPELINE_STATE_OPTIONS_PARAMS_VER1)
+        return IncompatibleStructVersion(n, pState->version);
+
+    auto device = NvapiD3d12Device::GetOrCreate(pDevice);
+    if (!device)
+        return NoImplementation(n, alreadyLoggedNoImplementation);
+
+    if (!device->IsOpacityMicromapSupported())
+        return NotSupported(n);
+
+    D3D12_VK_EXT_PIPELINE_CREATION_STATE_FLAG flags = D3D12_VK_EXT_PIPELINE_CREATION_STATE_FLAGS_NONE;
+    static const NVAPI_D3D12_PIPELINE_CREATION_STATE_FLAGS supprotedNvapiFlags =
+        NVAPI_D3D12_PIPELINE_CREATION_STATE_FLAGS_ENABLE_OMM_SUPPORT;
+    if (pState->flags & ~supprotedNvapiFlags)
+        return NotSupported(n);
+
+    if (pState->flags & NVAPI_D3D12_PIPELINE_CREATION_STATE_FLAGS_ENABLE_OMM_SUPPORT)
+        flags = (D3D12_VK_EXT_PIPELINE_CREATION_STATE_FLAG)(flags | D3D12_VK_EXT_PIPELINE_CREATION_STATE_FLAGS_ENABLE_OMM_SUPPORT);
+
+    if (!device->SetCreatePipelineStateFlagsNVAPI(flags))
+        return NotSupported(n);
+
+    return Ok(n, alreadyLoggedOk);
+}
+
 NVAPI_FUNCTION NvAPI_D3D12_NotifyOutOfBandCommandQueue(ID3D12CommandQueue* pCommandQueue, NV_OUT_OF_BAND_CQ_TYPE cqType) {
     constexpr auto n = __func__;
     thread_local bool alreadyLoggedOk = false;

--- a/src/nvapi_d3d12.cpp
+++ b/src/nvapi_d3d12.cpp
@@ -805,6 +805,44 @@ NVAPI_FUNCTION NvAPI_D3D12_BuildRaytracingAccelerationStructureEx(ID3D12Graphics
     return Ok(n, alreadyLoggedOk);
 }
 
+NVAPI_FUNCTION NvAPI_D3D12_GetRaytracingOpacityMicromapArrayPrebuildInfo(ID3D12Device5* pDevice, NVAPI_GET_RAYTRACING_OPACITY_MICROMAP_ARRAY_PREBUILD_INFO_PARAMS* pParams) {
+    constexpr auto n = __func__;
+    thread_local bool alreadyLoggedNoImplementation = false;
+    thread_local bool alreadyLoggedOk = false;
+
+    if (log::tracing())
+        log::trace(n, log::fmt::ptr(pDevice), log::fmt::ptr(pParams));
+
+    if (!pDevice || !pParams)
+        return InvalidArgument(n);
+
+    if (pParams->version != NVAPI_GET_RAYTRACING_OPACITY_MICROMAP_ARRAY_PREBUILD_INFO_PARAMS_VER1)
+        return IncompatibleStructVersion(n, pParams->version);
+    if (!pParams->pDesc || !pParams->pInfo)
+        return InvalidArgument(n);
+
+    auto device = NvapiD3d12Device::GetOrCreate(pDevice);
+    if (!device)
+        return NoImplementation(n, alreadyLoggedNoImplementation);
+
+    if (!device->IsOpacityMicromapSupported())
+        return NotSupported(n);
+
+    D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS inputs;
+    D3D12_RAYTRACING_OPACITY_MICROMAP_ARRAY_DESC arrayDesc;
+    if (auto status = OmmArrayInputsToD3d12(inputs, arrayDesc, *pParams->pDesc);
+        status != NVAPI_OK)
+        return status;
+
+    D3D12_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO d3d12Info;
+    pDevice->GetRaytracingAccelerationStructurePrebuildInfo(&inputs, &d3d12Info);
+
+    pParams->pInfo->resultDataMaxSizeInBytes = d3d12Info.ResultDataMaxSizeInBytes;
+    pParams->pInfo->scratchDataSizeInBytes = d3d12Info.ScratchDataSizeInBytes;
+
+    return Ok(n, alreadyLoggedOk);
+}
+
 NVAPI_FUNCTION NvAPI_D3D12_NotifyOutOfBandCommandQueue(ID3D12CommandQueue* pCommandQueue, NV_OUT_OF_BAND_CQ_TYPE cqType) {
     constexpr auto n = __func__;
     thread_local bool alreadyLoggedOk = false;

--- a/src/nvapi_d3d12.cpp
+++ b/src/nvapi_d3d12.cpp
@@ -690,7 +690,9 @@ NVAPI_FUNCTION NvAPI_D3D12_GetRaytracingCaps(ID3D12Device* pDevice, NVAPI_D3D12_
             if (dataSize != sizeof(NVAPI_D3D12_RAYTRACING_OPACITY_MICROMAP_CAPS))
                 return InvalidArgument(n);
 
-            *static_cast<NVAPI_D3D12_RAYTRACING_OPACITY_MICROMAP_CAPS*>(pData) = NVAPI_D3D12_RAYTRACING_OPACITY_MICROMAP_CAP_NONE;
+            *static_cast<NVAPI_D3D12_RAYTRACING_OPACITY_MICROMAP_CAPS*>(pData) = NvapiD3d12Device::IsOpacityMicromapSupported(pDevice)
+                ? NVAPI_D3D12_RAYTRACING_OPACITY_MICROMAP_CAP_STANDARD
+                : NVAPI_D3D12_RAYTRACING_OPACITY_MICROMAP_CAP_NONE;
             break;
 
         case NVAPI_D3D12_RAYTRACING_CAPS_TYPE_DISPLACEMENT_MICROMAP:

--- a/src/nvapi_interface.cpp
+++ b/src/nvapi_interface.cpp
@@ -127,6 +127,7 @@ NVAPI_QUERY_INTERFACE nvapi_QueryInterface(NvU32 id) {
     INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_D3D12_CheckDriverMatchingIdentifierEx)
     INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_D3D12_GetRaytracingAccelerationStructurePrebuildInfoEx)
     INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_D3D12_BuildRaytracingOpacityMicromapArray)
+    INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_D3D12_RelocateRaytracingOpacityMicromapArray)
     INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_D3D12_BuildRaytracingAccelerationStructureEx)
     INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_D3D12_NotifyOutOfBandCommandQueue)
     INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_D3D12_SetAsyncFrameMarker)

--- a/src/nvapi_interface.cpp
+++ b/src/nvapi_interface.cpp
@@ -122,6 +122,7 @@ NVAPI_QUERY_INTERFACE nvapi_QueryInterface(NvU32 id) {
     INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_D3D12_SetNvShaderExtnSlotSpace)
     INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_D3D12_SetNvShaderExtnSlotSpaceLocalThread)
     INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_D3D12_GetRaytracingCaps)
+    INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_D3D12_GetRaytracingOpacityMicromapArrayPrebuildInfo)
     INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_D3D12_GetRaytracingAccelerationStructurePrebuildInfoEx)
     INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_D3D12_BuildRaytracingAccelerationStructureEx)
     INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_D3D12_NotifyOutOfBandCommandQueue)

--- a/src/nvapi_interface.cpp
+++ b/src/nvapi_interface.cpp
@@ -124,6 +124,7 @@ NVAPI_QUERY_INTERFACE nvapi_QueryInterface(NvU32 id) {
     INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_D3D12_GetRaytracingCaps)
     INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_D3D12_GetRaytracingOpacityMicromapArrayPrebuildInfo)
     INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_D3D12_SetCreatePipelineStateOptions)
+    INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_D3D12_CheckDriverMatchingIdentifierEx)
     INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_D3D12_GetRaytracingAccelerationStructurePrebuildInfoEx)
     INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_D3D12_BuildRaytracingAccelerationStructureEx)
     INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_D3D12_NotifyOutOfBandCommandQueue)

--- a/src/nvapi_interface.cpp
+++ b/src/nvapi_interface.cpp
@@ -126,6 +126,7 @@ NVAPI_QUERY_INTERFACE nvapi_QueryInterface(NvU32 id) {
     INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_D3D12_SetCreatePipelineStateOptions)
     INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_D3D12_CheckDriverMatchingIdentifierEx)
     INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_D3D12_GetRaytracingAccelerationStructurePrebuildInfoEx)
+    INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_D3D12_BuildRaytracingOpacityMicromapArray)
     INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_D3D12_BuildRaytracingAccelerationStructureEx)
     INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_D3D12_NotifyOutOfBandCommandQueue)
     INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_D3D12_SetAsyncFrameMarker)

--- a/src/nvapi_interface.cpp
+++ b/src/nvapi_interface.cpp
@@ -128,6 +128,7 @@ NVAPI_QUERY_INTERFACE nvapi_QueryInterface(NvU32 id) {
     INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_D3D12_GetRaytracingAccelerationStructurePrebuildInfoEx)
     INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_D3D12_BuildRaytracingOpacityMicromapArray)
     INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_D3D12_RelocateRaytracingOpacityMicromapArray)
+    INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_D3D12_EmitRaytracingOpacityMicromapArrayPostbuildInfo)
     INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_D3D12_BuildRaytracingAccelerationStructureEx)
     INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_D3D12_NotifyOutOfBandCommandQueue)
     INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_D3D12_SetAsyncFrameMarker)

--- a/src/nvapi_interface.cpp
+++ b/src/nvapi_interface.cpp
@@ -123,6 +123,7 @@ NVAPI_QUERY_INTERFACE nvapi_QueryInterface(NvU32 id) {
     INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_D3D12_SetNvShaderExtnSlotSpaceLocalThread)
     INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_D3D12_GetRaytracingCaps)
     INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_D3D12_GetRaytracingOpacityMicromapArrayPrebuildInfo)
+    INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_D3D12_SetCreatePipelineStateOptions)
     INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_D3D12_GetRaytracingAccelerationStructurePrebuildInfoEx)
     INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_D3D12_BuildRaytracingAccelerationStructureEx)
     INSERT_AND_RETURN_WHEN_EQUALS(NvAPI_D3D12_NotifyOutOfBandCommandQueue)

--- a/src/util/com_pointer.h
+++ b/src/util/com_pointer.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../nvapi_private.h"
+#include <initializer_list>
 
 namespace dxvk {
     /**
@@ -103,5 +104,49 @@ namespace dxvk {
             object->AddRef();
 
         return object;
+    }
+
+    // Walks a COM interface chain via QueryInterface and returns the count of
+    // consecutive tiers supported. Scans from highest to lowest under the
+    // single-inheritance precondition: a successful, identity-matched QI at
+    // tier N implies every lower tier is present, so the typical "top tier
+    // supported" case exits in three QI calls total.
+    //
+    // Avoids the following issues:
+    //   - Unchecked static_cast from base to a derived tier is UB in C++ but
+    //     safe under COM once QI has confirmed the tier exists. Cast sites
+    //     NOLINT on the strength of this probe.
+    //   - Tear-offs / aggregation: QI may return an object with a different
+    //     identity than the base; a later cast back to the base type lands on
+    //     the wrong vtable. The IUnknown round-trip rejects such tiers and
+    //     continues to lower ones.
+    //
+    // PRECONDITION: `chain` is a single-inheritance progression
+    // (IFoo -> IFoo1 -> IFoo2). Sibling or unrelated IIDs silently mis-report
+    // supported tiers.
+    inline uint32_t probeInterfaceChain(IUnknown* base, std::initializer_list<IID> chain) {
+        if (base == nullptr)
+            return 0;
+
+        Com<IUnknown> baseIdentity;
+        if (FAILED(base->QueryInterface(IID_PPV_ARGS(&baseIdentity))))
+            return 0;
+
+        const auto begin = chain.begin();
+        for (uint32_t i = static_cast<uint32_t>(chain.size()); i > 0; --i) {
+            Com<IUnknown> tierPtr;
+            if (FAILED(base->QueryInterface(begin[i - 1], reinterpret_cast<void**>(&tierPtr))))
+                continue;
+
+            Com<IUnknown> identity;
+            if (FAILED(tierPtr->QueryInterface(IID_PPV_ARGS(&identity))))
+                continue;
+
+            if (identity != baseIdentity)
+                continue; // tear-off at this tier; try lower tiers
+
+            return i;
+        }
+        return 0;
     }
 }

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -7,6 +7,7 @@ nvapi_src = files([
   '../src/shared/resource_factory.cpp',
   '../src/nvapi/nvml.cpp',
   '../src/nvapi/low_latency_frame_id_generator.cpp',
+  '../src/nvapi/nvapi_as_convert.cpp',
   '../src/nvapi/nvapi_resource_factory.cpp',
   '../src/nvapi/nvapi_d3d_low_latency_device.cpp',
   '../src/nvapi/nvapi_vulkan_low_latency_device.cpp',

--- a/tests/mocks/d3d12_mocks.h
+++ b/tests/mocks/d3d12_mocks.h
@@ -3,7 +3,7 @@
 #include "../../src/nvapi_private.h"
 #include "../../src/interfaces/vkd3d-proton_interfaces.h"
 
-class ID3D12Vkd3dDevice : public ID3D12Device5, public ID3D12DeviceExt4, public ID3D12DXVKInteropDevice1 {};
+class ID3D12Vkd3dDevice : public ID3D12Device5, public ID3D12DeviceExt5, public ID3D12DXVKInteropDevice1 {};
 
 class D3D12Vkd3dDeviceMock final : public trompeloeil::mock_interface<ID3D12Vkd3dDevice> {
     MAKE_MOCK2(QueryInterface, HRESULT(REFIID, void**), override);
@@ -115,9 +115,11 @@ class D3D12Vkd3dDeviceMock final : public trompeloeil::mock_interface<ID3D12Vkd3
     IMPLEMENT_MOCK1(SetAGSUAVSlot);
     IMPLEMENT_MOCK1(IsNvShaderExtnOpCodeSupported);
     IMPLEMENT_MOCK3(SetNvShaderExtnSlotSpace);
+
+    IMPLEMENT_MOCK1(SetCreatePipelineStateFlagsNVAPI);
 };
 
-class ID3D12Vkd3dGraphicsCommandList : public ID3D12GraphicsCommandList4, public ID3D12GraphicsCommandListExt1 {};
+class ID3D12Vkd3dGraphicsCommandList : public ID3D12GraphicsCommandList4, public ID3D12GraphicsCommandListExt2 {};
 
 class D3D12Vkd3dGraphicsCommandListMock final : public trompeloeil::mock_interface<ID3D12Vkd3dGraphicsCommandList> {
     MAKE_MOCK2(QueryInterface, HRESULT(REFIID, void**), override);
@@ -200,6 +202,8 @@ class D3D12Vkd3dGraphicsCommandListMock final : public trompeloeil::mock_interfa
     IMPLEMENT_MOCK1(GetVulkanHandle);
     IMPLEMENT_MOCK6(LaunchCubinShader);
     IMPLEMENT_MOCK9(LaunchCubinShaderEx);
+
+    IMPLEMENT_MOCK1(VerifyOpacityMicromapArrayNVAPI);
 };
 
 class ID3D12Vkd3dCommandQueue : public ID3D12CommandQueue, public ID3D12CommandQueueExt {};

--- a/tests/nvapi_d3d11.cpp
+++ b/tests/nvapi_d3d11.cpp
@@ -11,6 +11,15 @@ TEST_CASE("D3D11 methods succeed", "[.d3d11]") {
     auto deviceRefCount = 0;
     auto contextRefCount = 0;
 
+    ALLOW_CALL(device, QueryInterface(__uuidof(IUnknown), _))
+        .LR_SIDE_EFFECT(*_2 = static_cast<IUnknown*>(static_cast<ID3D11Device*>(&device)))
+        .LR_SIDE_EFFECT(deviceRefCount++)
+        .RETURN(S_OK);
+    ALLOW_CALL(context, QueryInterface(__uuidof(IUnknown), _))
+        .LR_SIDE_EFFECT(*_2 = static_cast<IUnknown*>(static_cast<ID3D11DeviceContext*>(&context)))
+        .LR_SIDE_EFFECT(contextRefCount++)
+        .RETURN(S_OK);
+
     ALLOW_CALL(device, QueryInterface(__uuidof(ID3D11Device), _))
         .LR_SIDE_EFFECT(*_2 = static_cast<ID3D11Device*>(&device))
         .LR_SIDE_EFFECT(deviceRefCount++)

--- a/tests/nvapi_d3d12.cpp
+++ b/tests/nvapi_d3d12.cpp
@@ -1639,6 +1639,56 @@ TEST_CASE("D3D12 methods succeed", "[.d3d12]") {
         }
     }
 
+    SECTION("D3D12 OMM methods without the OMM extension return not-supported") {
+        ALLOW_CALL(device, GetExtensionSupport(D3D12_VK_OPACITY_MICROMAP))
+            .RETURN(false);
+
+        FORBID_CALL(device, GetRaytracingAccelerationStructurePrebuildInfo(_, _));
+        FORBID_CALL(device, SetCreatePipelineStateFlagsNVAPI(_));
+        FORBID_CALL(commandList, BuildRaytracingAccelerationStructure(_, _, _));
+        FORBID_CALL(commandList, VerifyOpacityMicromapArrayNVAPI(_));
+        FORBID_CALL(commandList, EmitRaytracingAccelerationStructurePostbuildInfo(_, _, _));
+
+        {
+            NVAPI_D3D12_BUILD_RAYTRACING_OPACITY_MICROMAP_ARRAY_INPUTS inputs{};
+            NVAPI_D3D12_RAYTRACING_OPACITY_MICROMAP_ARRAY_PREBUILD_INFO info{};
+            NVAPI_GET_RAYTRACING_OPACITY_MICROMAP_ARRAY_PREBUILD_INFO_PARAMS params{};
+            params.version = NVAPI_GET_RAYTRACING_OPACITY_MICROMAP_ARRAY_PREBUILD_INFO_PARAMS_VER1;
+            params.pDesc = &inputs;
+            params.pInfo = &info;
+            REQUIRE(NvAPI_D3D12_GetRaytracingOpacityMicromapArrayPrebuildInfo(static_cast<ID3D12Device5*>(&device), &params) == NVAPI_NOT_SUPPORTED);
+        }
+        {
+            NVAPI_D3D12_SET_CREATE_PIPELINE_STATE_OPTIONS_PARAMS params{};
+            params.version = NVAPI_D3D12_SET_CREATE_PIPELINE_STATE_OPTIONS_PARAMS_VER1;
+            params.flags = NVAPI_D3D12_PIPELINE_CREATION_STATE_FLAGS_ENABLE_OMM_SUPPORT;
+            REQUIRE(NvAPI_D3D12_SetCreatePipelineStateOptions(static_cast<ID3D12Device5*>(&device), &params) == NVAPI_NOT_SUPPORTED);
+        }
+        {
+            NVAPI_D3D12_BUILD_RAYTRACING_OPACITY_MICROMAP_ARRAY_DESC ommArrayDesc{};
+            NVAPI_BUILD_RAYTRACING_OPACITY_MICROMAP_ARRAY_PARAMS params{};
+            params.version = NVAPI_BUILD_RAYTRACING_OPACITY_MICROMAP_ARRAY_PARAMS_VER1;
+            params.pDesc = &ommArrayDesc;
+            REQUIRE(NvAPI_D3D12_BuildRaytracingOpacityMicromapArray(static_cast<ID3D12GraphicsCommandList4*>(&commandList), &params) == NVAPI_NOT_SUPPORTED);
+        }
+        {
+            NVAPI_RELOCATE_RAYTRACING_OPACITY_MICROMAP_ARRAY_PARAMS params{};
+            params.version = NVAPI_RELOCATE_RAYTRACING_OPACITY_MICROMAP_ARRAY_PARAMS_VER1;
+            REQUIRE(NvAPI_D3D12_RelocateRaytracingOpacityMicromapArray(static_cast<ID3D12GraphicsCommandList4*>(&commandList), &params) == NVAPI_NOT_SUPPORTED);
+        }
+        {
+            NVAPI_D3D12_RAYTRACING_OPACITY_MICROMAP_ARRAY_POSTBUILD_INFO_DESC postbuildDesc{};
+            postbuildDesc.infoType = NVAPI_D3D12_RAYTRACING_OPACITY_MICROMAP_ARRAY_POSTBUILD_INFO_CURRENT_SIZE;
+            NVAPI_EMIT_RAYTRACING_OPACITY_MICROMAP_ARRAY_POSTBUILD_INFO_PARAMS params{};
+            params.version = NVAPI_EMIT_RAYTRACING_OPACITY_MICROMAP_ARRAY_POSTBUILD_INFO_PARAMS_VER1;
+            params.pDesc = &postbuildDesc;
+            REQUIRE(NvAPI_D3D12_EmitRaytracingOpacityMicromapArrayPostbuildInfo(static_cast<ID3D12GraphicsCommandList4*>(&commandList), &params) == NVAPI_NOT_SUPPORTED);
+        }
+
+        REQUIRE(deviceRefCount == 0);
+        REQUIRE(commandListRefCount == 0);
+    }
+
     SECTION("GetRaytracingOpacityMicromapArrayPrebuildInfo returns OK") {
         ALLOW_CALL(device, GetExtensionSupport(D3D12_VK_OPACITY_MICROMAP))
             .RETURN(true);

--- a/tests/nvapi_d3d12.cpp
+++ b/tests/nvapi_d3d12.cpp
@@ -1439,6 +1439,206 @@ TEST_CASE("D3D12 methods succeed", "[.d3d12]") {
         }
     }
 
+    SECTION("BuildRaytracingAccelerationStructureEx succeeds when Opacity Micromaps are supported") {
+        ALLOW_CALL(device, GetExtensionSupport(D3D12_VK_OPACITY_MICROMAP))
+            .RETURN(true);
+
+        NVAPI_D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC_EX desc{};
+        NVAPI_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_EX_PARAMS params{};
+        params.version = NVAPI_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_EX_PARAMS_VER1;
+        params.pDesc = &desc;
+
+        D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC d3d12Desc{};
+        std::vector<D3D12_RAYTRACING_GEOMETRY_DESC> geometryDescs{};
+        std::vector<D3D12_GPU_VIRTUAL_ADDRESS> ommArrays{};
+        ALLOW_CALL(commandList, BuildRaytracingAccelerationStructure(_, params.numPostbuildInfoDescs, params.pPostbuildInfoDescs))
+            .LR_SIDE_EFFECT({
+                d3d12Desc = *_1;
+
+                if (_1->Inputs.Type == D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL && _1->Inputs.DescsLayout == D3D12_ELEMENTS_LAYOUT_ARRAY) {
+                    geometryDescs.assign(_1->Inputs.pGeometryDescs, _1->Inputs.pGeometryDescs + _1->Inputs.NumDescs);
+                    ommArrays.clear();
+                    for (UINT i = 0; i < _1->Inputs.NumDescs; i++)
+                        if (_1->Inputs.pGeometryDescs[i].Type == D3D12_RAYTRACING_GEOMETRY_TYPE_OMM_TRIANGLES)
+                            ommArrays.push_back(_1->Inputs.pGeometryDescs[i].OmmTriangles.pOmmLinkage->OpacityMicromapArray);
+                }
+            });
+
+        SECTION("BuildRaytracingAccelerationStructureEx with TLAS and allow OMM update flag") {
+            desc.inputs.type = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL;
+            desc.inputs.instanceDescs = D3D12_GPU_VIRTUAL_ADDRESS{};
+            desc.inputs.flags = NVAPI_D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_OMM_UPDATE_EX;
+
+            REQUIRE(NvAPI_D3D12_BuildRaytracingAccelerationStructureEx(static_cast<ID3D12GraphicsCommandList4*>(&commandList), &params) == NVAPI_OK);
+            REQUIRE(d3d12Desc.DestAccelerationStructureData == desc.destAccelerationStructureData);
+            REQUIRE(d3d12Desc.Inputs.InstanceDescs == desc.inputs.instanceDescs);
+            REQUIRE((d3d12Desc.Inputs.Flags & D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_OMM_UPDATE) != 0);
+        }
+
+        SECTION("BuildRaytracingAccelerationStructureEx with BLAS for pointer array and allow disable OMMs flag") {
+            NVAPI_D3D12_RAYTRACING_GEOMETRY_DESC_EX geometryDescEx{};
+            geometryDescEx.type = NVAPI_D3D12_RAYTRACING_GEOMETRY_TYPE_TRIANGLES_EX;
+            geometryDescEx.triangles.IndexBuffer = 3;
+            NVAPI_D3D12_RAYTRACING_GEOMETRY_DESC_EX* geometryDescExArray[] = {&geometryDescEx};
+
+            desc.inputs.type = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL;
+            desc.inputs.descsLayout = D3D12_ELEMENTS_LAYOUT_ARRAY_OF_POINTERS;
+            desc.inputs.numDescs = 1;
+            desc.inputs.ppGeometryDescs = geometryDescExArray;
+            desc.inputs.flags = NVAPI_D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_DISABLE_OMMS_EX;
+
+            REQUIRE(NvAPI_D3D12_BuildRaytracingAccelerationStructureEx(static_cast<ID3D12GraphicsCommandList4*>(&commandList), &params) == NVAPI_OK);
+            REQUIRE(d3d12Desc.Inputs.NumDescs == desc.inputs.numDescs);
+            REQUIRE((d3d12Desc.Inputs.Flags & D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_DISABLE_OMMS) != 0);
+            REQUIRE(geometryDescs[0].Type == D3D12_RAYTRACING_GEOMETRY_TYPE_TRIANGLES);
+            REQUIRE(geometryDescs[0].Triangles.IndexBuffer == geometryDescEx.triangles.IndexBuffer);
+        }
+
+        SECTION("BuildRaytracingAccelerationStructureEx with BLAS for array") {
+            NVAPI_D3D12_RAYTRACING_GEOMETRY_DESC_EX geometryDescEx[2];
+            desc.inputs.type = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL;
+            desc.inputs.descsLayout = D3D12_ELEMENTS_LAYOUT_ARRAY;
+            desc.inputs.numDescs = 2;
+            desc.inputs.pGeometryDescs = geometryDescEx;
+            desc.inputs.geometryDescStrideInBytes = sizeof(NVAPI_D3D12_RAYTRACING_GEOMETRY_DESC_EX);
+
+            SECTION("BuildRaytracingAccelerationStructureEx for triangles geometry") {
+                geometryDescEx[0].type = NVAPI_D3D12_RAYTRACING_GEOMETRY_TYPE_TRIANGLES_EX;
+                geometryDescEx[0].triangles.IndexBuffer = 3;
+                geometryDescEx[1].type = NVAPI_D3D12_RAYTRACING_GEOMETRY_TYPE_TRIANGLES_EX;
+                geometryDescEx[1].triangles.IndexBuffer = 4;
+
+                REQUIRE(NvAPI_D3D12_BuildRaytracingAccelerationStructureEx(static_cast<ID3D12GraphicsCommandList4*>(&commandList), &params) == NVAPI_OK);
+                REQUIRE(d3d12Desc.Inputs.NumDescs == desc.inputs.numDescs);
+                REQUIRE(geometryDescs[0].Type == D3D12_RAYTRACING_GEOMETRY_TYPE_TRIANGLES);
+                REQUIRE(geometryDescs[0].Triangles.IndexBuffer == geometryDescEx[0].triangles.IndexBuffer);
+                REQUIRE(geometryDescs[1].Type == D3D12_RAYTRACING_GEOMETRY_TYPE_TRIANGLES);
+                REQUIRE(geometryDescs[1].Triangles.IndexBuffer == geometryDescEx[1].triangles.IndexBuffer);
+            }
+
+            SECTION("BuildRaytracingAccelerationStructureEx for OMM triangles geometry") {
+                geometryDescEx[0].type = NVAPI_D3D12_RAYTRACING_GEOMETRY_TYPE_OMM_TRIANGLES_EX;
+                geometryDescEx[0].ommTriangles.triangles.IndexBuffer = 3;
+                geometryDescEx[0].ommTriangles.ommAttachment.opacityMicromapArray = D3D12_GPU_VIRTUAL_ADDRESS{0x1000};
+                geometryDescEx[1].type = NVAPI_D3D12_RAYTRACING_GEOMETRY_TYPE_OMM_TRIANGLES_EX;
+                geometryDescEx[1].ommTriangles.triangles.IndexBuffer = 4;
+                geometryDescEx[1].ommTriangles.ommAttachment.opacityMicromapArray = D3D12_GPU_VIRTUAL_ADDRESS{0x2000};
+
+                REQUIRE(NvAPI_D3D12_BuildRaytracingAccelerationStructureEx(static_cast<ID3D12GraphicsCommandList4*>(&commandList), &params) == NVAPI_OK);
+                REQUIRE(d3d12Desc.Inputs.NumDescs == desc.inputs.numDescs);
+                REQUIRE(geometryDescs[0].Type == D3D12_RAYTRACING_GEOMETRY_TYPE_OMM_TRIANGLES);
+                REQUIRE(geometryDescs[0].OmmTriangles.pTriangles->IndexBuffer == geometryDescEx[0].ommTriangles.triangles.IndexBuffer);
+                REQUIRE(geometryDescs[1].Type == D3D12_RAYTRACING_GEOMETRY_TYPE_OMM_TRIANGLES);
+                REQUIRE(geometryDescs[1].OmmTriangles.pTriangles->IndexBuffer == geometryDescEx[1].ommTriangles.triangles.IndexBuffer);
+                REQUIRE(ommArrays.size() == 2);
+                REQUIRE(ommArrays[0] == geometryDescEx[0].ommTriangles.ommAttachment.opacityMicromapArray);
+                REQUIRE(ommArrays[1] == geometryDescEx[1].ommTriangles.ommAttachment.opacityMicromapArray);
+            }
+
+            SECTION("BuildRaytracingAccelerationStructureEx for AABBs geometry") {
+                geometryDescEx[0].type = NVAPI_D3D12_RAYTRACING_GEOMETRY_TYPE_PROCEDURAL_PRIMITIVE_AABBS_EX;
+                geometryDescEx[0].aabbs.AABBCount = 3;
+                geometryDescEx[1].type = NVAPI_D3D12_RAYTRACING_GEOMETRY_TYPE_PROCEDURAL_PRIMITIVE_AABBS_EX;
+                geometryDescEx[1].aabbs.AABBCount = 4;
+
+                REQUIRE(NvAPI_D3D12_BuildRaytracingAccelerationStructureEx(static_cast<ID3D12GraphicsCommandList4*>(&commandList), &params) == NVAPI_OK);
+                REQUIRE(d3d12Desc.Inputs.NumDescs == desc.inputs.numDescs);
+                REQUIRE(geometryDescs[0].Type == D3D12_RAYTRACING_GEOMETRY_TYPE_PROCEDURAL_PRIMITIVE_AABBS);
+                REQUIRE(geometryDescs[0].AABBs.AABBCount == geometryDescEx[0].aabbs.AABBCount);
+                REQUIRE(geometryDescs[1].Type == D3D12_RAYTRACING_GEOMETRY_TYPE_PROCEDURAL_PRIMITIVE_AABBS);
+                REQUIRE(geometryDescs[1].AABBs.AABBCount == geometryDescEx[1].aabbs.AABBCount);
+            }
+
+            SECTION("BuildRaytracingAccelerationStructureEx for mixed triangles and OMM triangles geometry") {
+                geometryDescEx[0].type = NVAPI_D3D12_RAYTRACING_GEOMETRY_TYPE_TRIANGLES_EX;
+                geometryDescEx[0].triangles.IndexBuffer = 3;
+                geometryDescEx[1].type = NVAPI_D3D12_RAYTRACING_GEOMETRY_TYPE_OMM_TRIANGLES_EX;
+                geometryDescEx[1].ommTriangles.triangles.IndexBuffer = 4;
+                geometryDescEx[1].ommTriangles.ommAttachment.opacityMicromapArray = D3D12_GPU_VIRTUAL_ADDRESS{0x3000};
+
+                REQUIRE(NvAPI_D3D12_BuildRaytracingAccelerationStructureEx(static_cast<ID3D12GraphicsCommandList4*>(&commandList), &params) == NVAPI_OK);
+                REQUIRE(d3d12Desc.Inputs.NumDescs == desc.inputs.numDescs);
+                REQUIRE(geometryDescs[0].Type == D3D12_RAYTRACING_GEOMETRY_TYPE_TRIANGLES);
+                REQUIRE(geometryDescs[0].Triangles.IndexBuffer == geometryDescEx[0].triangles.IndexBuffer);
+                REQUIRE(geometryDescs[1].Type == D3D12_RAYTRACING_GEOMETRY_TYPE_OMM_TRIANGLES);
+                REQUIRE(geometryDescs[1].OmmTriangles.pTriangles->IndexBuffer == geometryDescEx[1].ommTriangles.triangles.IndexBuffer);
+                REQUIRE(ommArrays.size() == 1);
+                REQUIRE(ommArrays[0] == geometryDescEx[1].ommTriangles.ommAttachment.opacityMicromapArray);
+            }
+        }
+    }
+
+    SECTION("BuildRaytracingAccelerationStructureEx ignores OMM build flags when Opacity Micromaps are not supported") {
+        NVAPI_D3D12_RAYTRACING_GEOMETRY_DESC_EX geometryDescEx{};
+        geometryDescEx.type = NVAPI_D3D12_RAYTRACING_GEOMETRY_TYPE_TRIANGLES_EX;
+        geometryDescEx.triangles.IndexBuffer = 3;
+        NVAPI_D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC_EX desc{};
+        NVAPI_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_EX_PARAMS params{};
+        params.version = NVAPI_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_EX_PARAMS_VER1;
+        params.pDesc = &desc;
+
+        D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAGS capturedFlags = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_NONE;
+        ALLOW_CALL(commandList, BuildRaytracingAccelerationStructure(_, _, _))
+            .LR_SIDE_EFFECT(capturedFlags = _1->Inputs.Flags);
+
+        SECTION("BuildRaytracingAccelerationStructureEx with TLAS and allow OMM update flag") {
+            desc.inputs.type = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL;
+            desc.inputs.flags = NVAPI_D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_OMM_UPDATE_EX;
+
+            REQUIRE(NvAPI_D3D12_BuildRaytracingAccelerationStructureEx(static_cast<ID3D12GraphicsCommandList4*>(&commandList), &params) == NVAPI_OK);
+            REQUIRE((capturedFlags & D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_OMM_UPDATE) == 0);
+        }
+
+        SECTION("BuildRaytracingAccelerationStructureEx with TLAS and allow disable OMMs flag") {
+            desc.inputs.type = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL;
+            desc.inputs.flags = NVAPI_D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_DISABLE_OMMS_EX;
+
+            REQUIRE(NvAPI_D3D12_BuildRaytracingAccelerationStructureEx(static_cast<ID3D12GraphicsCommandList4*>(&commandList), &params) == NVAPI_OK);
+            REQUIRE((capturedFlags & D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_DISABLE_OMMS) == 0);
+        }
+
+        SECTION("BuildRaytracingAccelerationStructureEx with BLAS and allow OMM update flag") {
+            desc.inputs.type = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL;
+            desc.inputs.descsLayout = D3D12_ELEMENTS_LAYOUT_ARRAY;
+            desc.inputs.numDescs = 1;
+            desc.inputs.pGeometryDescs = &geometryDescEx;
+            desc.inputs.geometryDescStrideInBytes = sizeof(geometryDescEx);
+            desc.inputs.flags = NVAPI_D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_OMM_UPDATE_EX;
+
+            REQUIRE(NvAPI_D3D12_BuildRaytracingAccelerationStructureEx(static_cast<ID3D12GraphicsCommandList4*>(&commandList), &params) == NVAPI_OK);
+            REQUIRE((capturedFlags & D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_OMM_UPDATE) == 0);
+        }
+    }
+
+    SECTION("BuildRaytracingAccelerationStructureEx fails for OMM triangles when Opacity Micromaps are not supported") {
+        FORBID_CALL(commandList, BuildRaytracingAccelerationStructure(_, _, _));
+
+        NVAPI_D3D12_RAYTRACING_GEOMETRY_DESC_EX geometryDescEx{};
+        geometryDescEx.type = NVAPI_D3D12_RAYTRACING_GEOMETRY_TYPE_OMM_TRIANGLES_EX;
+        NVAPI_D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC_EX desc{};
+        NVAPI_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_EX_PARAMS params{};
+        params.version = NVAPI_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_EX_PARAMS_VER1;
+        params.pDesc = &desc;
+        desc.inputs.type = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL;
+        desc.inputs.numDescs = 1;
+        desc.inputs.geometryDescStrideInBytes = sizeof(geometryDescEx);
+
+        SECTION("BuildRaytracingAccelerationStructureEx with BLAS for array") {
+            desc.inputs.descsLayout = D3D12_ELEMENTS_LAYOUT_ARRAY;
+            desc.inputs.pGeometryDescs = &geometryDescEx;
+
+            REQUIRE(NvAPI_D3D12_BuildRaytracingAccelerationStructureEx(static_cast<ID3D12GraphicsCommandList4*>(&commandList), &params) == NVAPI_NOT_SUPPORTED);
+        }
+
+        SECTION("BuildRaytracingAccelerationStructureEx with BLAS for pointer array") {
+            NVAPI_D3D12_RAYTRACING_GEOMETRY_DESC_EX* geometryDescExArray[] = {&geometryDescEx};
+            desc.inputs.descsLayout = D3D12_ELEMENTS_LAYOUT_ARRAY_OF_POINTERS;
+            desc.inputs.ppGeometryDescs = geometryDescExArray;
+
+            REQUIRE(NvAPI_D3D12_BuildRaytracingAccelerationStructureEx(static_cast<ID3D12GraphicsCommandList4*>(&commandList), &params) == NVAPI_NOT_SUPPORTED);
+        }
+    }
+
     SECTION("GetRaytracingOpacityMicromapArrayPrebuildInfo returns OK") {
         ALLOW_CALL(device, GetExtensionSupport(D3D12_VK_OPACITY_MICROMAP))
             .RETURN(true);

--- a/tests/nvapi_d3d12.cpp
+++ b/tests/nvapi_d3d12.cpp
@@ -1081,6 +1081,204 @@ TEST_CASE("D3D12 methods succeed", "[.d3d12]") {
         }
     }
 
+    SECTION("GetRaytracingAccelerationStructurePrebuildInfoEx succeeds when Opacity Micromaps are supported") {
+        ALLOW_CALL(device, GetExtensionSupport(D3D12_VK_OPACITY_MICROMAP))
+            .RETURN(true);
+
+        NVAPI_D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS_EX desc{};
+        D3D12_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO info{};
+        NVAPI_GET_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO_EX_PARAMS params{};
+        params.version = NVAPI_GET_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO_EX_PARAMS_VER1;
+        params.pDesc = &desc;
+        params.pInfo = &info;
+
+        FORBID_CALL(device, GetRaytracingAccelerationStructurePrebuildInfo(_, _));
+
+        D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS d3d12Desc{};
+        std::vector<D3D12_RAYTRACING_GEOMETRY_DESC> geometryDescs{};
+        std::vector<D3D12_GPU_VIRTUAL_ADDRESS> ommArrays{};
+        ALLOW_CALL(device, GetRaytracingAccelerationStructurePrebuildInfo(_, &info))
+            .LR_SIDE_EFFECT({
+                d3d12Desc = *_1;
+
+                if (_1->Type == D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL && _1->DescsLayout == D3D12_ELEMENTS_LAYOUT_ARRAY) {
+                    geometryDescs.assign(_1->pGeometryDescs, _1->pGeometryDescs + _1->NumDescs);
+                    ommArrays.clear();
+                    for (UINT i = 0; i < _1->NumDescs; i++)
+                        if (_1->pGeometryDescs[i].Type == D3D12_RAYTRACING_GEOMETRY_TYPE_OMM_TRIANGLES)
+                            ommArrays.push_back(_1->pGeometryDescs[i].OmmTriangles.pOmmLinkage->OpacityMicromapArray);
+                }
+            });
+
+        SECTION("GetRaytracingAccelerationStructurePrebuildInfoEx with TLAS and allow OMM update flag") {
+            desc.type = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL;
+            desc.instanceDescs = D3D12_GPU_VIRTUAL_ADDRESS{};
+            desc.flags = NVAPI_D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_OMM_UPDATE_EX;
+
+            REQUIRE(NvAPI_D3D12_GetRaytracingAccelerationStructurePrebuildInfoEx(static_cast<ID3D12Device5*>(&device), &params) == NVAPI_OK);
+            REQUIRE(d3d12Desc.InstanceDescs == desc.instanceDescs);
+            REQUIRE((d3d12Desc.Flags & D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_OMM_UPDATE) != 0);
+        }
+
+        SECTION("GetRaytracingAccelerationStructurePrebuildInfoEx with BLAS for pointer array and allow disable OMMs flag") {
+            NVAPI_D3D12_RAYTRACING_GEOMETRY_DESC_EX geometryDescEx{};
+            geometryDescEx.type = NVAPI_D3D12_RAYTRACING_GEOMETRY_TYPE_TRIANGLES_EX;
+            geometryDescEx.triangles.IndexBuffer = 3;
+            NVAPI_D3D12_RAYTRACING_GEOMETRY_DESC_EX* geometryDescExArray[] = {&geometryDescEx};
+
+            desc.type = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL;
+            desc.descsLayout = D3D12_ELEMENTS_LAYOUT_ARRAY_OF_POINTERS;
+            desc.numDescs = 1;
+            desc.ppGeometryDescs = geometryDescExArray;
+            desc.flags = NVAPI_D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_DISABLE_OMMS_EX;
+
+            REQUIRE(NvAPI_D3D12_GetRaytracingAccelerationStructurePrebuildInfoEx(static_cast<ID3D12Device5*>(&device), &params) == NVAPI_OK);
+            REQUIRE(d3d12Desc.NumDescs == desc.numDescs);
+            REQUIRE((d3d12Desc.Flags & D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_DISABLE_OMMS) != 0);
+            REQUIRE(geometryDescs[0].Type == D3D12_RAYTRACING_GEOMETRY_TYPE_TRIANGLES);
+            REQUIRE(geometryDescs[0].Triangles.IndexBuffer == geometryDescEx.triangles.IndexBuffer);
+        }
+
+        SECTION("GetRaytracingAccelerationStructurePrebuildInfoEx with BLAS for array") {
+            NVAPI_D3D12_RAYTRACING_GEOMETRY_DESC_EX geometryDescEx[2];
+            desc.type = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL;
+            desc.descsLayout = D3D12_ELEMENTS_LAYOUT_ARRAY;
+            desc.numDescs = 2;
+            desc.pGeometryDescs = geometryDescEx;
+            desc.geometryDescStrideInBytes = sizeof(NVAPI_D3D12_RAYTRACING_GEOMETRY_DESC_EX);
+
+            SECTION("GetRaytracingAccelerationStructurePrebuildInfoEx for triangles geometry") {
+                geometryDescEx[0].type = NVAPI_D3D12_RAYTRACING_GEOMETRY_TYPE_TRIANGLES_EX;
+                geometryDescEx[0].triangles.IndexBuffer = 3;
+                geometryDescEx[1].type = NVAPI_D3D12_RAYTRACING_GEOMETRY_TYPE_TRIANGLES_EX;
+                geometryDescEx[1].triangles.IndexBuffer = 4;
+
+                REQUIRE(NvAPI_D3D12_GetRaytracingAccelerationStructurePrebuildInfoEx(static_cast<ID3D12Device5*>(&device), &params) == NVAPI_OK);
+                REQUIRE(d3d12Desc.NumDescs == desc.numDescs);
+                REQUIRE(geometryDescs[0].Type == D3D12_RAYTRACING_GEOMETRY_TYPE_TRIANGLES);
+                REQUIRE(geometryDescs[0].Triangles.IndexBuffer == geometryDescEx[0].triangles.IndexBuffer);
+                REQUIRE(geometryDescs[1].Type == D3D12_RAYTRACING_GEOMETRY_TYPE_TRIANGLES);
+                REQUIRE(geometryDescs[1].Triangles.IndexBuffer == geometryDescEx[1].triangles.IndexBuffer);
+            }
+
+            SECTION("GetRaytracingAccelerationStructurePrebuildInfoEx for OMM triangles geometry") {
+                geometryDescEx[0].type = NVAPI_D3D12_RAYTRACING_GEOMETRY_TYPE_OMM_TRIANGLES_EX;
+                geometryDescEx[0].ommTriangles.triangles.IndexBuffer = 3;
+                geometryDescEx[0].ommTriangles.ommAttachment.opacityMicromapArray = D3D12_GPU_VIRTUAL_ADDRESS{0x1000};
+                geometryDescEx[1].type = NVAPI_D3D12_RAYTRACING_GEOMETRY_TYPE_OMM_TRIANGLES_EX;
+                geometryDescEx[1].ommTriangles.triangles.IndexBuffer = 4;
+                geometryDescEx[1].ommTriangles.ommAttachment.opacityMicromapArray = D3D12_GPU_VIRTUAL_ADDRESS{0x2000};
+
+                REQUIRE(NvAPI_D3D12_GetRaytracingAccelerationStructurePrebuildInfoEx(static_cast<ID3D12Device5*>(&device), &params) == NVAPI_OK);
+                REQUIRE(d3d12Desc.NumDescs == desc.numDescs);
+                REQUIRE(geometryDescs[0].Type == D3D12_RAYTRACING_GEOMETRY_TYPE_OMM_TRIANGLES);
+                REQUIRE(geometryDescs[0].OmmTriangles.pTriangles->IndexBuffer == geometryDescEx[0].ommTriangles.triangles.IndexBuffer);
+                REQUIRE(geometryDescs[1].Type == D3D12_RAYTRACING_GEOMETRY_TYPE_OMM_TRIANGLES);
+                REQUIRE(geometryDescs[1].OmmTriangles.pTriangles->IndexBuffer == geometryDescEx[1].ommTriangles.triangles.IndexBuffer);
+                REQUIRE(ommArrays.size() == 2);
+                REQUIRE(ommArrays[0] == geometryDescEx[0].ommTriangles.ommAttachment.opacityMicromapArray);
+                REQUIRE(ommArrays[1] == geometryDescEx[1].ommTriangles.ommAttachment.opacityMicromapArray);
+            }
+
+            SECTION("GetRaytracingAccelerationStructurePrebuildInfoEx with AABBs geometry") {
+                geometryDescEx[0].type = NVAPI_D3D12_RAYTRACING_GEOMETRY_TYPE_PROCEDURAL_PRIMITIVE_AABBS_EX;
+                geometryDescEx[0].aabbs.AABBCount = 3;
+                geometryDescEx[1].type = NVAPI_D3D12_RAYTRACING_GEOMETRY_TYPE_PROCEDURAL_PRIMITIVE_AABBS_EX;
+                geometryDescEx[1].aabbs.AABBCount = 4;
+
+                REQUIRE(NvAPI_D3D12_GetRaytracingAccelerationStructurePrebuildInfoEx(static_cast<ID3D12Device5*>(&device), &params) == NVAPI_OK);
+                REQUIRE(d3d12Desc.NumDescs == desc.numDescs);
+                REQUIRE(geometryDescs[0].Type == D3D12_RAYTRACING_GEOMETRY_TYPE_PROCEDURAL_PRIMITIVE_AABBS);
+                REQUIRE(geometryDescs[0].AABBs.AABBCount == geometryDescEx[0].aabbs.AABBCount);
+                REQUIRE(geometryDescs[1].Type == D3D12_RAYTRACING_GEOMETRY_TYPE_PROCEDURAL_PRIMITIVE_AABBS);
+                REQUIRE(geometryDescs[1].AABBs.AABBCount == geometryDescEx[1].aabbs.AABBCount);
+            }
+
+            SECTION("GetRaytracingAccelerationStructurePrebuildInfoEx for mixed triangles and OMM triangles geometry") {
+                geometryDescEx[0].type = NVAPI_D3D12_RAYTRACING_GEOMETRY_TYPE_TRIANGLES_EX;
+                geometryDescEx[0].triangles.IndexBuffer = 3;
+                geometryDescEx[1].type = NVAPI_D3D12_RAYTRACING_GEOMETRY_TYPE_OMM_TRIANGLES_EX;
+                geometryDescEx[1].ommTriangles.triangles.IndexBuffer = 4;
+                geometryDescEx[1].ommTriangles.ommAttachment.opacityMicromapArray = D3D12_GPU_VIRTUAL_ADDRESS{0x3000};
+
+                REQUIRE(NvAPI_D3D12_GetRaytracingAccelerationStructurePrebuildInfoEx(static_cast<ID3D12Device5*>(&device), &params) == NVAPI_OK);
+                REQUIRE(d3d12Desc.NumDescs == desc.numDescs);
+                REQUIRE(geometryDescs[0].Type == D3D12_RAYTRACING_GEOMETRY_TYPE_TRIANGLES);
+                REQUIRE(geometryDescs[0].Triangles.IndexBuffer == geometryDescEx[0].triangles.IndexBuffer);
+                REQUIRE(geometryDescs[1].Type == D3D12_RAYTRACING_GEOMETRY_TYPE_OMM_TRIANGLES);
+                REQUIRE(geometryDescs[1].OmmTriangles.pTriangles->IndexBuffer == geometryDescEx[1].ommTriangles.triangles.IndexBuffer);
+                REQUIRE(ommArrays.size() == 1);
+                REQUIRE(ommArrays[0] == geometryDescEx[1].ommTriangles.ommAttachment.opacityMicromapArray);
+            }
+        }
+    }
+
+    SECTION("GetRaytracingAccelerationStructurePrebuildInfoEx ignores OMM build flags when Opacity Micromaps are not supported") {
+        NVAPI_D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS_EX desc{};
+        D3D12_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO info{};
+        NVAPI_GET_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO_EX_PARAMS params{};
+        params.version = NVAPI_GET_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO_EX_PARAMS_VER1;
+        params.pDesc = &desc;
+        params.pInfo = &info;
+        desc.type = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL;
+
+        D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAGS capturedFlags = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_NONE;
+        ALLOW_CALL(device, GetRaytracingAccelerationStructurePrebuildInfo(_, &info))
+            .LR_SIDE_EFFECT(capturedFlags = _1->Flags);
+
+        SECTION("GetRaytracingAccelerationStructurePrebuildInfoEx with allow OMM update flag") {
+            desc.flags = NVAPI_D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_OMM_UPDATE_EX;
+
+            REQUIRE(NvAPI_D3D12_GetRaytracingAccelerationStructurePrebuildInfoEx(static_cast<ID3D12Device5*>(&device), &params) == NVAPI_OK);
+            REQUIRE((capturedFlags & D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_OMM_UPDATE) == 0);
+        }
+
+        SECTION("GetRaytracingAccelerationStructurePrebuildInfoEx with allow disable OMMs flag") {
+            desc.flags = NVAPI_D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_DISABLE_OMMS_EX;
+
+            REQUIRE(NvAPI_D3D12_GetRaytracingAccelerationStructurePrebuildInfoEx(static_cast<ID3D12Device5*>(&device), &params) == NVAPI_OK);
+            REQUIRE((capturedFlags & D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_DISABLE_OMMS) == 0);
+        }
+
+        SECTION("GetRaytracingAccelerationStructurePrebuildInfoEx with allow OMM opacity states update flag") {
+            desc.flags = NVAPI_D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_OMM_OPACITY_STATES_UPDATE_EX;
+
+            REQUIRE(NvAPI_D3D12_GetRaytracingAccelerationStructurePrebuildInfoEx(static_cast<ID3D12Device5*>(&device), &params) == NVAPI_OK);
+            REQUIRE((capturedFlags & D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_OMM_UPDATE) == 0);
+        }
+    }
+
+    SECTION("GetRaytracingAccelerationStructurePrebuildInfoEx fails for OMM triangles when Opacity Micromaps are not supported") {
+        FORBID_CALL(device, GetRaytracingAccelerationStructurePrebuildInfo(_, _));
+
+        NVAPI_D3D12_RAYTRACING_GEOMETRY_DESC_EX geometryDescEx{};
+        geometryDescEx.type = NVAPI_D3D12_RAYTRACING_GEOMETRY_TYPE_OMM_TRIANGLES_EX;
+        NVAPI_D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS_EX desc{};
+        D3D12_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO info{};
+        NVAPI_GET_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO_EX_PARAMS params{};
+        params.version = NVAPI_GET_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO_EX_PARAMS_VER1;
+        params.pDesc = &desc;
+        params.pInfo = &info;
+        desc.type = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL;
+        desc.numDescs = 1;
+        desc.geometryDescStrideInBytes = sizeof(geometryDescEx);
+
+        SECTION("GetRaytracingAccelerationStructurePrebuildInfoEx with BLAS for array") {
+            desc.descsLayout = D3D12_ELEMENTS_LAYOUT_ARRAY;
+            desc.pGeometryDescs = &geometryDescEx;
+
+            REQUIRE(NvAPI_D3D12_GetRaytracingAccelerationStructurePrebuildInfoEx(static_cast<ID3D12Device5*>(&device), &params) == NVAPI_NOT_SUPPORTED);
+        }
+
+        SECTION("GetRaytracingAccelerationStructurePrebuildInfoEx with BLAS for pointer array") {
+            NVAPI_D3D12_RAYTRACING_GEOMETRY_DESC_EX* geometryDescExArray[] = {&geometryDescEx};
+            desc.descsLayout = D3D12_ELEMENTS_LAYOUT_ARRAY_OF_POINTERS;
+            desc.ppGeometryDescs = geometryDescExArray;
+
+            REQUIRE(NvAPI_D3D12_GetRaytracingAccelerationStructurePrebuildInfoEx(static_cast<ID3D12Device5*>(&device), &params) == NVAPI_NOT_SUPPORTED);
+        }
+    }
+
     SECTION("BuildRaytracingAccelerationStructureEx succeeds") {
         SECTION("BuildRaytracingAccelerationStructureEx returns OK") {
             NVAPI_D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC_EX desc{};

--- a/tests/nvapi_d3d12.cpp
+++ b/tests/nvapi_d3d12.cpp
@@ -937,6 +937,255 @@ TEST_CASE("D3D12 methods succeed", "[.d3d12]") {
         }
     }
 
+    SECTION("D3DLowLatencyDevice methods succeed") {
+        auto t = std::make_unique<DefaultTestEnvironment>();
+        auto e = t->ConfigureExpectations();
+
+        ALLOW_CALL(commandQueue, GetDevice(__uuidof(ID3DLowLatencyDevice), _))
+            .LR_SIDE_EFFECT(*_2 = static_cast<ID3DLowLatencyDevice*>(&lowLatencyDevice))
+            .LR_SIDE_EFFECT(lowLatencyDeviceRefCount++)
+            .RETURN(S_OK);
+        ALLOW_CALL(commandQueue, QueryInterface(__uuidof(ID3D12DeviceChild), _))
+            .LR_SIDE_EFFECT(*_2 = static_cast<ID3D12DeviceChild*>(&commandQueue))
+            .LR_SIDE_EFFECT(commandQueueRefCount++)
+            .RETURN(S_OK);
+        ALLOW_CALL(commandQueue, QueryInterface(__uuidof(ID3DLowLatencyDevice), _))
+            .RETURN(E_NOINTERFACE);
+        ALLOW_CALL(device, QueryInterface(__uuidof(ID3DLowLatencyDevice), _))
+            .LR_SIDE_EFFECT(*_2 = static_cast<ID3DLowLatencyDevice*>(&lowLatencyDevice))
+            .LR_SIDE_EFFECT(lowLatencyDeviceRefCount++)
+            .RETURN(S_OK);
+        ALLOW_CALL(lowLatencyDevice, AddRef())
+            .LR_SIDE_EFFECT(lowLatencyDeviceRefCount++)
+            .RETURN(lowLatencyDeviceRefCount);
+        ALLOW_CALL(lowLatencyDevice, Release())
+            .LR_SIDE_EFFECT(lowLatencyDeviceRefCount--)
+            .RETURN(lowLatencyDeviceRefCount);
+        ALLOW_CALL(lowLatencyDevice, SupportsLowLatency())
+            .RETURN(true);
+
+        SECTION("NotifyOutOfBandCommandQueue succeeds") {
+            SECTION("NotifyOutOfBandCommandQueue returns OK") {
+                REQUIRE_CALL(commandQueue, NotifyOutOfBandCommandQueue(static_cast<D3D12_OUT_OF_BAND_CQ_TYPE>(OUT_OF_BAND_RENDER)))
+                    .RETURN(S_OK);
+
+                REQUIRE(NvAPI_Initialize() == NVAPI_OK);
+                REQUIRE(NvAPI_D3D12_NotifyOutOfBandCommandQueue(&commandQueue, OUT_OF_BAND_RENDER) == NVAPI_OK);
+            }
+
+            SECTION("NotifyOutOfBandCommandQueue with null command queue returns invalid-pointer") {
+                REQUIRE(NvAPI_Initialize() == NVAPI_OK);
+                REQUIRE(NvAPI_D3D12_NotifyOutOfBandCommandQueue(nullptr, OUT_OF_BAND_RENDER) == NVAPI_INVALID_POINTER);
+            }
+        }
+
+        SECTION("SetAsyncFrameMarker succeeds") {
+            SECTION("SetAsyncFrameMarker returns OK") {
+                REQUIRE_CALL(lowLatencyDevice, SetLatencyMarker(1ULL, VK_LATENCY_MARKER_OUT_OF_BAND_RENDERSUBMIT_START_NV))
+                    .RETURN(S_OK);
+
+                REQUIRE(NvAPI_Initialize() == NVAPI_OK);
+
+                NV_ASYNC_FRAME_MARKER_PARAMS params{};
+                params.version = NV_ASYNC_FRAME_MARKER_PARAMS_VER1;
+                params.frameID = 123ULL;
+                params.markerType = OUT_OF_BAND_RENDERSUBMIT_START;
+                REQUIRE(NvAPI_D3D12_SetAsyncFrameMarker(&commandQueue, &params) == NVAPI_OK);
+            }
+
+            SECTION("SetAsyncFrameMarker drops PC_LATENCY_PING and returns OK") {
+                FORBID_CALL(lowLatencyDevice, SetLatencyMarker(_, _));
+
+                REQUIRE(NvAPI_Initialize() == NVAPI_OK);
+
+                NV_ASYNC_FRAME_MARKER_PARAMS params{};
+                params.version = NV_ASYNC_FRAME_MARKER_PARAMS_VER1;
+                params.frameID = 123ULL;
+                params.markerType = PC_LATENCY_PING;
+                REQUIRE(NvAPI_D3D12_SetAsyncFrameMarker(&commandQueue, &params) == NVAPI_OK);
+            }
+
+            SECTION("SetAsyncFrameMarker with second command queue from the same device uses the same D3DLowLatencyDevice") {
+                D3D12Vkd3dCommandQueueMock otherCommandQueue;
+                ALLOW_CALL(otherCommandQueue, QueryInterface(__uuidof(ID3D12CommandQueue), _))
+                    .LR_SIDE_EFFECT(*_2 = static_cast<ID3D12CommandQueue*>(&otherCommandQueue))
+                    .RETURN(S_OK);
+                ALLOW_CALL(otherCommandQueue, QueryInterface(__uuidof(ID3D12DeviceChild), _))
+                    .LR_SIDE_EFFECT(*_2 = static_cast<ID3D12DeviceChild*>(&otherCommandQueue))
+                    .RETURN(S_OK);
+                ALLOW_CALL(otherCommandQueue, QueryInterface(__uuidof(ID3D11DeviceChild), _))
+                    .RETURN(E_NOINTERFACE);
+                ALLOW_CALL(otherCommandQueue, AddRef())
+                    .RETURN(1);
+                ALLOW_CALL(otherCommandQueue, Release())
+                    .RETURN(1);
+                ALLOW_CALL(otherCommandQueue, GetDevice(__uuidof(ID3DLowLatencyDevice), _))
+                    .LR_SIDE_EFFECT(*_2 = static_cast<ID3DLowLatencyDevice*>(&lowLatencyDevice))
+                    .LR_SIDE_EFFECT(lowLatencyDeviceRefCount++)
+                    .RETURN(S_OK);
+                ALLOW_CALL(otherCommandQueue, QueryInterface(__uuidof(ID3DLowLatencyDevice), _))
+                    .RETURN(E_NOINTERFACE);
+
+                REQUIRE_CALL(lowLatencyDevice, SetLatencyMarker(_, VK_LATENCY_MARKER_OUT_OF_BAND_RENDERSUBMIT_START_NV))
+                    .RETURN(S_OK)
+                    .TIMES(4);
+
+                REQUIRE(NvAPI_Initialize() == NVAPI_OK);
+
+                NV_ASYNC_FRAME_MARKER_PARAMS params{};
+                params.version = NV_ASYNC_FRAME_MARKER_PARAMS_VER1;
+                params.frameID = 123ULL;
+                params.markerType = OUT_OF_BAND_RENDERSUBMIT_START;
+                REQUIRE(NvAPI_D3D12_SetAsyncFrameMarker(&commandQueue, &params) == NVAPI_OK);
+                params.frameID = 124ULL;
+                REQUIRE(NvAPI_D3D12_SetAsyncFrameMarker(&otherCommandQueue, &params) == NVAPI_OK);
+                params.frameID = 125ULL;
+                REQUIRE(NvAPI_D3D12_SetAsyncFrameMarker(&commandQueue, &params) == NVAPI_OK);
+                params.frameID = 126ULL;
+                REQUIRE(NvAPI_D3D12_SetAsyncFrameMarker(&otherCommandQueue, &params) == NVAPI_OK);
+            }
+
+            SECTION("SetAsyncFrameMarker with unknown struct version returns incompatible-struct-version") {
+                REQUIRE(NvAPI_Initialize() == NVAPI_OK);
+
+                NV_ASYNC_FRAME_MARKER_PARAMS params{};
+                params.version = NV_ASYNC_FRAME_MARKER_PARAMS_VER1 + 1;
+                REQUIRE(NvAPI_D3D12_SetAsyncFrameMarker(&commandQueue, &params) == NVAPI_INCOMPATIBLE_STRUCT_VERSION);
+            }
+
+            SECTION("SetAsyncFrameMarker with current struct version returns not incompatible-struct-version") {
+                ALLOW_CALL(lowLatencyDevice, SetLatencyMarker(_, _))
+                    .RETURN(S_OK);
+
+                REQUIRE(NvAPI_Initialize() == NVAPI_OK);
+
+                NV_ASYNC_FRAME_MARKER_PARAMS params{};
+                params.version = NV_ASYNC_FRAME_MARKER_PARAMS_VER;
+                REQUIRE(NvAPI_D3D12_SetAsyncFrameMarker(&commandQueue, &params) != NVAPI_INCOMPATIBLE_STRUCT_VERSION);
+            }
+
+            SECTION("SetAsyncFrameMarker with null command queue returns invalid-pointer") {
+                REQUIRE(NvAPI_Initialize() == NVAPI_OK);
+
+                NV_ASYNC_FRAME_MARKER_PARAMS params{};
+                params.version = NV_ASYNC_FRAME_MARKER_PARAMS_VER;
+                REQUIRE(NvAPI_D3D12_SetAsyncFrameMarker(nullptr, &params) == NVAPI_INVALID_POINTER);
+            }
+        }
+    }
+
+    CHECK(deviceRefCount == 0);
+    CHECK(commandListRefCount == 0);
+    CHECK(commandQueueRefCount == 0);
+    CHECK(lowLatencyDeviceRefCount == 0);
+}
+
+TEST_CASE("D3D12 raytracing methods succeed", "[.d3d12]") {
+    D3D12Vkd3dDeviceMock device;
+    D3D12Vkd3dCommandQueueMock commandQueue;
+    D3D12Vkd3dGraphicsCommandListMock commandList;
+    auto deviceRefCount = 0;
+    auto commandListRefCount = 0;
+    auto commandQueueRefCount = 0;
+
+    ALLOW_CALL(device, QueryInterface(__uuidof(ID3D12Device), _))
+        .LR_SIDE_EFFECT(*_2 = static_cast<ID3D12Device*>(&device))
+        .LR_SIDE_EFFECT(deviceRefCount++)
+        .RETURN(S_OK);
+    ALLOW_CALL(device, QueryInterface(__uuidof(ID3D12DeviceExt), _))
+        .LR_SIDE_EFFECT(*_2 = static_cast<ID3D12DeviceExt*>(&device))
+        .LR_SIDE_EFFECT(deviceRefCount++)
+        .RETURN(S_OK);
+    ALLOW_CALL(device, QueryInterface(__uuidof(ID3D12DeviceExt2), _))
+        .LR_SIDE_EFFECT(*_2 = static_cast<ID3D12DeviceExt2*>(&device))
+        .LR_SIDE_EFFECT(deviceRefCount++)
+        .RETURN(S_OK);
+    ALLOW_CALL(device, QueryInterface(__uuidof(ID3D12DeviceExt4), _))
+        .LR_SIDE_EFFECT(*_2 = static_cast<ID3D12DeviceExt4*>(&device))
+        .LR_SIDE_EFFECT(deviceRefCount++)
+        .RETURN(S_OK);
+    ALLOW_CALL(device, QueryInterface(__uuidof(ID3D12DeviceExt5), _))
+        .LR_SIDE_EFFECT(*_2 = static_cast<ID3D12DeviceExt5*>(&device))
+        .LR_SIDE_EFFECT(deviceRefCount++)
+        .RETURN(S_OK);
+    ALLOW_CALL(device, AddRef())
+        .LR_SIDE_EFFECT(deviceRefCount++)
+        .RETURN(deviceRefCount);
+    ALLOW_CALL(device, Release())
+        .LR_SIDE_EFFECT(deviceRefCount--)
+        .RETURN(deviceRefCount);
+
+    ALLOW_CALL(device, QueryInterface(__uuidof(IUnknown), _))
+        .LR_SIDE_EFFECT(*_2 = static_cast<IUnknown*>(static_cast<ID3D12Device*>(&device)))
+        .LR_SIDE_EFFECT(deviceRefCount++)
+        .RETURN(S_OK);
+
+    ALLOW_CALL(device, QueryInterface(__uuidof(ID3DLowLatencyDevice), _))
+        .RETURN(E_NOINTERFACE);
+
+    ALLOW_CALL(device, GetExtensionSupport(_))
+        .RETURN(true);
+    ALLOW_CALL(device, GetExtensionSupport(D3D12_VK_OPACITY_MICROMAP))
+        .RETURN(false);
+    ALLOW_CALL(device, SupportsCubin64bit())
+        .RETURN(true);
+
+    ALLOW_CALL(commandList, QueryInterface(__uuidof(ID3D12GraphicsCommandList), _))
+        .LR_SIDE_EFFECT(*_2 = static_cast<ID3D12GraphicsCommandList*>(&commandList))
+        .LR_SIDE_EFFECT(commandListRefCount++)
+        .RETURN(S_OK);
+    ALLOW_CALL(commandList, QueryInterface(__uuidof(ID3D12GraphicsCommandList1), _))
+        .LR_SIDE_EFFECT(*_2 = static_cast<ID3D12GraphicsCommandList1*>(&commandList))
+        .LR_SIDE_EFFECT(commandListRefCount++)
+        .RETURN(S_OK);
+    ALLOW_CALL(commandList, QueryInterface(__uuidof(ID3D12GraphicsCommandListExt), _))
+        .LR_SIDE_EFFECT(*_2 = static_cast<ID3D12GraphicsCommandListExt*>(&commandList))
+        .LR_SIDE_EFFECT(commandListRefCount++)
+        .RETURN(S_OK);
+    ALLOW_CALL(commandList, QueryInterface(__uuidof(ID3D12GraphicsCommandListExt1), _))
+        .LR_SIDE_EFFECT(*_2 = static_cast<ID3D12GraphicsCommandListExt*>(&commandList))
+        .LR_SIDE_EFFECT(commandListRefCount++)
+        .RETURN(S_OK);
+    ALLOW_CALL(commandList, QueryInterface(__uuidof(ID3D12GraphicsCommandListExt2), _))
+        .LR_SIDE_EFFECT(*_2 = static_cast<ID3D12GraphicsCommandListExt2*>(&commandList))
+        .LR_SIDE_EFFECT(commandListRefCount++)
+        .RETURN(S_OK);
+    ALLOW_CALL(commandList, QueryInterface(__uuidof(IUnknown), _))
+        .LR_SIDE_EFFECT(*_2 = static_cast<IUnknown*>(static_cast<ID3D12GraphicsCommandList1*>(&commandList)))
+        .LR_SIDE_EFFECT(commandListRefCount++)
+        .RETURN(S_OK);
+    ALLOW_CALL(commandList, AddRef())
+        .LR_SIDE_EFFECT(commandListRefCount++)
+        .RETURN(commandListRefCount);
+    ALLOW_CALL(commandList, Release())
+        .LR_SIDE_EFFECT(commandListRefCount--)
+        .RETURN(commandListRefCount);
+    ALLOW_CALL(commandList, GetDevice(__uuidof(ID3D12Device), _))
+        .LR_SIDE_EFFECT(*_2 = static_cast<ID3D12Device*>(&device))
+        .LR_SIDE_EFFECT(deviceRefCount++)
+        .RETURN(S_OK);
+
+    ALLOW_CALL(commandQueue, QueryInterface(__uuidof(ID3D12CommandQueue), _))
+        .LR_SIDE_EFFECT(*_2 = static_cast<ID3D12CommandQueue*>(&commandQueue))
+        .LR_SIDE_EFFECT(commandQueueRefCount++)
+        .RETURN(S_OK);
+    ALLOW_CALL(commandQueue, QueryInterface(__uuidof(ID3D12CommandQueueExt), _))
+        .LR_SIDE_EFFECT(*_2 = static_cast<ID3D12CommandQueueExt*>(&commandQueue))
+        .LR_SIDE_EFFECT(commandQueueRefCount++)
+        .RETURN(S_OK);
+    ALLOW_CALL(commandQueue, QueryInterface(__uuidof(ID3D11DeviceChild), _))
+        .RETURN(E_NOINTERFACE);
+    ALLOW_CALL(commandQueue, AddRef())
+        .LR_SIDE_EFFECT(commandQueueRefCount++)
+        .RETURN(commandQueueRefCount);
+    ALLOW_CALL(commandQueue, Release())
+        .LR_SIDE_EFFECT(commandQueueRefCount--)
+        .RETURN(commandQueueRefCount);
+    ALLOW_CALL(commandQueue, GetDevice(__uuidof(ID3D12Device), _))
+        .LR_SIDE_EFFECT(*_2 = static_cast<ID3D12Device*>(&device))
+        .LR_SIDE_EFFECT(deviceRefCount++)
+        .RETURN(S_OK);
+
     SECTION("GetRaytracingAccelerationStructurePrebuildInfoEx succeeds") {
         SECTION("GetRaytracingAccelerationStructurePrebuildInfoEx returns OK") {
             NVAPI_D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS_EX desc{};
@@ -2007,146 +2256,4 @@ TEST_CASE("D3D12 methods succeed", "[.d3d12]") {
         REQUIRE(NvAPI_D3D12_SetCreatePipelineStateOptions(static_cast<ID3D12Device5*>(&device), &params) == NVAPI_OK);
         REQUIRE(deviceRefCount == 0);
     }
-
-    SECTION("D3DLowLatencyDevice methods succeed") {
-        auto t = std::make_unique<DefaultTestEnvironment>();
-        auto e = t->ConfigureExpectations();
-
-        ALLOW_CALL(commandQueue, GetDevice(__uuidof(ID3DLowLatencyDevice), _))
-            .LR_SIDE_EFFECT(*_2 = static_cast<ID3DLowLatencyDevice*>(&lowLatencyDevice))
-            .LR_SIDE_EFFECT(lowLatencyDeviceRefCount++)
-            .RETURN(S_OK);
-        ALLOW_CALL(commandQueue, QueryInterface(__uuidof(ID3D12DeviceChild), _))
-            .LR_SIDE_EFFECT(*_2 = static_cast<ID3D12DeviceChild*>(&commandQueue))
-            .LR_SIDE_EFFECT(commandQueueRefCount++)
-            .RETURN(S_OK);
-        ALLOW_CALL(commandQueue, QueryInterface(__uuidof(ID3DLowLatencyDevice), _))
-            .RETURN(E_NOINTERFACE);
-        ALLOW_CALL(device, QueryInterface(__uuidof(ID3DLowLatencyDevice), _))
-            .LR_SIDE_EFFECT(*_2 = static_cast<ID3DLowLatencyDevice*>(&lowLatencyDevice))
-            .LR_SIDE_EFFECT(lowLatencyDeviceRefCount++)
-            .RETURN(S_OK);
-        ALLOW_CALL(lowLatencyDevice, AddRef())
-            .LR_SIDE_EFFECT(lowLatencyDeviceRefCount++)
-            .RETURN(lowLatencyDeviceRefCount);
-        ALLOW_CALL(lowLatencyDevice, Release())
-            .LR_SIDE_EFFECT(lowLatencyDeviceRefCount--)
-            .RETURN(lowLatencyDeviceRefCount);
-        ALLOW_CALL(lowLatencyDevice, SupportsLowLatency())
-            .RETURN(true);
-
-        SECTION("NotifyOutOfBandCommandQueue succeeds") {
-            SECTION("NotifyOutOfBandCommandQueue returns OK") {
-                REQUIRE_CALL(commandQueue, NotifyOutOfBandCommandQueue(static_cast<D3D12_OUT_OF_BAND_CQ_TYPE>(OUT_OF_BAND_RENDER)))
-                    .RETURN(S_OK);
-
-                REQUIRE(NvAPI_Initialize() == NVAPI_OK);
-                REQUIRE(NvAPI_D3D12_NotifyOutOfBandCommandQueue(&commandQueue, OUT_OF_BAND_RENDER) == NVAPI_OK);
-            }
-
-            SECTION("NotifyOutOfBandCommandQueue with null command queue returns invalid-pointer") {
-                REQUIRE(NvAPI_Initialize() == NVAPI_OK);
-                REQUIRE(NvAPI_D3D12_NotifyOutOfBandCommandQueue(nullptr, OUT_OF_BAND_RENDER) == NVAPI_INVALID_POINTER);
-            }
-        }
-
-        SECTION("SetAsyncFrameMarker succeeds") {
-            SECTION("SetAsyncFrameMarker returns OK") {
-                REQUIRE_CALL(lowLatencyDevice, SetLatencyMarker(1ULL, VK_LATENCY_MARKER_OUT_OF_BAND_RENDERSUBMIT_START_NV))
-                    .RETURN(S_OK);
-
-                REQUIRE(NvAPI_Initialize() == NVAPI_OK);
-
-                NV_ASYNC_FRAME_MARKER_PARAMS params{};
-                params.version = NV_ASYNC_FRAME_MARKER_PARAMS_VER1;
-                params.frameID = 123ULL;
-                params.markerType = OUT_OF_BAND_RENDERSUBMIT_START;
-                REQUIRE(NvAPI_D3D12_SetAsyncFrameMarker(&commandQueue, &params) == NVAPI_OK);
-            }
-
-            SECTION("SetAsyncFrameMarker drops PC_LATENCY_PING and returns OK") {
-                FORBID_CALL(lowLatencyDevice, SetLatencyMarker(_, _));
-
-                REQUIRE(NvAPI_Initialize() == NVAPI_OK);
-
-                NV_ASYNC_FRAME_MARKER_PARAMS params{};
-                params.version = NV_ASYNC_FRAME_MARKER_PARAMS_VER1;
-                params.frameID = 123ULL;
-                params.markerType = PC_LATENCY_PING;
-                REQUIRE(NvAPI_D3D12_SetAsyncFrameMarker(&commandQueue, &params) == NVAPI_OK);
-            }
-
-            SECTION("SetAsyncFrameMarker with second command queue from the same device uses the same D3DLowLatencyDevice") {
-                D3D12Vkd3dCommandQueueMock otherCommandQueue;
-                ALLOW_CALL(otherCommandQueue, QueryInterface(__uuidof(ID3D12CommandQueue), _))
-                    .LR_SIDE_EFFECT(*_2 = static_cast<ID3D12CommandQueue*>(&otherCommandQueue))
-                    .RETURN(S_OK);
-                ALLOW_CALL(otherCommandQueue, QueryInterface(__uuidof(ID3D12DeviceChild), _))
-                    .LR_SIDE_EFFECT(*_2 = static_cast<ID3D12DeviceChild*>(&otherCommandQueue))
-                    .RETURN(S_OK);
-                ALLOW_CALL(otherCommandQueue, QueryInterface(__uuidof(ID3D11DeviceChild), _))
-                    .RETURN(E_NOINTERFACE);
-                ALLOW_CALL(otherCommandQueue, AddRef())
-                    .RETURN(1);
-                ALLOW_CALL(otherCommandQueue, Release())
-                    .RETURN(1);
-                ALLOW_CALL(otherCommandQueue, GetDevice(__uuidof(ID3DLowLatencyDevice), _))
-                    .LR_SIDE_EFFECT(*_2 = static_cast<ID3DLowLatencyDevice*>(&lowLatencyDevice))
-                    .LR_SIDE_EFFECT(lowLatencyDeviceRefCount++)
-                    .RETURN(S_OK);
-                ALLOW_CALL(otherCommandQueue, QueryInterface(__uuidof(ID3DLowLatencyDevice), _))
-                    .RETURN(E_NOINTERFACE);
-
-                REQUIRE_CALL(lowLatencyDevice, SetLatencyMarker(_, VK_LATENCY_MARKER_OUT_OF_BAND_RENDERSUBMIT_START_NV))
-                    .RETURN(S_OK)
-                    .TIMES(4);
-
-                REQUIRE(NvAPI_Initialize() == NVAPI_OK);
-
-                NV_ASYNC_FRAME_MARKER_PARAMS params{};
-                params.version = NV_ASYNC_FRAME_MARKER_PARAMS_VER1;
-                params.frameID = 123ULL;
-                params.markerType = OUT_OF_BAND_RENDERSUBMIT_START;
-                REQUIRE(NvAPI_D3D12_SetAsyncFrameMarker(&commandQueue, &params) == NVAPI_OK);
-                params.frameID = 124ULL;
-                REQUIRE(NvAPI_D3D12_SetAsyncFrameMarker(&otherCommandQueue, &params) == NVAPI_OK);
-                params.frameID = 125ULL;
-                REQUIRE(NvAPI_D3D12_SetAsyncFrameMarker(&commandQueue, &params) == NVAPI_OK);
-                params.frameID = 126ULL;
-                REQUIRE(NvAPI_D3D12_SetAsyncFrameMarker(&otherCommandQueue, &params) == NVAPI_OK);
-            }
-
-            SECTION("SetAsyncFrameMarker with unknown struct version returns incompatible-struct-version") {
-                REQUIRE(NvAPI_Initialize() == NVAPI_OK);
-
-                NV_ASYNC_FRAME_MARKER_PARAMS params{};
-                params.version = NV_ASYNC_FRAME_MARKER_PARAMS_VER1 + 1;
-                REQUIRE(NvAPI_D3D12_SetAsyncFrameMarker(&commandQueue, &params) == NVAPI_INCOMPATIBLE_STRUCT_VERSION);
-            }
-
-            SECTION("SetAsyncFrameMarker with current struct version returns not incompatible-struct-version") {
-                ALLOW_CALL(lowLatencyDevice, SetLatencyMarker(_, _))
-                    .RETURN(S_OK);
-
-                REQUIRE(NvAPI_Initialize() == NVAPI_OK);
-
-                NV_ASYNC_FRAME_MARKER_PARAMS params{};
-                params.version = NV_ASYNC_FRAME_MARKER_PARAMS_VER;
-                REQUIRE(NvAPI_D3D12_SetAsyncFrameMarker(&commandQueue, &params) != NVAPI_INCOMPATIBLE_STRUCT_VERSION);
-            }
-
-            SECTION("SetAsyncFrameMarker with null command queue returns invalid-pointer") {
-                REQUIRE(NvAPI_Initialize() == NVAPI_OK);
-
-                NV_ASYNC_FRAME_MARKER_PARAMS params{};
-                params.version = NV_ASYNC_FRAME_MARKER_PARAMS_VER;
-                REQUIRE(NvAPI_D3D12_SetAsyncFrameMarker(nullptr, &params) == NVAPI_INVALID_POINTER);
-            }
-        }
-    }
-
-    CHECK(deviceRefCount == 0);
-    CHECK(commandListRefCount == 0);
-    CHECK(commandQueueRefCount == 0);
-    CHECK(lowLatencyDeviceRefCount == 0);
 }

--- a/tests/nvapi_d3d12.cpp
+++ b/tests/nvapi_d3d12.cpp
@@ -159,8 +159,13 @@ TEST_CASE("D3D12 methods succeed", "[.d3d12]") {
         FORBID_CALL(device, GetCudaTextureObject(_, _, _));
         FORBID_CALL(device, GetCudaSurfaceObject(_, _));
         FORBID_CALL(device, CaptureUAVInfo(_));
+        FORBID_CALL(device, SetCreatePipelineStateFlagsNVAPI(_));
+        FORBID_CALL(device, GetRaytracingAccelerationStructurePrebuildInfo(_, _));
         FORBID_CALL(commandList, LaunchCubinShader(_, _, _, _, _, _));
         FORBID_CALL(commandList, LaunchCubinShaderEx(_, _, _, _, _, _, _, _, _));
+        FORBID_CALL(commandList, BuildRaytracingAccelerationStructure(_, _, _));
+        FORBID_CALL(commandList, VerifyOpacityMicromapArrayNVAPI(_));
+        FORBID_CALL(commandList, EmitRaytracingAccelerationStructurePostbuildInfo(_, _, _));
 
         const void* cubinData = nullptr;
         NVDX_ObjectHandle handle{};
@@ -181,6 +186,48 @@ TEST_CASE("D3D12 methods succeed", "[.d3d12]") {
         REQUIRE(NvAPI_D3D12_IsFatbinPTXSupported(static_cast<ID3D12Device*>(&device), &isPTXSupported) == NVAPI_NO_IMPLEMENTATION);
 
         REQUIRE(NvAPI_D3D12_LaunchCubinShader(static_cast<ID3D12GraphicsCommandList*>(&commandList), handle, 0, 0, 0, nullptr, 0) == NVAPI_NO_IMPLEMENTATION);
+
+        {
+            NVAPI_D3D12_BUILD_RAYTRACING_OPACITY_MICROMAP_ARRAY_INPUTS inputs{};
+            NVAPI_D3D12_RAYTRACING_OPACITY_MICROMAP_ARRAY_PREBUILD_INFO info{};
+            NVAPI_GET_RAYTRACING_OPACITY_MICROMAP_ARRAY_PREBUILD_INFO_PARAMS params{};
+            params.version = NVAPI_GET_RAYTRACING_OPACITY_MICROMAP_ARRAY_PREBUILD_INFO_PARAMS_VER1;
+            params.pDesc = &inputs;
+            params.pInfo = &info;
+            REQUIRE(NvAPI_D3D12_GetRaytracingOpacityMicromapArrayPrebuildInfo(static_cast<ID3D12Device5*>(&device), &params) == NVAPI_NO_IMPLEMENTATION);
+        }
+        {
+            NVAPI_D3D12_SET_CREATE_PIPELINE_STATE_OPTIONS_PARAMS params{};
+            params.version = NVAPI_D3D12_SET_CREATE_PIPELINE_STATE_OPTIONS_PARAMS_VER1;
+            params.flags = NVAPI_D3D12_PIPELINE_CREATION_STATE_FLAGS_ENABLE_OMM_SUPPORT;
+            REQUIRE(NvAPI_D3D12_SetCreatePipelineStateOptions(static_cast<ID3D12Device5*>(&device), &params) == NVAPI_NO_IMPLEMENTATION);
+        }
+        {
+            NVAPI_CHECK_DRIVER_MATCHING_IDENTIFIER_EX_PARAMS params{};
+            params.version = NVAPI_CHECK_DRIVER_MATCHING_IDENTIFIER_EX_PARAMS_VER1;
+            params.serializedDataType = NVAPI_D3D12_SERIALIZED_DATA_RAYTRACING_OPACITY_MICROMAP_ARRAY_EX;
+            REQUIRE(NvAPI_D3D12_CheckDriverMatchingIdentifierEx(static_cast<ID3D12Device5*>(&device), &params) == NVAPI_NO_IMPLEMENTATION);
+        }
+        {
+            NVAPI_D3D12_BUILD_RAYTRACING_OPACITY_MICROMAP_ARRAY_DESC ommArrayDesc{};
+            NVAPI_BUILD_RAYTRACING_OPACITY_MICROMAP_ARRAY_PARAMS params{};
+            params.version = NVAPI_BUILD_RAYTRACING_OPACITY_MICROMAP_ARRAY_PARAMS_VER1;
+            params.pDesc = &ommArrayDesc;
+            REQUIRE(NvAPI_D3D12_BuildRaytracingOpacityMicromapArray(static_cast<ID3D12GraphicsCommandList4*>(&commandList), &params) == NVAPI_NO_IMPLEMENTATION);
+        }
+        {
+            NVAPI_RELOCATE_RAYTRACING_OPACITY_MICROMAP_ARRAY_PARAMS params{};
+            params.version = NVAPI_RELOCATE_RAYTRACING_OPACITY_MICROMAP_ARRAY_PARAMS_VER1;
+            REQUIRE(NvAPI_D3D12_RelocateRaytracingOpacityMicromapArray(static_cast<ID3D12GraphicsCommandList4*>(&commandList), &params) == NVAPI_NO_IMPLEMENTATION);
+        }
+        {
+            NVAPI_D3D12_RAYTRACING_OPACITY_MICROMAP_ARRAY_POSTBUILD_INFO_DESC postbuildDesc{};
+            postbuildDesc.infoType = NVAPI_D3D12_RAYTRACING_OPACITY_MICROMAP_ARRAY_POSTBUILD_INFO_CURRENT_SIZE;
+            NVAPI_EMIT_RAYTRACING_OPACITY_MICROMAP_ARRAY_POSTBUILD_INFO_PARAMS params{};
+            params.version = NVAPI_EMIT_RAYTRACING_OPACITY_MICROMAP_ARRAY_POSTBUILD_INFO_PARAMS_VER1;
+            params.pDesc = &postbuildDesc;
+            REQUIRE(NvAPI_D3D12_EmitRaytracingOpacityMicromapArrayPostbuildInfo(static_cast<ID3D12GraphicsCommandList4*>(&commandList), &params) == NVAPI_NO_IMPLEMENTATION);
+        }
     }
 
     SECTION("D3D12 methods without cubin extension return error") {

--- a/tests/nvapi_d3d12.cpp
+++ b/tests/nvapi_d3d12.cpp
@@ -1781,6 +1781,127 @@ TEST_CASE("D3D12 methods succeed", "[.d3d12]") {
         REQUIRE(commandListRefCount == 0);
     }
 
+    SECTION("OMM entry points with unknown struct version return incompatible-struct-version") {
+        {
+            NVAPI_GET_RAYTRACING_OPACITY_MICROMAP_ARRAY_PREBUILD_INFO_PARAMS params{};
+            params.version = NVAPI_GET_RAYTRACING_OPACITY_MICROMAP_ARRAY_PREBUILD_INFO_PARAMS_VER1 + 1;
+            REQUIRE(NvAPI_D3D12_GetRaytracingOpacityMicromapArrayPrebuildInfo(static_cast<ID3D12Device5*>(&device), &params) == NVAPI_INCOMPATIBLE_STRUCT_VERSION);
+        }
+        {
+            NVAPI_D3D12_SET_CREATE_PIPELINE_STATE_OPTIONS_PARAMS params{};
+            params.version = NVAPI_D3D12_SET_CREATE_PIPELINE_STATE_OPTIONS_PARAMS_VER1 + 1;
+            REQUIRE(NvAPI_D3D12_SetCreatePipelineStateOptions(static_cast<ID3D12Device5*>(&device), &params) == NVAPI_INCOMPATIBLE_STRUCT_VERSION);
+        }
+        {
+            NVAPI_CHECK_DRIVER_MATCHING_IDENTIFIER_EX_PARAMS params{};
+            params.version = NVAPI_CHECK_DRIVER_MATCHING_IDENTIFIER_EX_PARAMS_VER1 + 1;
+            REQUIRE(NvAPI_D3D12_CheckDriverMatchingIdentifierEx(static_cast<ID3D12Device5*>(&device), &params) == NVAPI_INCOMPATIBLE_STRUCT_VERSION);
+        }
+        {
+            NVAPI_BUILD_RAYTRACING_OPACITY_MICROMAP_ARRAY_PARAMS params{};
+            params.version = NVAPI_BUILD_RAYTRACING_OPACITY_MICROMAP_ARRAY_PARAMS_VER1 + 1;
+            REQUIRE(NvAPI_D3D12_BuildRaytracingOpacityMicromapArray(static_cast<ID3D12GraphicsCommandList4*>(&commandList), &params) == NVAPI_INCOMPATIBLE_STRUCT_VERSION);
+        }
+        {
+            NVAPI_RELOCATE_RAYTRACING_OPACITY_MICROMAP_ARRAY_PARAMS params{};
+            params.version = NVAPI_RELOCATE_RAYTRACING_OPACITY_MICROMAP_ARRAY_PARAMS_VER1 + 1;
+            REQUIRE(NvAPI_D3D12_RelocateRaytracingOpacityMicromapArray(static_cast<ID3D12GraphicsCommandList4*>(&commandList), &params) == NVAPI_INCOMPATIBLE_STRUCT_VERSION);
+        }
+        {
+            NVAPI_EMIT_RAYTRACING_OPACITY_MICROMAP_ARRAY_POSTBUILD_INFO_PARAMS params{};
+            params.version = NVAPI_EMIT_RAYTRACING_OPACITY_MICROMAP_ARRAY_POSTBUILD_INFO_PARAMS_VER1 + 1;
+            REQUIRE(NvAPI_D3D12_EmitRaytracingOpacityMicromapArrayPostbuildInfo(static_cast<ID3D12GraphicsCommandList4*>(&commandList), &params) == NVAPI_INCOMPATIBLE_STRUCT_VERSION);
+        }
+    }
+
+    SECTION("OMM entry points with current struct version do not return incompatible-struct-version") {
+        {
+            NVAPI_GET_RAYTRACING_OPACITY_MICROMAP_ARRAY_PREBUILD_INFO_PARAMS params{};
+            params.version = NVAPI_GET_RAYTRACING_OPACITY_MICROMAP_ARRAY_PREBUILD_INFO_PARAMS_VER;
+            REQUIRE(NvAPI_D3D12_GetRaytracingOpacityMicromapArrayPrebuildInfo(static_cast<ID3D12Device5*>(&device), &params) != NVAPI_INCOMPATIBLE_STRUCT_VERSION);
+        }
+        {
+            NVAPI_D3D12_SET_CREATE_PIPELINE_STATE_OPTIONS_PARAMS params{};
+            params.version = NVAPI_D3D12_SET_CREATE_PIPELINE_STATE_OPTIONS_PARAMS_VER;
+            REQUIRE(NvAPI_D3D12_SetCreatePipelineStateOptions(static_cast<ID3D12Device5*>(&device), &params) != NVAPI_INCOMPATIBLE_STRUCT_VERSION);
+        }
+        {
+            NVAPI_CHECK_DRIVER_MATCHING_IDENTIFIER_EX_PARAMS params{};
+            params.version = NVAPI_CHECK_DRIVER_MATCHING_IDENTIFIER_EX_PARAMS_VER;
+            REQUIRE(NvAPI_D3D12_CheckDriverMatchingIdentifierEx(static_cast<ID3D12Device5*>(&device), &params) != NVAPI_INCOMPATIBLE_STRUCT_VERSION);
+        }
+        {
+            NVAPI_BUILD_RAYTRACING_OPACITY_MICROMAP_ARRAY_PARAMS params{};
+            params.version = NVAPI_BUILD_RAYTRACING_OPACITY_MICROMAP_ARRAY_PARAMS_VER;
+            REQUIRE(NvAPI_D3D12_BuildRaytracingOpacityMicromapArray(static_cast<ID3D12GraphicsCommandList4*>(&commandList), &params) != NVAPI_INCOMPATIBLE_STRUCT_VERSION);
+        }
+        {
+            NVAPI_RELOCATE_RAYTRACING_OPACITY_MICROMAP_ARRAY_PARAMS params{};
+            params.version = NVAPI_RELOCATE_RAYTRACING_OPACITY_MICROMAP_ARRAY_PARAMS_VER;
+            REQUIRE(NvAPI_D3D12_RelocateRaytracingOpacityMicromapArray(static_cast<ID3D12GraphicsCommandList4*>(&commandList), &params) != NVAPI_INCOMPATIBLE_STRUCT_VERSION);
+        }
+        {
+            NVAPI_EMIT_RAYTRACING_OPACITY_MICROMAP_ARRAY_POSTBUILD_INFO_PARAMS params{};
+            params.version = NVAPI_EMIT_RAYTRACING_OPACITY_MICROMAP_ARRAY_POSTBUILD_INFO_PARAMS_VER;
+            REQUIRE(NvAPI_D3D12_EmitRaytracingOpacityMicromapArrayPostbuildInfo(static_cast<ID3D12GraphicsCommandList4*>(&commandList), &params) != NVAPI_INCOMPATIBLE_STRUCT_VERSION);
+        }
+    }
+
+    SECTION("OMM entry points with null arguments return invalid-argument") {
+        {
+            NVAPI_GET_RAYTRACING_OPACITY_MICROMAP_ARRAY_PREBUILD_INFO_PARAMS params{};
+            params.version = NVAPI_GET_RAYTRACING_OPACITY_MICROMAP_ARRAY_PREBUILD_INFO_PARAMS_VER1;
+            REQUIRE(NvAPI_D3D12_GetRaytracingOpacityMicromapArrayPrebuildInfo(nullptr, &params) == NVAPI_INVALID_ARGUMENT);
+            REQUIRE(NvAPI_D3D12_GetRaytracingOpacityMicromapArrayPrebuildInfo(static_cast<ID3D12Device5*>(&device), nullptr) == NVAPI_INVALID_ARGUMENT);
+        }
+        {
+            NVAPI_D3D12_SET_CREATE_PIPELINE_STATE_OPTIONS_PARAMS params{};
+            params.version = NVAPI_D3D12_SET_CREATE_PIPELINE_STATE_OPTIONS_PARAMS_VER1;
+            REQUIRE(NvAPI_D3D12_SetCreatePipelineStateOptions(nullptr, &params) == NVAPI_INVALID_ARGUMENT);
+            REQUIRE(NvAPI_D3D12_SetCreatePipelineStateOptions(static_cast<ID3D12Device5*>(&device), nullptr) == NVAPI_INVALID_ARGUMENT);
+        }
+        {
+            NVAPI_CHECK_DRIVER_MATCHING_IDENTIFIER_EX_PARAMS params{};
+            params.version = NVAPI_CHECK_DRIVER_MATCHING_IDENTIFIER_EX_PARAMS_VER1;
+            REQUIRE(NvAPI_D3D12_CheckDriverMatchingIdentifierEx(nullptr, &params) == NVAPI_INVALID_ARGUMENT);
+            REQUIRE(NvAPI_D3D12_CheckDriverMatchingIdentifierEx(static_cast<ID3D12Device5*>(&device), nullptr) == NVAPI_INVALID_ARGUMENT);
+        }
+        {
+            NVAPI_BUILD_RAYTRACING_OPACITY_MICROMAP_ARRAY_PARAMS params{};
+            params.version = NVAPI_BUILD_RAYTRACING_OPACITY_MICROMAP_ARRAY_PARAMS_VER1;
+            REQUIRE(NvAPI_D3D12_BuildRaytracingOpacityMicromapArray(nullptr, &params) == NVAPI_INVALID_ARGUMENT);
+            REQUIRE(NvAPI_D3D12_BuildRaytracingOpacityMicromapArray(static_cast<ID3D12GraphicsCommandList4*>(&commandList), nullptr) == NVAPI_INVALID_ARGUMENT);
+        }
+        {
+            NVAPI_RELOCATE_RAYTRACING_OPACITY_MICROMAP_ARRAY_PARAMS params{};
+            params.version = NVAPI_RELOCATE_RAYTRACING_OPACITY_MICROMAP_ARRAY_PARAMS_VER1;
+            REQUIRE(NvAPI_D3D12_RelocateRaytracingOpacityMicromapArray(nullptr, &params) == NVAPI_INVALID_ARGUMENT);
+            REQUIRE(NvAPI_D3D12_RelocateRaytracingOpacityMicromapArray(static_cast<ID3D12GraphicsCommandList4*>(&commandList), nullptr) == NVAPI_INVALID_ARGUMENT);
+        }
+        {
+            NVAPI_EMIT_RAYTRACING_OPACITY_MICROMAP_ARRAY_POSTBUILD_INFO_PARAMS params{};
+            params.version = NVAPI_EMIT_RAYTRACING_OPACITY_MICROMAP_ARRAY_POSTBUILD_INFO_PARAMS_VER1;
+            REQUIRE(NvAPI_D3D12_EmitRaytracingOpacityMicromapArrayPostbuildInfo(nullptr, &params) == NVAPI_INVALID_ARGUMENT);
+            REQUIRE(NvAPI_D3D12_EmitRaytracingOpacityMicromapArrayPostbuildInfo(static_cast<ID3D12GraphicsCommandList4*>(&commandList), nullptr) == NVAPI_INVALID_ARGUMENT);
+        }
+    }
+
+    SECTION("SetCreatePipelineStateOptions without the OMM support flag returns OK") {
+        ALLOW_CALL(device, GetExtensionSupport(D3D12_VK_OPACITY_MICROMAP))
+            .RETURN(true);
+
+        NVAPI_D3D12_SET_CREATE_PIPELINE_STATE_OPTIONS_PARAMS params{};
+        params.version = NVAPI_D3D12_SET_CREATE_PIPELINE_STATE_OPTIONS_PARAMS_VER1;
+        params.flags = NVAPI_D3D12_PIPELINE_CREATION_STATE_FLAGS_NONE;
+
+        REQUIRE_CALL(device, SetCreatePipelineStateFlagsNVAPI(D3D12_VK_EXT_PIPELINE_CREATION_STATE_FLAGS_NONE))
+            .RETURN(true)
+            .TIMES(1);
+
+        REQUIRE(NvAPI_D3D12_SetCreatePipelineStateOptions(static_cast<ID3D12Device5*>(&device), &params) == NVAPI_OK);
+        REQUIRE(deviceRefCount == 0);
+    }
+
     SECTION("D3DLowLatencyDevice methods succeed") {
         auto t = std::make_unique<DefaultTestEnvironment>();
         auto e = t->ConfigureExpectations();

--- a/tests/nvapi_d3d12.cpp
+++ b/tests/nvapi_d3d12.cpp
@@ -1279,6 +1279,62 @@ TEST_CASE("D3D12 methods succeed", "[.d3d12]") {
         }
     }
 
+    SECTION("GetRaytracingAccelerationStructurePrebuildInfoEx rejects a geometry desc stride that is too small") {
+        FORBID_CALL(device, GetRaytracingAccelerationStructurePrebuildInfo(_, _));
+
+        NVAPI_D3D12_RAYTRACING_GEOMETRY_DESC_EX geometryDescEx{};
+        NVAPI_D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS_EX desc{};
+        D3D12_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO info{};
+        NVAPI_GET_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO_EX_PARAMS params{};
+        params.version = NVAPI_GET_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO_EX_PARAMS_VER1;
+        params.pDesc = &desc;
+        params.pInfo = &info;
+        desc.type = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL;
+        desc.descsLayout = D3D12_ELEMENTS_LAYOUT_ARRAY;
+        desc.numDescs = 1;
+        desc.pGeometryDescs = &geometryDescEx;
+        desc.geometryDescStrideInBytes = 1;
+
+        SECTION("GetRaytracingAccelerationStructurePrebuildInfoEx for triangles geometry") {
+            geometryDescEx.type = NVAPI_D3D12_RAYTRACING_GEOMETRY_TYPE_TRIANGLES_EX;
+
+            REQUIRE(NvAPI_D3D12_GetRaytracingAccelerationStructurePrebuildInfoEx(static_cast<ID3D12Device5*>(&device), &params) == NVAPI_INVALID_ARGUMENT);
+        }
+
+        SECTION("GetRaytracingAccelerationStructurePrebuildInfoEx for AABBs geometry") {
+            geometryDescEx.type = NVAPI_D3D12_RAYTRACING_GEOMETRY_TYPE_PROCEDURAL_PRIMITIVE_AABBS_EX;
+
+            REQUIRE(NvAPI_D3D12_GetRaytracingAccelerationStructurePrebuildInfoEx(static_cast<ID3D12Device5*>(&device), &params) == NVAPI_INVALID_ARGUMENT);
+        }
+
+        SECTION("GetRaytracingAccelerationStructurePrebuildInfoEx for OMM triangles geometry") {
+            ALLOW_CALL(device, GetExtensionSupport(D3D12_VK_OPACITY_MICROMAP))
+                .RETURN(true);
+            geometryDescEx.type = NVAPI_D3D12_RAYTRACING_GEOMETRY_TYPE_OMM_TRIANGLES_EX;
+
+            REQUIRE(NvAPI_D3D12_GetRaytracingAccelerationStructurePrebuildInfoEx(static_cast<ID3D12Device5*>(&device), &params) == NVAPI_INVALID_ARGUMENT);
+        }
+    }
+
+    SECTION("GetRaytracingAccelerationStructurePrebuildInfoEx with an empty BLAS returns OK") {
+        NVAPI_D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS_EX desc{};
+        D3D12_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO info{};
+        NVAPI_GET_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO_EX_PARAMS params{};
+        params.version = NVAPI_GET_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO_EX_PARAMS_VER1;
+        params.pDesc = &desc;
+        params.pInfo = &info;
+        desc.type = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL;
+        desc.descsLayout = D3D12_ELEMENTS_LAYOUT_ARRAY;
+        desc.numDescs = 0;
+
+        D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS d3d12Desc{};
+        ALLOW_CALL(device, GetRaytracingAccelerationStructurePrebuildInfo(_, &info))
+            .LR_SIDE_EFFECT(d3d12Desc = *_1);
+
+        REQUIRE(NvAPI_D3D12_GetRaytracingAccelerationStructurePrebuildInfoEx(static_cast<ID3D12Device5*>(&device), &params) == NVAPI_OK);
+        REQUIRE(d3d12Desc.NumDescs == 0);
+    }
+
     SECTION("BuildRaytracingAccelerationStructureEx succeeds") {
         SECTION("BuildRaytracingAccelerationStructureEx returns OK") {
             NVAPI_D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC_EX desc{};

--- a/tests/nvapi_d3d12.cpp
+++ b/tests/nvapi_d3d12.cpp
@@ -803,10 +803,37 @@ TEST_CASE("D3D12 methods succeed", "[.d3d12]") {
             }
         }
 
-        SECTION("GetRaytracingCaps returns OK and claims that Opacity Micromap is not supported") {
+        SECTION("GetRaytracingCaps returns OK and claims that Opacity Micromap is supported") {
+            ALLOW_CALL(device, GetExtensionSupport(D3D12_VK_OPACITY_MICROMAP))
+                .RETURN(true);
+
             REQUIRE(NvAPI_Initialize() == NVAPI_OK);
 
-            NVAPI_D3D12_RAYTRACING_OPACITY_MICROMAP_CAPS caps;
+            NVAPI_D3D12_RAYTRACING_OPACITY_MICROMAP_CAPS caps = NVAPI_D3D12_RAYTRACING_OPACITY_MICROMAP_CAP_NONE;
+            REQUIRE(NvAPI_D3D12_GetRaytracingCaps(static_cast<ID3D12Device*>(&device), NVAPI_D3D12_RAYTRACING_CAPS_TYPE_OPACITY_MICROMAP, &caps, sizeof(caps)) == NVAPI_OK);
+            REQUIRE(caps == NVAPI_D3D12_RAYTRACING_OPACITY_MICROMAP_CAP_STANDARD);
+        }
+
+        SECTION("GetRaytracingCaps returns OK and claims that Opacity Micromap is not supported without the OMM extension") {
+            ALLOW_CALL(device, GetExtensionSupport(D3D12_VK_OPACITY_MICROMAP))
+                .RETURN(false);
+
+            REQUIRE(NvAPI_Initialize() == NVAPI_OK);
+
+            NVAPI_D3D12_RAYTRACING_OPACITY_MICROMAP_CAPS caps = NVAPI_D3D12_RAYTRACING_OPACITY_MICROMAP_CAP_STANDARD;
+            REQUIRE(NvAPI_D3D12_GetRaytracingCaps(static_cast<ID3D12Device*>(&device), NVAPI_D3D12_RAYTRACING_CAPS_TYPE_OPACITY_MICROMAP, &caps, sizeof(caps)) == NVAPI_OK);
+            REQUIRE(caps == NVAPI_D3D12_RAYTRACING_OPACITY_MICROMAP_CAP_NONE);
+        }
+
+        SECTION("GetRaytracingCaps returns OK and claims that Opacity Micromap is not supported below ID3D12DeviceExt5") {
+            ALLOW_CALL(device, GetExtensionSupport(D3D12_VK_OPACITY_MICROMAP))
+                .RETURN(true);
+            ALLOW_CALL(device, QueryInterface(__uuidof(ID3D12DeviceExt5), _))
+                .RETURN(E_NOINTERFACE);
+
+            REQUIRE(NvAPI_Initialize() == NVAPI_OK);
+
+            NVAPI_D3D12_RAYTRACING_OPACITY_MICROMAP_CAPS caps = NVAPI_D3D12_RAYTRACING_OPACITY_MICROMAP_CAP_STANDARD;
             REQUIRE(NvAPI_D3D12_GetRaytracingCaps(static_cast<ID3D12Device*>(&device), NVAPI_D3D12_RAYTRACING_CAPS_TYPE_OPACITY_MICROMAP, &caps, sizeof(caps)) == NVAPI_OK);
             REQUIRE(caps == NVAPI_D3D12_RAYTRACING_OPACITY_MICROMAP_CAP_NONE);
         }

--- a/tests/nvapi_d3d12.cpp
+++ b/tests/nvapi_d3d12.cpp
@@ -885,6 +885,17 @@ TEST_CASE("D3D12 methods succeed", "[.d3d12]") {
             REQUIRE(caps == NVAPI_D3D12_RAYTRACING_OPACITY_MICROMAP_CAP_NONE);
         }
 
+        SECTION("GetRaytracingCaps returns OK and claims that Opacity Micromap is not supported without the NVAPI device extension") {
+            ALLOW_CALL(device, QueryInterface(__uuidof(ID3D12DeviceExt), _))
+                .RETURN(E_NOINTERFACE);
+
+            REQUIRE(NvAPI_Initialize() == NVAPI_OK);
+
+            NVAPI_D3D12_RAYTRACING_OPACITY_MICROMAP_CAPS caps = NVAPI_D3D12_RAYTRACING_OPACITY_MICROMAP_CAP_STANDARD;
+            REQUIRE(NvAPI_D3D12_GetRaytracingCaps(static_cast<ID3D12Device*>(&device), NVAPI_D3D12_RAYTRACING_CAPS_TYPE_OPACITY_MICROMAP, &caps, sizeof(caps)) == NVAPI_OK);
+            REQUIRE(caps == NVAPI_D3D12_RAYTRACING_OPACITY_MICROMAP_CAP_NONE);
+        }
+
         SECTION("GetRaytracingCaps returns OK and claims that Displacement Micromap is not supported") {
             REQUIRE(NvAPI_Initialize() == NVAPI_OK);
 

--- a/tests/nvapi_d3d12.cpp
+++ b/tests/nvapi_d3d12.cpp
@@ -42,8 +42,16 @@ TEST_CASE("D3D12 methods succeed", "[.d3d12]") {
         .LR_SIDE_EFFECT(*_2 = static_cast<ID3D12DeviceExt2*>(&device))
         .LR_SIDE_EFFECT(deviceRefCount++)
         .RETURN(S_OK);
+    ALLOW_CALL(device, QueryInterface(__uuidof(ID3D12DeviceExt3), _))
+        .LR_SIDE_EFFECT(*_2 = static_cast<ID3D12DeviceExt3*>(&device))
+        .LR_SIDE_EFFECT(deviceRefCount++)
+        .RETURN(S_OK);
     ALLOW_CALL(device, QueryInterface(__uuidof(ID3D12DeviceExt4), _))
         .LR_SIDE_EFFECT(*_2 = static_cast<ID3D12DeviceExt4*>(&device))
+        .LR_SIDE_EFFECT(deviceRefCount++)
+        .RETURN(S_OK);
+    ALLOW_CALL(device, QueryInterface(__uuidof(ID3D12DeviceExt5), _))
+        .LR_SIDE_EFFECT(*_2 = static_cast<ID3D12DeviceExt5*>(&device))
         .LR_SIDE_EFFECT(deviceRefCount++)
         .RETURN(S_OK);
     ALLOW_CALL(device, AddRef())
@@ -53,14 +61,25 @@ TEST_CASE("D3D12 methods succeed", "[.d3d12]") {
         .LR_SIDE_EFFECT(deviceRefCount--)
         .RETURN(deviceRefCount);
 
+    ALLOW_CALL(device, QueryInterface(__uuidof(IUnknown), _))
+        .LR_SIDE_EFFECT(*_2 = static_cast<IUnknown*>(static_cast<ID3D12Device*>(&device)))
+        .LR_SIDE_EFFECT(deviceRefCount++)
+        .RETURN(S_OK);
+
     ALLOW_CALL(device, QueryInterface(__uuidof(ID3DLowLatencyDevice), _))
         .RETURN(E_NOINTERFACE);
 
     ALLOW_CALL(device, GetExtensionSupport(_))
         .RETURN(true);
+    ALLOW_CALL(device, GetExtensionSupport(D3D12_VK_OPACITY_MICROMAP))
+        .RETURN(false);
     ALLOW_CALL(device, SupportsCubin64bit())
         .RETURN(true);
 
+    ALLOW_CALL(commandList, QueryInterface(__uuidof(ID3D12GraphicsCommandList), _))
+        .LR_SIDE_EFFECT(*_2 = static_cast<ID3D12GraphicsCommandList*>(&commandList))
+        .LR_SIDE_EFFECT(commandListRefCount++)
+        .RETURN(S_OK);
     ALLOW_CALL(commandList, QueryInterface(__uuidof(ID3D12GraphicsCommandList1), _))
         .LR_SIDE_EFFECT(*_2 = static_cast<ID3D12GraphicsCommandList1*>(&commandList))
         .LR_SIDE_EFFECT(commandListRefCount++)
@@ -73,12 +92,24 @@ TEST_CASE("D3D12 methods succeed", "[.d3d12]") {
         .LR_SIDE_EFFECT(*_2 = static_cast<ID3D12GraphicsCommandListExt*>(&commandList))
         .LR_SIDE_EFFECT(commandListRefCount++)
         .RETURN(S_OK);
+    ALLOW_CALL(commandList, QueryInterface(__uuidof(ID3D12GraphicsCommandListExt2), _))
+        .LR_SIDE_EFFECT(*_2 = static_cast<ID3D12GraphicsCommandListExt2*>(&commandList))
+        .LR_SIDE_EFFECT(commandListRefCount++)
+        .RETURN(S_OK);
+    ALLOW_CALL(commandList, QueryInterface(__uuidof(IUnknown), _))
+        .LR_SIDE_EFFECT(*_2 = static_cast<IUnknown*>(static_cast<ID3D12GraphicsCommandList1*>(&commandList)))
+        .LR_SIDE_EFFECT(commandListRefCount++)
+        .RETURN(S_OK);
     ALLOW_CALL(commandList, AddRef())
         .LR_SIDE_EFFECT(commandListRefCount++)
         .RETURN(commandListRefCount);
     ALLOW_CALL(commandList, Release())
         .LR_SIDE_EFFECT(commandListRefCount--)
         .RETURN(commandListRefCount);
+    ALLOW_CALL(commandList, GetDevice(__uuidof(ID3D12Device), _))
+        .LR_SIDE_EFFECT(*_2 = static_cast<ID3D12Device*>(&device))
+        .LR_SIDE_EFFECT(deviceRefCount++)
+        .RETURN(S_OK);
 
     ALLOW_CALL(commandQueue, QueryInterface(__uuidof(ID3D12CommandQueue), _))
         .LR_SIDE_EFFECT(*_2 = static_cast<ID3D12CommandQueue*>(&commandQueue))
@@ -187,6 +218,8 @@ TEST_CASE("D3D12 methods succeed", "[.d3d12]") {
         // DXVK_NVAPI_D3D12_NV_SHADER_EXTN = 1 is set in section starting listener
 
         SECTION("IsNvShaderExtnOpCodeSupported without VKD3D-Proton support") {
+            ALLOW_CALL(device, QueryInterface(__uuidof(ID3D12DeviceExt5), _))
+                .RETURN(E_NOTIMPL);
             ALLOW_CALL(device, QueryInterface(__uuidof(ID3D12DeviceExt4), _))
                 .RETURN(E_NOTIMPL);
 
@@ -231,6 +264,8 @@ TEST_CASE("D3D12 methods succeed", "[.d3d12]") {
         }
 
         SECTION("SetNvShaderExtnSlotSpace without VKD3D-Proton support returns no-implementation") {
+            ALLOW_CALL(device, QueryInterface(__uuidof(ID3D12DeviceExt5), _))
+                .RETURN(E_NOTIMPL);
             ALLOW_CALL(device, QueryInterface(__uuidof(ID3D12DeviceExt4), _))
                 .RETURN(E_NOTIMPL);
 
@@ -248,6 +283,8 @@ TEST_CASE("D3D12 methods succeed", "[.d3d12]") {
         }
 
         SECTION("SetNvShaderExtnSlotSpaceLocalThread without VKD3D-Proton support returns no-implementation") {
+            ALLOW_CALL(device, QueryInterface(__uuidof(ID3D12DeviceExt5), _))
+                .RETURN(E_NOTIMPL);
             ALLOW_CALL(device, QueryInterface(__uuidof(ID3D12DeviceExt4), _))
                 .RETURN(E_NOTIMPL);
 
@@ -547,6 +584,8 @@ TEST_CASE("D3D12 methods succeed", "[.d3d12]") {
     }
 
     SECTION("Launch CuBIN without ID3D12GraphicsCommandListExt1 returns OK") {
+        ALLOW_CALL(commandList, QueryInterface(__uuidof(ID3D12GraphicsCommandListExt2), _))
+            .RETURN(E_NOINTERFACE);
         ALLOW_CALL(commandList, QueryInterface(__uuidof(ID3D12GraphicsCommandListExt1), _))
             .RETURN(E_NOINTERFACE);
 
@@ -751,6 +790,8 @@ TEST_CASE("D3D12 methods succeed", "[.d3d12]") {
             }
 
             SECTION("GetRaytracingCaps without VKD3D-Proton support returns OK and claims that thread reordering is not supported") {
+                ALLOW_CALL(device, QueryInterface(__uuidof(ID3D12DeviceExt5), _))
+                    .RETURN(E_NOTIMPL);
                 ALLOW_CALL(device, QueryInterface(__uuidof(ID3D12DeviceExt4), _))
                     .RETURN(E_NOTIMPL);
 
@@ -841,13 +882,25 @@ TEST_CASE("D3D12 methods succeed", "[.d3d12]") {
             }
 
             SECTION("GetRaytracingAccelerationStructurePrebuildInfoEx with BLAS for pointer array") {
-                NVAPI_D3D12_RAYTRACING_GEOMETRY_DESC_EX** geometryDescExArray = nullptr;
+                NVAPI_D3D12_RAYTRACING_GEOMETRY_DESC_EX geometryDescEx[2];
+                geometryDescEx[0].type = NVAPI_D3D12_RAYTRACING_GEOMETRY_TYPE_TRIANGLES_EX;
+                geometryDescEx[0].triangles.IndexBuffer = 3;
+                geometryDescEx[1].type = NVAPI_D3D12_RAYTRACING_GEOMETRY_TYPE_TRIANGLES_EX;
+                geometryDescEx[1].triangles.IndexBuffer = 4;
+                NVAPI_D3D12_RAYTRACING_GEOMETRY_DESC_EX* geometryDescExArray[] = {&geometryDescEx[0], &geometryDescEx[1]};
+
                 desc.type = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL;
                 desc.descsLayout = D3D12_ELEMENTS_LAYOUT_ARRAY_OF_POINTERS;
+                desc.numDescs = 2;
                 desc.ppGeometryDescs = geometryDescExArray;
 
                 REQUIRE(NvAPI_D3D12_GetRaytracingAccelerationStructurePrebuildInfoEx(static_cast<ID3D12Device5*>(&device), &params) == NVAPI_OK);
-                REQUIRE(d3d12Desc.ppGeometryDescs == reinterpret_cast<const D3D12_RAYTRACING_GEOMETRY_DESC* const*>(desc.ppGeometryDescs));
+
+                REQUIRE(d3d12Desc.NumDescs == desc.numDescs);
+                REQUIRE(geometryDescs[0].Type == D3D12_RAYTRACING_GEOMETRY_TYPE_TRIANGLES);
+                REQUIRE(geometryDescs[0].Triangles.IndexBuffer == geometryDescEx[0].triangles.IndexBuffer);
+                REQUIRE(geometryDescs[1].Type == D3D12_RAYTRACING_GEOMETRY_TYPE_TRIANGLES);
+                REQUIRE(geometryDescs[1].Triangles.IndexBuffer == geometryDescEx[1].triangles.IndexBuffer);
             }
 
             SECTION("GetRaytracingAccelerationStructurePrebuildInfoEx with BLAS for array") {
@@ -974,16 +1027,28 @@ TEST_CASE("D3D12 methods succeed", "[.d3d12]") {
             }
 
             SECTION("BuildRaytracingAccelerationStructureEx with BLAS for pointer array") {
-                NVAPI_D3D12_RAYTRACING_GEOMETRY_DESC_EX** geometryDescExArray = nullptr;
+                NVAPI_D3D12_RAYTRACING_GEOMETRY_DESC_EX geometryDescEx[2];
+                geometryDescEx[0].type = NVAPI_D3D12_RAYTRACING_GEOMETRY_TYPE_TRIANGLES_EX;
+                geometryDescEx[0].triangles.IndexBuffer = 3;
+                geometryDescEx[1].type = NVAPI_D3D12_RAYTRACING_GEOMETRY_TYPE_TRIANGLES_EX;
+                geometryDescEx[1].triangles.IndexBuffer = 4;
+                NVAPI_D3D12_RAYTRACING_GEOMETRY_DESC_EX* geometryDescExArray[] = {&geometryDescEx[0], &geometryDescEx[1]};
+
                 desc.inputs.type = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL;
                 desc.inputs.descsLayout = D3D12_ELEMENTS_LAYOUT_ARRAY_OF_POINTERS;
+                desc.inputs.numDescs = 2;
                 desc.inputs.ppGeometryDescs = geometryDescExArray;
 
                 REQUIRE(NvAPI_D3D12_BuildRaytracingAccelerationStructureEx(static_cast<ID3D12GraphicsCommandList4*>(&commandList), &params) == NVAPI_OK);
                 REQUIRE(d3d12Desc.DestAccelerationStructureData == desc.destAccelerationStructureData);
-                REQUIRE(d3d12Desc.Inputs.ppGeometryDescs == reinterpret_cast<const D3D12_RAYTRACING_GEOMETRY_DESC* const*>(desc.inputs.ppGeometryDescs));
                 REQUIRE(d3d12Desc.SourceAccelerationStructureData == desc.sourceAccelerationStructureData);
                 REQUIRE(d3d12Desc.ScratchAccelerationStructureData == desc.scratchAccelerationStructureData);
+
+                REQUIRE(d3d12Desc.Inputs.NumDescs == desc.inputs.numDescs);
+                REQUIRE(geometryDescs[0].Type == D3D12_RAYTRACING_GEOMETRY_TYPE_TRIANGLES);
+                REQUIRE(geometryDescs[0].Triangles.IndexBuffer == geometryDescEx[0].triangles.IndexBuffer);
+                REQUIRE(geometryDescs[1].Type == D3D12_RAYTRACING_GEOMETRY_TYPE_TRIANGLES);
+                REQUIRE(geometryDescs[1].Triangles.IndexBuffer == geometryDescEx[1].triangles.IndexBuffer);
             }
 
             SECTION("BuildRaytracingAccelerationStructureEx with BLAS for array") {

--- a/tests/nvapi_d3d12.cpp
+++ b/tests/nvapi_d3d12.cpp
@@ -1183,6 +1183,148 @@ TEST_CASE("D3D12 methods succeed", "[.d3d12]") {
         }
     }
 
+    SECTION("GetRaytracingOpacityMicromapArrayPrebuildInfo returns OK") {
+        ALLOW_CALL(device, GetExtensionSupport(D3D12_VK_OPACITY_MICROMAP))
+            .RETURN(true);
+
+        NVAPI_D3D12_BUILD_RAYTRACING_OPACITY_MICROMAP_ARRAY_INPUTS inputs{};
+        NVAPI_D3D12_RAYTRACING_OPACITY_MICROMAP_ARRAY_PREBUILD_INFO info{};
+        NVAPI_GET_RAYTRACING_OPACITY_MICROMAP_ARRAY_PREBUILD_INFO_PARAMS params{};
+        params.version = NVAPI_GET_RAYTRACING_OPACITY_MICROMAP_ARRAY_PREBUILD_INFO_PARAMS_VER1;
+        params.pDesc = &inputs;
+        params.pInfo = &info;
+
+        REQUIRE_CALL(device, GetRaytracingAccelerationStructurePrebuildInfo(_, _))
+            .LR_SIDE_EFFECT({
+                _2->ResultDataMaxSizeInBytes = 123;
+                _2->ScratchDataSizeInBytes = 456;
+            })
+            .TIMES(1);
+
+        REQUIRE(NvAPI_D3D12_GetRaytracingOpacityMicromapArrayPrebuildInfo(static_cast<ID3D12Device5*>(&device), &params) == NVAPI_OK);
+        REQUIRE(info.resultDataMaxSizeInBytes == 123);
+        REQUIRE(info.scratchDataSizeInBytes == 456);
+        REQUIRE(deviceRefCount == 0);
+        REQUIRE(commandListRefCount == 0);
+    }
+
+    SECTION("SetCreatePipelineStateOptions succeeds") {
+        ALLOW_CALL(device, GetExtensionSupport(D3D12_VK_OPACITY_MICROMAP))
+            .RETURN(true);
+
+        NVAPI_D3D12_SET_CREATE_PIPELINE_STATE_OPTIONS_PARAMS params{};
+        params.version = NVAPI_D3D12_SET_CREATE_PIPELINE_STATE_OPTIONS_PARAMS_VER1;
+        params.flags = NVAPI_D3D12_PIPELINE_CREATION_STATE_FLAGS_ENABLE_OMM_SUPPORT;
+
+        SECTION("SetCreatePipelineStateOptions returns OK when the override is accepted") {
+            REQUIRE_CALL(device, SetCreatePipelineStateFlagsNVAPI(D3D12_VK_EXT_PIPELINE_CREATION_STATE_FLAGS_ENABLE_OMM_SUPPORT))
+                .RETURN(true)
+                .TIMES(1);
+
+            REQUIRE(NvAPI_D3D12_SetCreatePipelineStateOptions(static_cast<ID3D12Device5*>(&device), &params) == NVAPI_OK);
+            REQUIRE(deviceRefCount == 0);
+        }
+
+        SECTION("SetCreatePipelineStateOptions returns not-supported when the override is rejected") {
+            REQUIRE_CALL(device, SetCreatePipelineStateFlagsNVAPI(D3D12_VK_EXT_PIPELINE_CREATION_STATE_FLAGS_ENABLE_OMM_SUPPORT))
+                .RETURN(false)
+                .TIMES(1);
+
+            REQUIRE(NvAPI_D3D12_SetCreatePipelineStateOptions(static_cast<ID3D12Device5*>(&device), &params) == NVAPI_NOT_SUPPORTED);
+            REQUIRE(deviceRefCount == 0);
+        }
+    }
+
+    SECTION("CheckDriverMatchingIdentifierEx returns OK") {
+        D3D12_SERIALIZED_DATA_DRIVER_MATCHING_IDENTIFIER identifier{};
+        NVAPI_CHECK_DRIVER_MATCHING_IDENTIFIER_EX_PARAMS params{};
+        params.version = NVAPI_CHECK_DRIVER_MATCHING_IDENTIFIER_EX_PARAMS_VER1;
+        params.pIdentifierToCheck = &identifier;
+
+        REQUIRE_CALL(device, CheckDriverMatchingIdentifier(D3D12_SERIALIZED_DATA_RAYTRACING_ACCELERATION_STRUCTURE, &identifier))
+            .RETURN(D3D12_DRIVER_MATCHING_IDENTIFIER_UNRECOGNIZED);
+
+        SECTION("CheckDriverMatchingIdentifierEx forwards an OMM Array as BLAS") {
+            params.serializedDataType = NVAPI_D3D12_SERIALIZED_DATA_RAYTRACING_OPACITY_MICROMAP_ARRAY_EX;
+
+            REQUIRE(NvAPI_D3D12_CheckDriverMatchingIdentifierEx(static_cast<ID3D12Device5*>(&device), &params) == NVAPI_OK);
+            REQUIRE(params.checkStatus == D3D12_DRIVER_MATCHING_IDENTIFIER_UNRECOGNIZED);
+            REQUIRE(deviceRefCount == 0);
+        }
+
+        SECTION("CheckDriverMatchingIdentifierEx forwards an acceleration structure") {
+            params.serializedDataType = NVAPI_D3D12_SERIALIZED_DATA_RAYTRACING_ACCELERATION_STRUCTURE_EX;
+
+            REQUIRE(NvAPI_D3D12_CheckDriverMatchingIdentifierEx(static_cast<ID3D12Device5*>(&device), &params) == NVAPI_OK);
+            REQUIRE(params.checkStatus == D3D12_DRIVER_MATCHING_IDENTIFIER_UNRECOGNIZED);
+            REQUIRE(deviceRefCount == 0);
+        }
+    }
+
+    SECTION("BuildRaytracingOpacityMicromapArray returns OK") {
+        ALLOW_CALL(device, GetExtensionSupport(D3D12_VK_OPACITY_MICROMAP))
+            .RETURN(true);
+
+        NVAPI_D3D12_BUILD_RAYTRACING_OPACITY_MICROMAP_ARRAY_DESC ommArrayDesc{};
+        NVAPI_BUILD_RAYTRACING_OPACITY_MICROMAP_ARRAY_PARAMS params{};
+        params.version = NVAPI_BUILD_RAYTRACING_OPACITY_MICROMAP_ARRAY_PARAMS_VER1;
+        params.pDesc = &ommArrayDesc;
+
+        REQUIRE_CALL(commandList, BuildRaytracingAccelerationStructure(_, 0U, _))
+            .TIMES(1);
+
+        REQUIRE(NvAPI_D3D12_BuildRaytracingOpacityMicromapArray(static_cast<ID3D12GraphicsCommandList4*>(&commandList), &params) == NVAPI_OK);
+        REQUIRE(deviceRefCount == 0);
+        REQUIRE(commandListRefCount == 0);
+    }
+
+    SECTION("RelocateRaytracingOpacityMicromapArray succeeds") {
+        ALLOW_CALL(device, GetExtensionSupport(D3D12_VK_OPACITY_MICROMAP))
+            .RETURN(true);
+
+        NVAPI_RELOCATE_RAYTRACING_OPACITY_MICROMAP_ARRAY_PARAMS params{};
+        params.version = NVAPI_RELOCATE_RAYTRACING_OPACITY_MICROMAP_ARRAY_PARAMS_VER1;
+        params.opacityMicromapArray = D3D12_GPU_VIRTUAL_ADDRESS{};
+
+        SECTION("RelocateRaytracingOpacityMicromapArray returns OK when verification succeeds") {
+            REQUIRE_CALL(commandList, VerifyOpacityMicromapArrayNVAPI(params.opacityMicromapArray))
+                .RETURN(true)
+                .TIMES(1);
+
+            REQUIRE(NvAPI_D3D12_RelocateRaytracingOpacityMicromapArray(static_cast<ID3D12GraphicsCommandList4*>(&commandList), &params) == NVAPI_OK);
+            REQUIRE(deviceRefCount == 0);
+            REQUIRE(commandListRefCount == 0);
+        }
+
+        SECTION("RelocateRaytracingOpacityMicromapArray returns error when verification fails") {
+            REQUIRE_CALL(commandList, VerifyOpacityMicromapArrayNVAPI(params.opacityMicromapArray))
+                .RETURN(false)
+                .TIMES(1);
+
+            REQUIRE(NvAPI_D3D12_RelocateRaytracingOpacityMicromapArray(static_cast<ID3D12GraphicsCommandList4*>(&commandList), &params) == NVAPI_ERROR);
+            REQUIRE(deviceRefCount == 0);
+            REQUIRE(commandListRefCount == 0);
+        }
+    }
+
+    SECTION("EmitRaytracingOpacityMicromapArrayPostbuildInfo returns OK") {
+        ALLOW_CALL(device, GetExtensionSupport(D3D12_VK_OPACITY_MICROMAP))
+            .RETURN(true);
+
+        NVAPI_D3D12_RAYTRACING_OPACITY_MICROMAP_ARRAY_POSTBUILD_INFO_DESC postbuildDesc{};
+        postbuildDesc.infoType = NVAPI_D3D12_RAYTRACING_OPACITY_MICROMAP_ARRAY_POSTBUILD_INFO_CURRENT_SIZE;
+        NVAPI_EMIT_RAYTRACING_OPACITY_MICROMAP_ARRAY_POSTBUILD_INFO_PARAMS params{};
+        params.version = NVAPI_EMIT_RAYTRACING_OPACITY_MICROMAP_ARRAY_POSTBUILD_INFO_PARAMS_VER1;
+        params.pDesc = &postbuildDesc;
+
+        REQUIRE_CALL(commandList, EmitRaytracingAccelerationStructurePostbuildInfo(_, 0U, _))
+            .TIMES(1);
+
+        REQUIRE(NvAPI_D3D12_EmitRaytracingOpacityMicromapArrayPostbuildInfo(static_cast<ID3D12GraphicsCommandList4*>(&commandList), &params) == NVAPI_OK);
+        REQUIRE(deviceRefCount == 0);
+        REQUIRE(commandListRefCount == 0);
+    }
+
     SECTION("D3DLowLatencyDevice methods succeed") {
         auto t = std::make_unique<DefaultTestEnvironment>();
         auto e = t->ConfigureExpectations();


### PR DESCRIPTION
This adds OMM support for NVAPI. This takes a different approach than https://github.com/jp7677/dxvk-nvapi/pull/125. However 125 was a major source of inspiration. Notably this approach put most of the burden on dxvk-nvapi to convert the data, and then pass it along into vkd3d-proton.

There is still two call paths 1 for DXR1.2 which requires SER as well. Whereas NVAPI is more permissive.

Please look at https://github.com/HansKristian-Work/vkd3d-proton/pull/3005 for the VKD3D side of these changes. I have tried to keep the changes atomic. I am willing to split the PR into phases if needed.