### PR TITLE
nvapi-vulkan: Refactor VkReflex implementation into separate backends

### DIFF
--- a/src/nvapi/nvapi_vulkan_low_latency_device.cpp
+++ b/src/nvapi/nvapi_vulkan_low_latency_device.cpp
@@ -1,4 +1,6 @@
 #include "./nvapi_vulkan_low_latency_device.h"
+#include "../util/util_env.h"
+#include "../util/util_log.h"
 
 namespace dxvk {
     std::unique_ptr<Vk> NvapiVulkanLowLatencyDevice::m_vk = nullptr;
@@ -28,30 +30,24 @@ namespace dxvk {
         m_vk.reset();
     }
 
-    std::pair<NvapiVulkanLowLatencyDevice*, VkResult> NvapiVulkanLowLatencyDevice::GetOrCreate(VkDevice device, bool allowFake) {
+    std::pair<NvapiVulkanLowLatencyDevice*, VkResult> NvapiVulkanLowLatencyDevice::GetOrCreate(VkDevice device) {
         std::scoped_lock lock{m_mutex};
 
         if (auto lowLatencyDevice = Get(device))
             return {lowLatencyDevice, VK_SUCCESS};
 
-        if (!m_vk || !m_vk->IsAvailable())
+        if (!m_vk || !m_vk->IsAvailable()) {
+            log::info("Initializing Vulkan Low-Latency failed: could not find usable Vulkan loader (or winevulkan) module in the current process");
             return {nullptr, VK_ERROR_INITIALIZATION_FAILED};
-
-#define VK_GET_DEVICE_PROC_ADDR(proc) auto proc = reinterpret_cast<PFN_##proc>(m_vk->GetDeviceProcAddr(device, #proc))
-
-        VK_GET_DEVICE_PROC_ADDR(vkCreateSemaphore);
-        VK_GET_DEVICE_PROC_ADDR(vkDestroySemaphore);
-
-        if (!vkCreateSemaphore || !vkDestroySemaphore)
-            return {nullptr, VK_ERROR_INCOMPATIBLE_DRIVER};
+        }
 
         std::unique_ptr<NvapiVulkanLowLatencyDevice> lowLatencyDevice;
         VkResult vr;
 
-        std::tie(lowLatencyDevice, vr) = NvapiVulkanLowLatency2LayerDevice::TryCreate(device, vkDestroySemaphore, vkCreateSemaphore);
+        std::tie(lowLatencyDevice, vr) = NvapiVulkanLowLatency2LayerDevice::TryCreate(device);
 
-        if ((!lowLatencyDevice || vr != VK_SUCCESS) && allowFake)
-            std::tie(lowLatencyDevice, vr) = NvapiVulkanLowLatencyFakeDevice::TryCreate(device, vkDestroySemaphore, vkCreateSemaphore);
+        if (!lowLatencyDevice || vr != VK_SUCCESS)
+            std::tie(lowLatencyDevice, vr) = NvapiVulkanLowLatencyFakeDevice::TryCreate(device);
 
         if (!lowLatencyDevice || vr != VK_SUCCESS)
             return {nullptr, vr};
@@ -124,6 +120,8 @@ namespace dxvk {
         m_vkDestroySemaphore(m_device, m_semaphore, nullptr);
     }
 
+#define VK_GET_DEVICE_PROC_ADDR(proc) auto proc = reinterpret_cast<PFN_##proc>(m_vk->GetDeviceProcAddr(device, #proc))
+
     NvapiVulkanLowLatencyFakeDevice::NvapiVulkanLowLatencyFakeDevice(
         VkDevice device,
         VkSemaphore semaphore,
@@ -132,22 +130,39 @@ namespace dxvk {
         : NvapiVulkanLowLatencyDevice(device, semaphore, vkDestroySemaphore),
           PFN_INIT(vkSignalSemaphore) {}
 
-    std::pair<std::unique_ptr<NvapiVulkanLowLatencyFakeDevice>, VkResult> NvapiVulkanLowLatencyFakeDevice::TryCreate(
-        VkDevice device,
-        PFN_PARAM(vkDestroySemaphore),
-        PFN_PARAM(vkCreateSemaphore)) {
+    // NvapiVulkanLowLatencyFakeDevice
+
+    std::pair<std::unique_ptr<NvapiVulkanLowLatencyFakeDevice>, VkResult> NvapiVulkanLowLatencyFakeDevice::TryCreate(VkDevice device) {
+        VK_GET_DEVICE_PROC_ADDR(vkCreateSemaphore);
+        VK_GET_DEVICE_PROC_ADDR(vkDestroySemaphore);
+
+        if (!vkCreateSemaphore || !vkDestroySemaphore) {
+            log::info("Initializing Vulkan Low-Latency with VkFakeReflex implementation failed: device does not appear to support semaphores?!");
+            return {nullptr, VK_ERROR_INCOMPATIBLE_DRIVER};
+        }
+
+        auto fakeVkReflex = env::getEnvVariable("DXVK_NVAPI_FAKE_VKREFLEX");
+        if ((!env::needsLowLatencyDevice() && fakeVkReflex != "1") || fakeVkReflex == "0") {
+            log::info("Initializing Vulkan Low-Latency with VkFakeReflex implementation failed: DXVK_NVAPI_FAKE_VKREFLEX not set");
+            return {nullptr, VK_ERROR_FEATURE_NOT_PRESENT};
+        }
+
         // Grab vkSignalSemaphore to fake that Reflex is working
         // The app should have requested either the Vulkan 1.2 or the VK_KHR_timeline_semaphore extension
         // We'll use whichever is available
         VK_GET_DEVICE_PROC_ADDR(vkSignalSemaphore);
 
-        if (!(vkSignalSemaphore || (vkSignalSemaphore = reinterpret_cast<PFN_vkSignalSemaphoreKHR>(m_vk->GetDeviceProcAddr(device, "vkSignalSemaphoreKHR")))))
+        if (!(vkSignalSemaphore || (vkSignalSemaphore = reinterpret_cast<PFN_vkSignalSemaphoreKHR>(m_vk->GetDeviceProcAddr(device, "vkSignalSemaphoreKHR"))))) {
+            log::info("Initializing Vulkan Low-Latency with VkFakeReflex implementation failed: could not find vkSignalSemaphore commands in VkDevice's dispatch table");
             return {nullptr, VK_ERROR_EXTENSION_NOT_PRESENT};
+        }
 
         auto [semaphore, vr] = CreateVkSemaphore(device, vkCreateSemaphore);
 
-        if (vr != VK_SUCCESS)
+        if (vr != VK_SUCCESS) {
+            log::info(str::format("Initializing Vulkan Low-Latency with VkFakeReflex implementation failed: create semaphore failed (", vr, ")?!"));
             return {nullptr, vr};
+        }
 
         // Pretend that Reflex is happening so that apps don't get a pink tint.
         auto lowLatencyDevice = std::make_unique<NvapiVulkanLowLatencyFakeDevice>(
@@ -156,6 +171,7 @@ namespace dxvk {
             vkDestroySemaphore,
             vkSignalSemaphore);
 
+        log::info("Successfully initialized Vulkan Low-Latency with VkFakeReflex implementation: faking success as a workaround but latency will not be reduced");
         return {std::move(lowLatencyDevice), VK_SUCCESS};
     }
 
@@ -191,6 +207,8 @@ namespace dxvk {
 
     void NvapiVulkanLowLatencyFakeDevice::QueueNotifyOutOfBand(VkQueue queue, NV_VULKAN_OUT_OF_BAND_QUEUE_TYPE queueType) {}
 
+    // NvapiVulkanLowLatency2LayerDevice
+
     NvapiVulkanLowLatency2LayerDevice::NvapiVulkanLowLatency2LayerDevice(
         VkDevice device,
         VkSemaphore semaphore,
@@ -207,10 +225,15 @@ namespace dxvk {
           PFN_INIT(vkSetLatencyMarkerNV),
           PFN_INIT(vkQueueNotifyOutOfBandNV) {}
 
-    std::pair<std::unique_ptr<NvapiVulkanLowLatency2LayerDevice>, VkResult> NvapiVulkanLowLatency2LayerDevice::TryCreate(
-        VkDevice device,
-        PFN_PARAM(vkDestroySemaphore),
-        PFN_PARAM(vkCreateSemaphore)) {
+    std::pair<std::unique_ptr<NvapiVulkanLowLatency2LayerDevice>, VkResult> NvapiVulkanLowLatency2LayerDevice::TryCreate(VkDevice device) {
+        VK_GET_DEVICE_PROC_ADDR(vkCreateSemaphore);
+        VK_GET_DEVICE_PROC_ADDR(vkDestroySemaphore);
+
+        if (!vkCreateSemaphore || !vkDestroySemaphore) {
+            log::info("Initializing Vulkan Low-Latency with VkNvLowLatency2 implementation failed: device does not appear to support semaphores?!");
+            return {nullptr, VK_ERROR_INCOMPATIBLE_DRIVER};
+        }
+
         // If the Vulkan Reflex Layer is present it will enable VK_NV_low_latency2 which will let us query
         // these function pointers.
         VK_GET_DEVICE_PROC_ADDR(vkSetLatencySleepModeNV);
@@ -219,15 +242,19 @@ namespace dxvk {
         VK_GET_DEVICE_PROC_ADDR(vkSetLatencyMarkerNV);
         VK_GET_DEVICE_PROC_ADDR(vkQueueNotifyOutOfBandNV);
 
-        if (!(vkSetLatencySleepModeNV && vkLatencySleepNV && vkGetLatencyTimingsNV && vkSetLatencyMarkerNV && vkQueueNotifyOutOfBandNV))
+        if (!(vkSetLatencySleepModeNV && vkLatencySleepNV && vkGetLatencyTimingsNV && vkSetLatencyMarkerNV && vkQueueNotifyOutOfBandNV)) {
+            log::info("Initializing Vulkan Low-Latency with VkNvLowLatency2 implementation failed, DXVK-NVAPI's Vulkan layer is not present");
             return {nullptr, VK_ERROR_EXTENSION_NOT_PRESENT};
+        }
 
         // VK_NV_low_latency2 was requested -> our compatibility layer is present
 
         auto [semaphore, vr] = CreateVkSemaphore(device, vkCreateSemaphore);
 
-        if (vr != VK_SUCCESS)
+        if (vr != VK_SUCCESS) {
+            log::info(str::format("Initializing Vulkan Low-Latency with VkNvLowLatency2 implementation failed: create semaphore failed (", vr, ")?!"));
             return {nullptr, vr};
+        }
 
         auto lowLatencyDevice = std::make_unique<NvapiVulkanLowLatency2LayerDevice>(
             device,
@@ -239,6 +266,7 @@ namespace dxvk {
             vkSetLatencyMarkerNV,
             vkQueueNotifyOutOfBandNV);
 
+        log::info("Successfully initialized Vulkan Low-Latency with VkNvLowLatency2 implementation, DXVK-NVAPI's Vulkan layer is present");
         return {std::move(lowLatencyDevice), VK_SUCCESS};
     }
 

--- a/src/nvapi/nvapi_vulkan_low_latency_device.cpp
+++ b/src/nvapi/nvapi_vulkan_low_latency_device.cpp
@@ -2,7 +2,7 @@
 
 namespace dxvk {
     std::unique_ptr<Vk> NvapiVulkanLowLatencyDevice::m_vk = nullptr;
-    std::unordered_map<VkDevice, NvapiVulkanLowLatencyDevice> NvapiVulkanLowLatencyDevice::m_nvapiDeviceMap = {};
+    std::unordered_map<VkDevice, std::unique_ptr<NvapiVulkanLowLatencyDevice>> NvapiVulkanLowLatencyDevice::m_nvapiDeviceMap = {};
     std::mutex NvapiVulkanLowLatencyDevice::m_mutex = {};
 
     bool NvapiVulkanLowLatencyDevice::Initialize(NvapiResourceFactory& resourceFactory) {
@@ -24,14 +24,11 @@ namespace dxvk {
     void NvapiVulkanLowLatencyDevice::Reset() {
         std::scoped_lock lock{m_mutex};
 
-        for (auto& [_, lowLatencyDevice] : m_nvapiDeviceMap)
-            lowLatencyDevice.m_vkDestroySemaphore(lowLatencyDevice.m_device, lowLatencyDevice.m_semaphore, nullptr);
-
         m_nvapiDeviceMap.clear();
         m_vk.reset();
     }
 
-    std::pair<NvapiVulkanLowLatencyDevice*, VkResult> NvapiVulkanLowLatencyDevice::GetOrCreate(VkDevice device) {
+    std::pair<NvapiVulkanLowLatencyDevice*, VkResult> NvapiVulkanLowLatencyDevice::GetOrCreate(VkDevice device, bool allowFake) {
         std::scoped_lock lock{m_mutex};
 
         if (auto lowLatencyDevice = Get(device))
@@ -44,32 +41,66 @@ namespace dxvk {
 
         VK_GET_DEVICE_PROC_ADDR(vkCreateSemaphore);
         VK_GET_DEVICE_PROC_ADDR(vkDestroySemaphore);
-        VK_GET_DEVICE_PROC_ADDR(vkSetLatencySleepModeNV);
-        VK_GET_DEVICE_PROC_ADDR(vkLatencySleepNV);
-        VK_GET_DEVICE_PROC_ADDR(vkGetLatencyTimingsNV);
-        VK_GET_DEVICE_PROC_ADDR(vkSetLatencyMarkerNV);
-        VK_GET_DEVICE_PROC_ADDR(vkQueueNotifyOutOfBandNV);
-        VK_GET_DEVICE_PROC_ADDR(vkSignalSemaphore);
-
-        if (!vkSetLatencySleepModeNV || !vkLatencySleepNV || !vkGetLatencyTimingsNV || !vkSetLatencyMarkerNV || !vkQueueNotifyOutOfBandNV) {
-            // VK_NV_low_latency2 was not requested -> our Vulkan Reflex layer is not present -> grab vkSignalSemaphore to fake that reflex is working
-            //
-            // The app should have requested either the Vulkan 1.2 or the VK_KHR_timeline_semaphore extension
-            // We'll query whichever is available
-            if (!vkSignalSemaphore) {
-                VK_GET_DEVICE_PROC_ADDR(vkSignalSemaphoreKHR);
-                vkSignalSemaphore = vkSignalSemaphoreKHR;
-            }
-
-            if (!vkSignalSemaphore)
-                return {nullptr, VK_ERROR_EXTENSION_NOT_PRESENT};
-        } else {
-            vkSignalSemaphore = nullptr; // We don't need this, we're signalling with vkLatencySleepNV
-        }
 
         if (!vkCreateSemaphore || !vkDestroySemaphore)
             return {nullptr, VK_ERROR_INCOMPATIBLE_DRIVER};
 
+        std::unique_ptr<NvapiVulkanLowLatencyDevice> lowLatencyDevice;
+        VkResult vr;
+
+        std::tie(lowLatencyDevice, vr) = NvapiVulkanLowLatency2LayerDevice::TryCreate(device, vkDestroySemaphore, vkCreateSemaphore);
+
+        if ((!lowLatencyDevice || vr != VK_SUCCESS) && allowFake)
+            std::tie(lowLatencyDevice, vr) = NvapiVulkanLowLatencyFakeDevice::TryCreate(device, vkDestroySemaphore, vkCreateSemaphore);
+
+        if (!lowLatencyDevice || vr != VK_SUCCESS)
+            return {nullptr, vr};
+
+        auto [it, inserted] = m_nvapiDeviceMap.emplace(
+            std::piecewise_construct,
+            std::forward_as_tuple(device),
+            std::forward_as_tuple(std::move(lowLatencyDevice)));
+
+        if (!inserted)
+            return {nullptr, VK_ERROR_UNKNOWN};
+
+        return {it->second.get(), vr};
+    }
+
+    NvapiVulkanLowLatencyDevice* NvapiVulkanLowLatencyDevice::Get(VkDevice device) {
+        auto it = m_nvapiDeviceMap.find(device);
+        return it == m_nvapiDeviceMap.end() ? nullptr : it->second.get();
+    }
+
+    bool NvapiVulkanLowLatencyDevice::Destroy(VkDevice device) {
+        std::scoped_lock lock{m_mutex};
+
+        auto node = m_nvapiDeviceMap.extract(device);
+
+        if (node.empty())
+            return false;
+
+        auto lowLatencyDevice = std::move(node.mapped());
+        // the destructor will take care of semaphore cleanup
+
+        return true;
+    }
+
+#define PFN_PARAM(proc) PFN_##proc proc
+#define PFN_INIT(proc) m_##proc(proc)
+    NvapiVulkanLowLatencyDevice::NvapiVulkanLowLatencyDevice(
+        VkDevice device,
+        VkSemaphore semaphore,
+        PFN_PARAM(vkDestroySemaphore))
+        : m_device(device),
+          m_semaphore(semaphore),
+          PFN_INIT(vkDestroySemaphore) {}
+
+    VkSemaphore NvapiVulkanLowLatencyDevice::GetSemaphore() const {
+        return m_semaphore;
+    }
+
+    std::pair<VkSemaphore, VkResult> NvapiVulkanLowLatencyDevice::CreateVkSemaphore(VkDevice device, PFN_PARAM(vkCreateSemaphore)) {
         auto semaphoreTypeCreateInfo = VkSemaphoreTypeCreateInfo{
             .sType = VK_STRUCTURE_TYPE_SEMAPHORE_TYPE_CREATE_INFO,
             .pNext = nullptr,
@@ -84,53 +115,211 @@ namespace dxvk {
         };
 
         VkSemaphore semaphore;
-
         auto vr = vkCreateSemaphore(device, &semaphoreCreateInfo, nullptr, &semaphore);
+
+        return {semaphore, vr};
+    }
+
+    NvapiVulkanLowLatencyDevice::~NvapiVulkanLowLatencyDevice() {
+        m_vkDestroySemaphore(m_device, m_semaphore, nullptr);
+    }
+
+    NvapiVulkanLowLatencyFakeDevice::NvapiVulkanLowLatencyFakeDevice(
+        VkDevice device,
+        VkSemaphore semaphore,
+        PFN_PARAM(vkDestroySemaphore),
+        PFN_PARAM(vkSignalSemaphore))
+        : NvapiVulkanLowLatencyDevice(device, semaphore, vkDestroySemaphore),
+          PFN_INIT(vkSignalSemaphore) {}
+
+    std::pair<std::unique_ptr<NvapiVulkanLowLatencyFakeDevice>, VkResult> NvapiVulkanLowLatencyFakeDevice::TryCreate(
+        VkDevice device,
+        PFN_PARAM(vkDestroySemaphore),
+        PFN_PARAM(vkCreateSemaphore)) {
+        // Grab vkSignalSemaphore to fake that Reflex is working
+        // The app should have requested either the Vulkan 1.2 or the VK_KHR_timeline_semaphore extension
+        // We'll use whichever is available
+        VK_GET_DEVICE_PROC_ADDR(vkSignalSemaphore);
+
+        if (!(vkSignalSemaphore || (vkSignalSemaphore = reinterpret_cast<PFN_vkSignalSemaphoreKHR>(m_vk->GetDeviceProcAddr(device, "vkSignalSemaphoreKHR")))))
+            return {nullptr, VK_ERROR_EXTENSION_NOT_PRESENT};
+
+        auto [semaphore, vr] = CreateVkSemaphore(device, vkCreateSemaphore);
 
         if (vr != VK_SUCCESS)
             return {nullptr, vr};
 
-        auto [it, inserted] = m_nvapiDeviceMap.emplace(
-            std::piecewise_construct,
-            std::forward_as_tuple(device),
-            std::forward_as_tuple(
-                device,
-                semaphore,
-                vkDestroySemaphore,
-                vkSetLatencySleepModeNV,
-                vkLatencySleepNV,
-                vkGetLatencyTimingsNV,
-                vkSetLatencyMarkerNV,
-                vkQueueNotifyOutOfBandNV,
-                vkSignalSemaphore));
+        // Pretend that Reflex is happening so that apps don't get a pink tint.
+        auto lowLatencyDevice = std::make_unique<NvapiVulkanLowLatencyFakeDevice>(
+            device,
+            semaphore,
+            vkDestroySemaphore,
+            vkSignalSemaphore);
 
-        if (!inserted)
-            return {nullptr, VK_ERROR_UNKNOWN};
-
-        return {&it->second, vr};
+        return {std::move(lowLatencyDevice), VK_SUCCESS};
     }
 
-    NvapiVulkanLowLatencyDevice* NvapiVulkanLowLatencyDevice::Get(VkDevice device) {
-        auto it = m_nvapiDeviceMap.find(device);
-        return it == m_nvapiDeviceMap.end() ? nullptr : &it->second;
+    NvBool NvapiVulkanLowLatencyFakeDevice::GetLowLatencyMode() const {
+        return NV_FALSE;
     }
 
-    bool NvapiVulkanLowLatencyDevice::Destroy(VkDevice device) {
-        std::scoped_lock lock{m_mutex};
+    VkResult NvapiVulkanLowLatencyFakeDevice::SetLatencySleepMode(std::nullptr_t) {
+        return VK_SUCCESS;
+    }
 
-        auto node = m_nvapiDeviceMap.extract(device);
+    VkResult NvapiVulkanLowLatencyFakeDevice::SetLatencySleepMode(bool lowLatencyMode, bool lowLatencyBoost, uint32_t minimumIntervalUs) {
+        return VK_SUCCESS;
+    }
 
-        if (node.empty())
-            return false;
+    VkResult NvapiVulkanLowLatencyFakeDevice::LatencySleep(uint64_t value) {
+        auto info = VkSemaphoreSignalInfoKHR{
+            .sType = VK_STRUCTURE_TYPE_SEMAPHORE_SIGNAL_INFO_KHR,
+            .pNext = nullptr,
+            .semaphore = m_semaphore,
+            .value = value};
 
-        auto& lowLatencyDevice = node.mapped();
+        return m_vkSignalSemaphore(m_device, &info);
+    }
 
-        lowLatencyDevice.m_vkDestroySemaphore(lowLatencyDevice.m_device, lowLatencyDevice.m_semaphore, nullptr);
+    void NvapiVulkanLowLatencyFakeDevice::GetLatencyTimings(std::span<NV_VULKAN_LATENCY_RESULT_PARAMS_V1::vkFrameReport, 64> frameReports) {
+        memset(frameReports.data(), 0, frameReports.size_bytes());
+    }
 
+    bool NvapiVulkanLowLatencyFakeDevice::SetLatencyMarker(uint64_t frameID, NV_VULKAN_LATENCY_MARKER_TYPE marker) {
         return true;
     }
 
-    VkLatencyMarkerNV NvapiVulkanLowLatencyDevice::ToVkLatencyMarkerNV(NV_VULKAN_LATENCY_MARKER_TYPE marker) {
+    void NvapiVulkanLowLatencyFakeDevice::QueueNotifyOutOfBand(VkQueue queue, NV_VULKAN_OUT_OF_BAND_QUEUE_TYPE queueType) {}
+
+    NvapiVulkanLowLatency2LayerDevice::NvapiVulkanLowLatency2LayerDevice(
+        VkDevice device,
+        VkSemaphore semaphore,
+        PFN_PARAM(vkDestroySemaphore),
+        PFN_PARAM(vkSetLatencySleepModeNV),
+        PFN_PARAM(vkLatencySleepNV),
+        PFN_PARAM(vkGetLatencyTimingsNV),
+        PFN_PARAM(vkSetLatencyMarkerNV),
+        PFN_PARAM(vkQueueNotifyOutOfBandNV))
+        : NvapiVulkanLowLatencyDevice(device, semaphore, vkDestroySemaphore),
+          PFN_INIT(vkSetLatencySleepModeNV),
+          PFN_INIT(vkLatencySleepNV),
+          PFN_INIT(vkGetLatencyTimingsNV),
+          PFN_INIT(vkSetLatencyMarkerNV),
+          PFN_INIT(vkQueueNotifyOutOfBandNV) {}
+
+    std::pair<std::unique_ptr<NvapiVulkanLowLatency2LayerDevice>, VkResult> NvapiVulkanLowLatency2LayerDevice::TryCreate(
+        VkDevice device,
+        PFN_PARAM(vkDestroySemaphore),
+        PFN_PARAM(vkCreateSemaphore)) {
+        // If the Vulkan Reflex Layer is present it will enable VK_NV_low_latency2 which will let us query
+        // these function pointers.
+        VK_GET_DEVICE_PROC_ADDR(vkSetLatencySleepModeNV);
+        VK_GET_DEVICE_PROC_ADDR(vkLatencySleepNV);
+        VK_GET_DEVICE_PROC_ADDR(vkGetLatencyTimingsNV);
+        VK_GET_DEVICE_PROC_ADDR(vkSetLatencyMarkerNV);
+        VK_GET_DEVICE_PROC_ADDR(vkQueueNotifyOutOfBandNV);
+
+        if (!(vkSetLatencySleepModeNV && vkLatencySleepNV && vkGetLatencyTimingsNV && vkSetLatencyMarkerNV && vkQueueNotifyOutOfBandNV))
+            return {nullptr, VK_ERROR_EXTENSION_NOT_PRESENT};
+
+        // VK_NV_low_latency2 was requested -> our compatibility layer is present
+
+        auto [semaphore, vr] = CreateVkSemaphore(device, vkCreateSemaphore);
+
+        if (vr != VK_SUCCESS)
+            return {nullptr, vr};
+
+        auto lowLatencyDevice = std::make_unique<NvapiVulkanLowLatency2LayerDevice>(
+            device,
+            semaphore,
+            vkDestroySemaphore,
+            vkSetLatencySleepModeNV,
+            vkLatencySleepNV,
+            vkGetLatencyTimingsNV,
+            vkSetLatencyMarkerNV,
+            vkQueueNotifyOutOfBandNV);
+
+        return {std::move(lowLatencyDevice), VK_SUCCESS};
+    }
+
+    NvBool NvapiVulkanLowLatency2LayerDevice::GetLowLatencyMode() const {
+        return m_lowLatencyMode ? NV_TRUE : NV_FALSE;
+    }
+
+    static inline VkSwapchainKHR GetSwapchain(VkDevice device) {
+        // winevulkan expects valid Vulkan usage so it never checks if swapchains passed to VK_NV_low_latency2 functions
+        // are null handles or not, it just unconditionally dereferences them, and we just need our calls to make it
+        // to the Linux-side Vulkan layer without crashing in the meantime, this hack makes winevulkan happy enough
+        return reinterpret_cast<VkSwapchainKHR>(device);
+    }
+
+    VkResult NvapiVulkanLowLatency2LayerDevice::SetLatencySleepMode(std::nullptr_t) {
+        auto vr = m_vkSetLatencySleepModeNV(m_device, GetSwapchain(m_device), nullptr);
+
+        if (vr == VK_SUCCESS)
+            m_lowLatencyMode = false;
+
+        return vr;
+    }
+
+    VkResult NvapiVulkanLowLatency2LayerDevice::SetLatencySleepMode(bool lowLatencyMode, bool lowLatencyBoost, uint32_t minimumIntervalUs) {
+        auto info = VkLatencySleepModeInfoNV{
+            .sType = VK_STRUCTURE_TYPE_LATENCY_SLEEP_MODE_INFO_NV,
+            .pNext = nullptr,
+            .lowLatencyMode = lowLatencyMode,
+            .lowLatencyBoost = lowLatencyBoost,
+            .minimumIntervalUs = minimumIntervalUs,
+        };
+
+        auto vr = m_vkSetLatencySleepModeNV(m_device, GetSwapchain(m_device), &info);
+
+        if (vr == VK_SUCCESS)
+            m_lowLatencyMode = lowLatencyMode;
+
+        return vr;
+    }
+
+    VkResult NvapiVulkanLowLatency2LayerDevice::LatencySleep(uint64_t value) {
+        auto info = VkLatencySleepInfoNV{
+            .sType = VK_STRUCTURE_TYPE_LATENCY_SLEEP_INFO_NV,
+            .pNext = nullptr,
+            .signalSemaphore = m_semaphore,
+            .value = value,
+        };
+
+        return m_vkLatencySleepNV(m_device, GetSwapchain(m_device), &info);
+    }
+
+    void NvapiVulkanLowLatency2LayerDevice::GetLatencyTimings(std::span<NV_VULKAN_LATENCY_RESULT_PARAMS_V1::vkFrameReport, 64> frameReports) {
+        std::array<VkLatencyTimingsFrameReportNV, 64> latencyTimingsFrameReports;
+
+        for (auto& report : latencyTimingsFrameReports) {
+            report.sType = VK_STRUCTURE_TYPE_LATENCY_TIMINGS_FRAME_REPORT_NV;
+            report.pNext = nullptr;
+        }
+
+        auto info = VkGetLatencyMarkerInfoNV{
+            .sType = VK_STRUCTURE_TYPE_GET_LATENCY_MARKER_INFO_NV,
+            .pNext = nullptr,
+            .timingCount = 64,
+            .pTimings = latencyTimingsFrameReports.data(),
+        };
+
+        m_vkGetLatencyTimingsNV(m_device, GetSwapchain(m_device), &info);
+
+        if (info.timingCount == 64) {
+            for (size_t i = 0; i < 64; ++i) {
+                std::memcpy(
+                    &frameReports[i].frameID,
+                    &latencyTimingsFrameReports[i].presentID,
+                    offsetof(NV_VULKAN_LATENCY_RESULT_PARAMS::vkFrameReport, rsvd));
+            }
+        } else {
+            std::memset(frameReports.data(), 0, frameReports.size_bytes());
+        }
+    }
+
+    static inline VkLatencyMarkerNV ToVkLatencyMarkerNV(NV_VULKAN_LATENCY_MARKER_TYPE marker) {
         switch (marker) {
             case VULKAN_SIMULATION_START:
                 return VK_LATENCY_MARKER_SIMULATION_START_NV;
@@ -163,148 +352,32 @@ namespace dxvk {
         return VK_LATENCY_MARKER_MAX_ENUM_NV;
     }
 
-#define PFN_PARAM(proc) PFN_##proc proc
-#define PFN_INIT(proc) m_##proc(proc)
-    NvapiVulkanLowLatencyDevice::NvapiVulkanLowLatencyDevice(
-        VkDevice device,
-        VkSemaphore semaphore,
-        PFN_PARAM(vkDestroySemaphore),
-        PFN_PARAM(vkSetLatencySleepModeNV),
-        PFN_PARAM(vkLatencySleepNV),
-        PFN_PARAM(vkGetLatencyTimingsNV),
-        PFN_PARAM(vkSetLatencyMarkerNV),
-        PFN_PARAM(vkQueueNotifyOutOfBandNV),
-        PFN_PARAM(vkSignalSemaphore))
-        : m_device(device),
-          m_semaphore(semaphore),
-          // If the Vulkan Reflex Layer is present it will enable VK_NV_low_latency2 which will let us query
-          // these function pointers.
-          // Without the layer we'll pretend that Reflex is happening so that apps don't get a pink tint.
-          m_layerPresent(vkSetLatencySleepModeNV && vkLatencySleepNV && vkGetLatencyTimingsNV
-              && vkSetLatencyMarkerNV && vkQueueNotifyOutOfBandNV),
-          PFN_INIT(vkDestroySemaphore),
-          PFN_INIT(vkSetLatencySleepModeNV),
-          PFN_INIT(vkLatencySleepNV),
-          PFN_INIT(vkGetLatencyTimingsNV),
-          PFN_INIT(vkSetLatencyMarkerNV),
-          PFN_INIT(vkQueueNotifyOutOfBandNV),
-          PFN_INIT(vkSignalSemaphore) {}
+    bool NvapiVulkanLowLatency2LayerDevice::SetLatencyMarker(uint64_t frameID, NV_VULKAN_LATENCY_MARKER_TYPE marker) {
+        auto markerType = ToVkLatencyMarkerNV(marker);
 
-    bool NvapiVulkanLowLatencyDevice::IsLayerPresent() const {
-        return m_layerPresent;
-    }
-
-    VkSemaphore NvapiVulkanLowLatencyDevice::GetSemaphore() const {
-        return m_semaphore;
-    }
-
-    bool NvapiVulkanLowLatencyDevice::GetLowLatencyMode() const {
-        return m_lowLatencyMode;
-    }
-
-    static inline VkSwapchainKHR GetSwapchain(VkDevice device) {
-        // winevulkan expects valid Vulkan usage so it never checks if swapchains passed to VK_NV_low_latency2 functions
-        // are null handles or not, it just unconditionally dereferences them, and we just need our calls to make it
-        // to the Linux-side Vulkan layer without crashing in the meantime, this hack makes winevulkan happy enough
-        return reinterpret_cast<VkSwapchainKHR>(device);
-    }
-
-    VkResult NvapiVulkanLowLatencyDevice::SetLatencySleepMode(std::nullptr_t) {
-        if (!m_layerPresent)
-            return VK_SUCCESS;
-
-        auto vr = m_vkSetLatencySleepModeNV(m_device, GetSwapchain(m_device), nullptr);
-
-        if (vr == VK_SUCCESS)
-            m_lowLatencyMode = false;
-
-        return vr;
-    }
-
-    VkResult NvapiVulkanLowLatencyDevice::SetLatencySleepMode(bool lowLatencyMode, bool lowLatencyBoost, uint32_t minimumIntervalUs) {
-        if (!m_layerPresent)
-            return VK_SUCCESS;
-
-        auto info = VkLatencySleepModeInfoNV{
-            .sType = VK_STRUCTURE_TYPE_LATENCY_SLEEP_MODE_INFO_NV,
-            .pNext = nullptr,
-            .lowLatencyMode = lowLatencyMode,
-            .lowLatencyBoost = lowLatencyBoost,
-            .minimumIntervalUs = minimumIntervalUs,
-        };
-
-        auto vr = m_vkSetLatencySleepModeNV(m_device, GetSwapchain(m_device), &info);
-
-        if (vr == VK_SUCCESS)
-            m_lowLatencyMode = lowLatencyMode;
-
-        return vr;
-    }
-
-    VkResult NvapiVulkanLowLatencyDevice::LatencySleep(uint64_t value) {
-        if (m_layerPresent) {
-            auto info = VkLatencySleepInfoNV{
-                .sType = VK_STRUCTURE_TYPE_LATENCY_SLEEP_INFO_NV,
-                .pNext = nullptr,
-                .signalSemaphore = m_semaphore,
-                .value = value,
-            };
-
-            return m_vkLatencySleepNV(m_device, GetSwapchain(m_device), &info);
-        } else {
-            auto info = VkSemaphoreSignalInfoKHR{
-                .sType = VK_STRUCTURE_TYPE_SEMAPHORE_SIGNAL_INFO_KHR,
-                .pNext = nullptr,
-                .semaphore = m_semaphore,
-                .value = value};
-
-            return m_vkSignalSemaphore(m_device, &info);
-        }
-    }
-
-    bool NvapiVulkanLowLatencyDevice::GetLatencyTimings(std::array<VkLatencyTimingsFrameReportNV, 64>& timings) {
-        if (!m_layerPresent)
+        if (markerType == VK_LATENCY_MARKER_MAX_ENUM_NV)
             return false;
-
-        for (auto& timing : timings) {
-            timing.sType = VK_STRUCTURE_TYPE_LATENCY_TIMINGS_FRAME_REPORT_NV;
-            timing.pNext = nullptr;
-        }
-
-        auto info = VkGetLatencyMarkerInfoNV{
-            .sType = VK_STRUCTURE_TYPE_GET_LATENCY_MARKER_INFO_NV,
-            .pNext = nullptr,
-            .timingCount = 64,
-            .pTimings = timings.data(),
-        };
-
-        m_vkGetLatencyTimingsNV(m_device, GetSwapchain(m_device), &info);
-
-        return info.timingCount == 64;
-    }
-
-    void NvapiVulkanLowLatencyDevice::SetLatencyMarker(uint64_t presentID, VkLatencyMarkerNV marker) {
-        if (!m_layerPresent)
-            return;
 
         auto info = VkSetLatencyMarkerInfoNV{
             .sType = VK_STRUCTURE_TYPE_SET_LATENCY_MARKER_INFO_NV,
             .pNext = nullptr,
-            .presentID = presentID,
-            .marker = marker,
+            .presentID = frameID,
+            .marker = markerType,
         };
 
         m_vkSetLatencyMarkerNV(m_device, GetSwapchain(m_device), &info);
+
+        return true;
     }
 
-    void NvapiVulkanLowLatencyDevice::QueueNotifyOutOfBand(VkQueue queue, VkOutOfBandQueueTypeNV queueType) {
-        if (!m_layerPresent)
-            return;
+    void NvapiVulkanLowLatency2LayerDevice::QueueNotifyOutOfBand(VkQueue queue, NV_VULKAN_OUT_OF_BAND_QUEUE_TYPE queueType) {
+        static_assert(static_cast<VkOutOfBandQueueTypeNV>(VULKAN_OUT_OF_BAND_QUEUE_TYPE_PRESENT) == VK_OUT_OF_BAND_QUEUE_TYPE_PRESENT_NV);
+        static_assert(static_cast<VkOutOfBandQueueTypeNV>(VULKAN_OUT_OF_BAND_QUEUE_TYPE_RENDER) == VK_OUT_OF_BAND_QUEUE_TYPE_RENDER_NV);
 
         auto info = VkOutOfBandQueueTypeInfoNV{
             .sType = VK_STRUCTURE_TYPE_OUT_OF_BAND_QUEUE_TYPE_INFO_NV,
             .pNext = nullptr,
-            .queueType = queueType,
+            .queueType = static_cast<VkOutOfBandQueueTypeNV>(queueType),
         };
 
         m_vkQueueNotifyOutOfBandNV(queue, &info);

--- a/src/nvapi/nvapi_vulkan_low_latency_device.cpp
+++ b/src/nvapi/nvapi_vulkan_low_latency_device.cpp
@@ -87,14 +87,12 @@ namespace dxvk {
     NvapiVulkanLowLatencyDevice::NvapiVulkanLowLatencyDevice(
         VkDevice device,
         VkSemaphore semaphore,
-        PFN_PARAM(vkDestroySemaphore))
+        PFN_PARAM(vkDestroySemaphore),
+        LowLatencyDeviceImplementation implementation)
         : m_device(device),
           m_semaphore(semaphore),
-          PFN_INIT(vkDestroySemaphore) {}
-
-    VkSemaphore NvapiVulkanLowLatencyDevice::GetSemaphore() const {
-        return m_semaphore;
-    }
+          PFN_INIT(vkDestroySemaphore),
+          m_implementation(implementation) {}
 
     std::pair<VkSemaphore, VkResult> NvapiVulkanLowLatencyDevice::CreateVkSemaphore(VkDevice device, PFN_PARAM(vkCreateSemaphore)) {
         auto semaphoreTypeCreateInfo = VkSemaphoreTypeCreateInfo{
@@ -120,6 +118,50 @@ namespace dxvk {
         m_vkDestroySemaphore(m_device, m_semaphore, nullptr);
     }
 
+#define INVOKE(call)                                                            \
+    switch (m_implementation) {                                                 \
+        case LowLatencyDeviceImplementation::LowLatency2:                       \
+            return static_cast<NvapiVulkanLowLatency2LayerDevice*>(this)->call; \
+        case LowLatencyDeviceImplementation::VkReflexFake:                      \
+            return static_cast<NvapiVulkanLowLatencyFakeDevice*>(this)->call;   \
+        default:                                                                \
+            __builtin_unreachable();                                            \
+    }
+
+#define INVOKE_CONST(call)                                                            \
+    switch (m_implementation) {                                                       \
+        case LowLatencyDeviceImplementation::LowLatency2:                             \
+            return static_cast<const NvapiVulkanLowLatency2LayerDevice*>(this)->call; \
+        case LowLatencyDeviceImplementation::VkReflexFake:                            \
+            return static_cast<const NvapiVulkanLowLatencyFakeDevice*>(this)->call;   \
+        default:                                                                      \
+            __builtin_unreachable();                                                  \
+    }
+
+    NvBool NvapiVulkanLowLatencyDevice::GetLowLatencyMode() const {
+        INVOKE_CONST(GetLowLatencyMode())}
+
+    VkResult NvapiVulkanLowLatencyDevice::SetLatencySleepMode(std::nullptr_t){
+        INVOKE(SetLatencySleepMode(nullptr))}
+
+    VkResult NvapiVulkanLowLatencyDevice::SetLatencySleepMode(bool lowLatencyMode, bool lowLatencyBoost, uint32_t minimumIntervalUs){
+        INVOKE(SetLatencySleepMode(lowLatencyMode, lowLatencyBoost, minimumIntervalUs))}
+
+    VkResult NvapiVulkanLowLatencyDevice::LatencySleep(uint64_t value) {
+        INVOKE(LatencySleep(value))
+    }
+
+    void NvapiVulkanLowLatencyDevice::GetLatencyTimings(std::span<NV_VULKAN_LATENCY_RESULT_PARAMS_V1::vkFrameReport, 64> frameReports) {
+        INVOKE(GetLatencyTimings(frameReports))
+    }
+
+    bool NvapiVulkanLowLatencyDevice::SetLatencyMarker(uint64_t frameID, NV_VULKAN_LATENCY_MARKER_TYPE marker) {
+        INVOKE(SetLatencyMarker(frameID, marker))
+    }
+
+    void NvapiVulkanLowLatencyDevice::QueueNotifyOutOfBand(VkQueue queue, NV_VULKAN_OUT_OF_BAND_QUEUE_TYPE queueType){
+        INVOKE(QueueNotifyOutOfBand(queue, queueType))}
+
 #define VK_GET_DEVICE_PROC_ADDR(proc) auto proc = reinterpret_cast<PFN_##proc>(m_vk->GetDeviceProcAddr(device, #proc))
 
     NvapiVulkanLowLatencyFakeDevice::NvapiVulkanLowLatencyFakeDevice(
@@ -127,8 +169,9 @@ namespace dxvk {
         VkSemaphore semaphore,
         PFN_PARAM(vkDestroySemaphore),
         PFN_PARAM(vkSignalSemaphore))
-        : NvapiVulkanLowLatencyDevice(device, semaphore, vkDestroySemaphore),
-          PFN_INIT(vkSignalSemaphore) {}
+        : NvapiVulkanLowLatencyDevice(device, semaphore, vkDestroySemaphore, LowLatencyDeviceImplementation::VkReflexFake),
+          PFN_INIT(vkSignalSemaphore) {
+    }
 
     // NvapiVulkanLowLatencyFakeDevice
 
@@ -218,7 +261,7 @@ namespace dxvk {
         PFN_PARAM(vkGetLatencyTimingsNV),
         PFN_PARAM(vkSetLatencyMarkerNV),
         PFN_PARAM(vkQueueNotifyOutOfBandNV))
-        : NvapiVulkanLowLatencyDevice(device, semaphore, vkDestroySemaphore),
+        : NvapiVulkanLowLatencyDevice(device, semaphore, vkDestroySemaphore, LowLatencyDeviceImplementation::LowLatency2),
           PFN_INIT(vkSetLatencySleepModeNV),
           PFN_INIT(vkLatencySleepNV),
           PFN_INIT(vkGetLatencyTimingsNV),

--- a/src/nvapi/nvapi_vulkan_low_latency_device.h
+++ b/src/nvapi/nvapi_vulkan_low_latency_device.h
@@ -4,30 +4,13 @@
 #include "./nvapi_resource_factory.h"
 
 namespace dxvk {
-    enum class VulkanLowLatencyImplementation {
-        Fake,
-        VkNvLowLatency2,
-    };
-
-    inline std::ostream& operator<<(std::ostream& stream, VulkanLowLatencyImplementation implementation) {
-        switch (implementation) {
-#define CASE(x)                             \
-    case VulkanLowLatencyImplementation::x: \
-        return stream << #x;
-            CASE(Fake)
-            CASE(VkNvLowLatency2)
-#undef CASE
-            default:
-                return stream << "Unknown";
-        }
-    }
 
     class NvapiVulkanLowLatencyDevice {
       public:
         static bool Initialize(NvapiResourceFactory& resourceFactory);
         static void Reset();
 
-        [[nodiscard]] static std::pair<NvapiVulkanLowLatencyDevice*, VkResult> GetOrCreate(VkDevice device, bool allowFake);
+        [[nodiscard]] static std::pair<NvapiVulkanLowLatencyDevice*, VkResult> GetOrCreate(VkDevice device);
         [[nodiscard]] static NvapiVulkanLowLatencyDevice* Get(VkDevice device);
         static bool Destroy(VkDevice device);
 
@@ -38,7 +21,6 @@ namespace dxvk {
 
         [[nodiscard]] VkSemaphore GetSemaphore() const;
 
-        [[nodiscard]] virtual VulkanLowLatencyImplementation GetImplementation() const = 0;
         [[nodiscard]] virtual NvBool GetLowLatencyMode() const = 0;
         [[nodiscard]] virtual VkResult SetLatencySleepMode(std::nullptr_t) = 0;
         [[nodiscard]] virtual VkResult SetLatencySleepMode(bool lowLatencyMode, bool lowLatencyBoost, uint32_t minimumIntervalUs) = 0;
@@ -74,13 +56,9 @@ namespace dxvk {
             VkSemaphore semaphore,
             PFN_PARAM(vkDestroySemaphore),
             PFN_PARAM(vkSignalSemaphore));
-        [[nodiscard]] static std::pair<std::unique_ptr<NvapiVulkanLowLatencyFakeDevice>, VkResult> TryCreate(
-            VkDevice device,
-            PFN_PARAM(vkDestroySemaphore),
-            PFN_PARAM(vkCreateSemaphore));
+        [[nodiscard]] static std::pair<std::unique_ptr<NvapiVulkanLowLatencyFakeDevice>, VkResult> TryCreate(VkDevice device);
 #undef PFN_PARAM
 
-        [[nodiscard]] VulkanLowLatencyImplementation GetImplementation() const override { return VulkanLowLatencyImplementation::Fake; }
         [[nodiscard]] NvBool GetLowLatencyMode() const override;
         [[nodiscard]] VkResult SetLatencySleepMode(std::nullptr_t) override;
         [[nodiscard]] VkResult SetLatencySleepMode(bool lowLatencyMode, bool lowLatencyBoost, uint32_t minimumIntervalUs) override;
@@ -105,13 +83,9 @@ namespace dxvk {
             PFN_PARAM(vkGetLatencyTimingsNV),
             PFN_PARAM(vkSetLatencyMarkerNV),
             PFN_PARAM(vkQueueNotifyOutOfBandNV));
-        [[nodiscard]] static std::pair<std::unique_ptr<NvapiVulkanLowLatency2LayerDevice>, VkResult> TryCreate(
-            VkDevice device,
-            PFN_PARAM(vkDestroySemaphore),
-            PFN_PARAM(vkCreateSemaphore));
 #undef PFN_PARAM
+        [[nodiscard]] static std::pair<std::unique_ptr<NvapiVulkanLowLatency2LayerDevice>, VkResult> TryCreate(VkDevice device);
 
-        [[nodiscard]] VulkanLowLatencyImplementation GetImplementation() const override { return VulkanLowLatencyImplementation::VkNvLowLatency2; }
         [[nodiscard]] NvBool GetLowLatencyMode() const override;
         [[nodiscard]] VkResult SetLatencySleepMode(std::nullptr_t) override;
         [[nodiscard]] VkResult SetLatencySleepMode(bool lowLatencyMode, bool lowLatencyBoost, uint32_t minimumIntervalUs) override;

--- a/src/nvapi/nvapi_vulkan_low_latency_device.h
+++ b/src/nvapi/nvapi_vulkan_low_latency_device.h
@@ -4,19 +4,99 @@
 #include "./nvapi_resource_factory.h"
 
 namespace dxvk {
+    enum class VulkanLowLatencyImplementation {
+        Fake,
+        VkNvLowLatency2,
+    };
+
+    inline std::ostream& operator<<(std::ostream& stream, VulkanLowLatencyImplementation implementation) {
+        switch (implementation) {
+#define CASE(x)                             \
+    case VulkanLowLatencyImplementation::x: \
+        return stream << #x;
+            CASE(Fake)
+            CASE(VkNvLowLatency2)
+#undef CASE
+            default:
+                return stream << "Unknown";
+        }
+    }
+
     class NvapiVulkanLowLatencyDevice {
       public:
         static bool Initialize(NvapiResourceFactory& resourceFactory);
         static void Reset();
 
-        [[nodiscard]] static std::pair<NvapiVulkanLowLatencyDevice*, VkResult> GetOrCreate(VkDevice device);
+        [[nodiscard]] static std::pair<NvapiVulkanLowLatencyDevice*, VkResult> GetOrCreate(VkDevice device, bool allowFake);
         [[nodiscard]] static NvapiVulkanLowLatencyDevice* Get(VkDevice device);
         static bool Destroy(VkDevice device);
 
-        [[nodiscard]] static VkLatencyMarkerNV ToVkLatencyMarkerNV(NV_VULKAN_LATENCY_MARKER_TYPE marker);
+        // Prevent default construction and copy semantics.
+        NvapiVulkanLowLatencyDevice() = delete;
+        NvapiVulkanLowLatencyDevice(const NvapiVulkanLowLatencyDevice&) = delete;
+        NvapiVulkanLowLatencyDevice& operator=(const NvapiVulkanLowLatencyDevice&) = delete;
 
-#define PFN_PARAM(proc) PFN_##proc proc
+        [[nodiscard]] VkSemaphore GetSemaphore() const;
+
+        [[nodiscard]] virtual VulkanLowLatencyImplementation GetImplementation() const = 0;
+        [[nodiscard]] virtual NvBool GetLowLatencyMode() const = 0;
+        [[nodiscard]] virtual VkResult SetLatencySleepMode(std::nullptr_t) = 0;
+        [[nodiscard]] virtual VkResult SetLatencySleepMode(bool lowLatencyMode, bool lowLatencyBoost, uint32_t minimumIntervalUs) = 0;
+        [[nodiscard]] virtual VkResult LatencySleep(uint64_t value) = 0;
+        virtual void GetLatencyTimings(std::span<NV_VULKAN_LATENCY_RESULT_PARAMS_V1::vkFrameReport, 64> frameReports) = 0;
+        [[nodiscard]] virtual bool SetLatencyMarker(uint64_t frameID, NV_VULKAN_LATENCY_MARKER_TYPE marker) = 0;
+        virtual void QueueNotifyOutOfBand(VkQueue queue, NV_VULKAN_OUT_OF_BAND_QUEUE_TYPE queueType) = 0;
+
+        virtual ~NvapiVulkanLowLatencyDevice();
+
+      protected:
+        [[nodiscard]] static std::pair<VkSemaphore, VkResult> CreateVkSemaphore(VkDevice device, PFN_vkCreateSemaphore vkCreateSemaphore);
         [[nodiscard]] explicit NvapiVulkanLowLatencyDevice(
+            VkDevice device,
+            VkSemaphore semaphore,
+            PFN_vkDestroySemaphore vkDestroySemaphore);
+
+        VkDevice m_device{};
+        VkSemaphore m_semaphore{};
+        PFN_vkDestroySemaphore m_vkDestroySemaphore{};
+        static std::unique_ptr<Vk> m_vk;
+
+      private:
+        static std::unordered_map<VkDevice, std::unique_ptr<NvapiVulkanLowLatencyDevice>> m_nvapiDeviceMap;
+        static std::mutex m_mutex;
+    };
+
+    class NvapiVulkanLowLatencyFakeDevice final : public NvapiVulkanLowLatencyDevice {
+      public:
+#define PFN_PARAM(proc) PFN_##proc proc
+        [[nodiscard]] explicit NvapiVulkanLowLatencyFakeDevice(
+            VkDevice device,
+            VkSemaphore semaphore,
+            PFN_PARAM(vkDestroySemaphore),
+            PFN_PARAM(vkSignalSemaphore));
+        [[nodiscard]] static std::pair<std::unique_ptr<NvapiVulkanLowLatencyFakeDevice>, VkResult> TryCreate(
+            VkDevice device,
+            PFN_PARAM(vkDestroySemaphore),
+            PFN_PARAM(vkCreateSemaphore));
+#undef PFN_PARAM
+
+        [[nodiscard]] VulkanLowLatencyImplementation GetImplementation() const override { return VulkanLowLatencyImplementation::Fake; }
+        [[nodiscard]] NvBool GetLowLatencyMode() const override;
+        [[nodiscard]] VkResult SetLatencySleepMode(std::nullptr_t) override;
+        [[nodiscard]] VkResult SetLatencySleepMode(bool lowLatencyMode, bool lowLatencyBoost, uint32_t minimumIntervalUs) override;
+        [[nodiscard]] VkResult LatencySleep(uint64_t value) override;
+        void GetLatencyTimings(std::span<NV_VULKAN_LATENCY_RESULT_PARAMS_V1::vkFrameReport, 64> frameReports) override;
+        [[nodiscard]] bool SetLatencyMarker(uint64_t frameID, NV_VULKAN_LATENCY_MARKER_TYPE marker) override;
+        void QueueNotifyOutOfBand(VkQueue queue, NV_VULKAN_OUT_OF_BAND_QUEUE_TYPE queueType) override;
+
+      private:
+        PFN_vkSignalSemaphore m_vkSignalSemaphore{};
+    };
+
+    class NvapiVulkanLowLatency2LayerDevice final : public NvapiVulkanLowLatencyDevice {
+      public:
+#define PFN_PARAM(proc) PFN_##proc proc
+        [[nodiscard]] explicit NvapiVulkanLowLatency2LayerDevice(
             VkDevice device,
             VkSemaphore semaphore,
             PFN_PARAM(vkDestroySemaphore),
@@ -24,40 +104,31 @@ namespace dxvk {
             PFN_PARAM(vkLatencySleepNV),
             PFN_PARAM(vkGetLatencyTimingsNV),
             PFN_PARAM(vkSetLatencyMarkerNV),
-            PFN_PARAM(vkQueueNotifyOutOfBandNV),
-            PFN_PARAM(vkSignalSemaphore));
+            PFN_PARAM(vkQueueNotifyOutOfBandNV));
+        [[nodiscard]] static std::pair<std::unique_ptr<NvapiVulkanLowLatency2LayerDevice>, VkResult> TryCreate(
+            VkDevice device,
+            PFN_PARAM(vkDestroySemaphore),
+            PFN_PARAM(vkCreateSemaphore));
 #undef PFN_PARAM
 
-        [[nodiscard]] bool IsLayerPresent() const;
-        [[nodiscard]] VkSemaphore GetSemaphore() const;
-
-        [[nodiscard]] bool GetLowLatencyMode() const;
-
-        [[nodiscard]] VkResult SetLatencySleepMode(std::nullptr_t);
-        [[nodiscard]] VkResult SetLatencySleepMode(bool lowLatencyMode, bool lowLatencyBoost, uint32_t minimumIntervalUs);
-        [[nodiscard]] VkResult LatencySleep(uint64_t value);
-        [[nodiscard]] bool GetLatencyTimings(std::array<VkLatencyTimingsFrameReportNV, 64>& timings);
-        void SetLatencyMarker(uint64_t presentID, VkLatencyMarkerNV marker);
-        void QueueNotifyOutOfBand(VkQueue queue, VkOutOfBandQueueTypeNV queueType);
+        [[nodiscard]] VulkanLowLatencyImplementation GetImplementation() const override { return VulkanLowLatencyImplementation::VkNvLowLatency2; }
+        [[nodiscard]] NvBool GetLowLatencyMode() const override;
+        [[nodiscard]] VkResult SetLatencySleepMode(std::nullptr_t) override;
+        [[nodiscard]] VkResult SetLatencySleepMode(bool lowLatencyMode, bool lowLatencyBoost, uint32_t minimumIntervalUs) override;
+        [[nodiscard]] VkResult LatencySleep(uint64_t value) override;
+        void GetLatencyTimings(std::span<NV_VULKAN_LATENCY_RESULT_PARAMS_V1::vkFrameReport, 64> frameReports) override;
+        [[nodiscard]] bool SetLatencyMarker(uint64_t frameID, NV_VULKAN_LATENCY_MARKER_TYPE marker) override;
+        void QueueNotifyOutOfBand(VkQueue queue, NV_VULKAN_OUT_OF_BAND_QUEUE_TYPE queueType) override;
 
       private:
-        static std::unique_ptr<Vk> m_vk;
-        static std::unordered_map<VkDevice, NvapiVulkanLowLatencyDevice> m_nvapiDeviceMap;
-        static std::mutex m_mutex;
-
-        VkDevice m_device{};
-        VkSemaphore m_semaphore{};
         bool m_lowLatencyMode{};
-        bool m_layerPresent{};
 #define PFN_MEMBER(proc) \
     PFN_##proc m_##proc {}
-        PFN_MEMBER(vkDestroySemaphore);
         PFN_MEMBER(vkSetLatencySleepModeNV);
         PFN_MEMBER(vkLatencySleepNV);
         PFN_MEMBER(vkGetLatencyTimingsNV);
         PFN_MEMBER(vkSetLatencyMarkerNV);
         PFN_MEMBER(vkQueueNotifyOutOfBandNV);
-        PFN_MEMBER(vkSignalSemaphore);
 #undef PFN_MEMBER
     };
 }

--- a/src/nvapi/nvapi_vulkan_low_latency_device.h
+++ b/src/nvapi/nvapi_vulkan_low_latency_device.h
@@ -5,6 +5,11 @@
 
 namespace dxvk {
 
+    enum class LowLatencyDeviceImplementation : uint8_t {
+        LowLatency2,
+        VkReflexFake
+    };
+
     class NvapiVulkanLowLatencyDevice {
       public:
         static bool Initialize(NvapiResourceFactory& resourceFactory);
@@ -17,17 +22,20 @@ namespace dxvk {
         // Prevent default construction and copy semantics.
         NvapiVulkanLowLatencyDevice() = delete;
         NvapiVulkanLowLatencyDevice(const NvapiVulkanLowLatencyDevice&) = delete;
+        NvapiVulkanLowLatencyDevice(NvapiVulkanLowLatencyDevice&&) = delete;
         NvapiVulkanLowLatencyDevice& operator=(const NvapiVulkanLowLatencyDevice&) = delete;
+        NvapiVulkanLowLatencyDevice& operator=(NvapiVulkanLowLatencyDevice&&) = delete;
 
-        [[nodiscard]] VkSemaphore GetSemaphore() const;
+        [[nodiscard]] LowLatencyDeviceImplementation GetImplementation() const { return m_implementation; }
+        [[nodiscard]] VkSemaphore GetSemaphore() const { return m_semaphore; }
 
-        [[nodiscard]] virtual NvBool GetLowLatencyMode() const = 0;
-        [[nodiscard]] virtual VkResult SetLatencySleepMode(std::nullptr_t) = 0;
-        [[nodiscard]] virtual VkResult SetLatencySleepMode(bool lowLatencyMode, bool lowLatencyBoost, uint32_t minimumIntervalUs) = 0;
-        [[nodiscard]] virtual VkResult LatencySleep(uint64_t value) = 0;
-        virtual void GetLatencyTimings(std::span<NV_VULKAN_LATENCY_RESULT_PARAMS_V1::vkFrameReport, 64> frameReports) = 0;
-        [[nodiscard]] virtual bool SetLatencyMarker(uint64_t frameID, NV_VULKAN_LATENCY_MARKER_TYPE marker) = 0;
-        virtual void QueueNotifyOutOfBand(VkQueue queue, NV_VULKAN_OUT_OF_BAND_QUEUE_TYPE queueType) = 0;
+        [[nodiscard]] NvBool GetLowLatencyMode() const;
+        [[nodiscard]] VkResult SetLatencySleepMode(std::nullptr_t);
+        [[nodiscard]] VkResult SetLatencySleepMode(bool lowLatencyMode, bool lowLatencyBoost, uint32_t minimumIntervalUs);
+        [[nodiscard]] VkResult LatencySleep(uint64_t value);
+        void GetLatencyTimings(std::span<NV_VULKAN_LATENCY_RESULT_PARAMS_V1::vkFrameReport, 64> frameReports);
+        [[nodiscard]] bool SetLatencyMarker(uint64_t frameID, NV_VULKAN_LATENCY_MARKER_TYPE marker);
+        void QueueNotifyOutOfBand(VkQueue queue, NV_VULKAN_OUT_OF_BAND_QUEUE_TYPE queueType);
 
         virtual ~NvapiVulkanLowLatencyDevice();
 
@@ -36,7 +44,8 @@ namespace dxvk {
         [[nodiscard]] explicit NvapiVulkanLowLatencyDevice(
             VkDevice device,
             VkSemaphore semaphore,
-            PFN_vkDestroySemaphore vkDestroySemaphore);
+            PFN_vkDestroySemaphore vkDestroySemaphore,
+            LowLatencyDeviceImplementation type);
 
         VkDevice m_device{};
         VkSemaphore m_semaphore{};
@@ -44,6 +53,7 @@ namespace dxvk {
         static std::unique_ptr<Vk> m_vk;
 
       private:
+        LowLatencyDeviceImplementation m_implementation{};
         static std::unordered_map<VkDevice, std::unique_ptr<NvapiVulkanLowLatencyDevice>> m_nvapiDeviceMap;
         static std::mutex m_mutex;
     };
@@ -59,13 +69,13 @@ namespace dxvk {
         [[nodiscard]] static std::pair<std::unique_ptr<NvapiVulkanLowLatencyFakeDevice>, VkResult> TryCreate(VkDevice device);
 #undef PFN_PARAM
 
-        [[nodiscard]] NvBool GetLowLatencyMode() const override;
-        [[nodiscard]] VkResult SetLatencySleepMode(std::nullptr_t) override;
-        [[nodiscard]] VkResult SetLatencySleepMode(bool lowLatencyMode, bool lowLatencyBoost, uint32_t minimumIntervalUs) override;
-        [[nodiscard]] VkResult LatencySleep(uint64_t value) override;
-        void GetLatencyTimings(std::span<NV_VULKAN_LATENCY_RESULT_PARAMS_V1::vkFrameReport, 64> frameReports) override;
-        [[nodiscard]] bool SetLatencyMarker(uint64_t frameID, NV_VULKAN_LATENCY_MARKER_TYPE marker) override;
-        void QueueNotifyOutOfBand(VkQueue queue, NV_VULKAN_OUT_OF_BAND_QUEUE_TYPE queueType) override;
+        [[nodiscard]] NvBool GetLowLatencyMode() const;
+        [[nodiscard]] VkResult SetLatencySleepMode(std::nullptr_t);
+        [[nodiscard]] VkResult SetLatencySleepMode(bool lowLatencyMode, bool lowLatencyBoost, uint32_t minimumIntervalUs);
+        [[nodiscard]] VkResult LatencySleep(uint64_t value);
+        void GetLatencyTimings(std::span<NV_VULKAN_LATENCY_RESULT_PARAMS_V1::vkFrameReport, 64> frameReports);
+        [[nodiscard]] bool SetLatencyMarker(uint64_t frameID, NV_VULKAN_LATENCY_MARKER_TYPE marker);
+        void QueueNotifyOutOfBand(VkQueue queue, NV_VULKAN_OUT_OF_BAND_QUEUE_TYPE queueType);
 
       private:
         PFN_vkSignalSemaphore m_vkSignalSemaphore{};
@@ -86,13 +96,13 @@ namespace dxvk {
 #undef PFN_PARAM
         [[nodiscard]] static std::pair<std::unique_ptr<NvapiVulkanLowLatency2LayerDevice>, VkResult> TryCreate(VkDevice device);
 
-        [[nodiscard]] NvBool GetLowLatencyMode() const override;
-        [[nodiscard]] VkResult SetLatencySleepMode(std::nullptr_t) override;
-        [[nodiscard]] VkResult SetLatencySleepMode(bool lowLatencyMode, bool lowLatencyBoost, uint32_t minimumIntervalUs) override;
-        [[nodiscard]] VkResult LatencySleep(uint64_t value) override;
-        void GetLatencyTimings(std::span<NV_VULKAN_LATENCY_RESULT_PARAMS_V1::vkFrameReport, 64> frameReports) override;
-        [[nodiscard]] bool SetLatencyMarker(uint64_t frameID, NV_VULKAN_LATENCY_MARKER_TYPE marker) override;
-        void QueueNotifyOutOfBand(VkQueue queue, NV_VULKAN_OUT_OF_BAND_QUEUE_TYPE queueType) override;
+        [[nodiscard]] NvBool GetLowLatencyMode() const;
+        [[nodiscard]] VkResult SetLatencySleepMode(std::nullptr_t);
+        [[nodiscard]] VkResult SetLatencySleepMode(bool lowLatencyMode, bool lowLatencyBoost, uint32_t minimumIntervalUs);
+        [[nodiscard]] VkResult LatencySleep(uint64_t value);
+        void GetLatencyTimings(std::span<NV_VULKAN_LATENCY_RESULT_PARAMS_V1::vkFrameReport, 64> frameReports);
+        [[nodiscard]] bool SetLatencyMarker(uint64_t frameID, NV_VULKAN_LATENCY_MARKER_TYPE marker);
+        void QueueNotifyOutOfBand(VkQueue queue, NV_VULKAN_OUT_OF_BAND_QUEUE_TYPE queueType);
 
       private:
         bool m_lowLatencyMode{};

--- a/src/nvapi_private.h
+++ b/src/nvapi_private.h
@@ -24,6 +24,7 @@
 #include <optional>
 #include <regex>
 #include <set>
+#include <span>
 #include <sstream>
 #include <string_view>
 #include <string>

--- a/src/nvapi_private.h
+++ b/src/nvapi_private.h
@@ -61,7 +61,8 @@
 
 #if defined(__GNUC__)
 #define _ReturnAddress() __builtin_return_address(0);
-#elif defined(_MSC_VER)
+#elif defined(_MSC_VER) && !defined(__clang__)
+#define __builtin_unreachable() __assume(false)
 #include <intrin.h>
 #endif
 

--- a/src/nvapi_vulkan.cpp
+++ b/src/nvapi_vulkan.cpp
@@ -26,13 +26,31 @@ NVAPI_FUNCTION NvAPI_Vulkan_InitLowLatencyDevice(HANDLE vkDevice, HANDLE* signal
     if (!semaphore)
         return InvalidPointer(n);
 
-    auto [lowLatencyDevice, vr] = NvapiVulkanLowLatencyDevice::GetOrCreate(device);
+    auto fakeVkReflex = env::getEnvVariable("DXVK_NVAPI_FAKE_VKREFLEX");
+    bool fakeVkReflexAllowed;
+
+    if (fakeVkReflex == "0")
+        fakeVkReflexAllowed = false;
+    else if (fakeVkReflex == "1")
+        fakeVkReflexAllowed = true;
+    else
+        fakeVkReflexAllowed = env::needsLowLatencyDevice();
+
+    auto [lowLatencyDevice, vr] = NvapiVulkanLowLatencyDevice::GetOrCreate(device, fakeVkReflexAllowed);
 
     if (!lowLatencyDevice) {
         switch (vr) {
-            case VK_ERROR_EXTENSION_NOT_PRESENT:
-                log::info("Initializing Vulkan Low-Latency failed: could not find VK_NV_low_latency2 or vkSignalSemaphore commands in VkDevice's dispatch table, returning failure to the application due to no fallback possible");
+            case VK_ERROR_INCOMPATIBLE_DRIVER:
+                log::info("Initializing Vulkan Low-Latency failed: device does not appear to support semaphores?!");
                 return NotSupported(n);
+            case VK_ERROR_EXTENSION_NOT_PRESENT:
+                if (fakeVkReflexAllowed) {
+                    log::info("Initializing Vulkan Low-Latency failed: could not find VK_NV_low_latency2 or vkSignalSemaphore commands in VkDevice's dispatch table, returning failure to the application due to no fallback possible");
+                    return NotSupported(n);
+                } else {
+                    log::info("Initializing Vulkan Low-Latency failed: could not find VK_NV_low_latency2 commands in VkDevice's dispatch table");
+                    return NoImplementation(n);
+                }
             case VK_ERROR_INITIALIZATION_FAILED:
                 log::info("Initializing Vulkan Low-Latency failed: could not find usable Vulkan loader (or winevulkan) module in the current process");
                 [[fallthrough]];
@@ -41,23 +59,11 @@ NVAPI_FUNCTION NvAPI_Vulkan_InitLowLatencyDevice(HANDLE vkDevice, HANDLE* signal
         }
     }
 
-    if (!lowLatencyDevice->IsLayerPresent()) {
-        auto fakeVkReflex = env::getEnvVariable("DXVK_NVAPI_FAKE_VKREFLEX");
+    auto implementation = lowLatencyDevice->GetImplementation();
+    if (implementation == VulkanLowLatencyImplementation::Fake)
+        log::info("Initializing Vulkan Low-Latency failed: could not find VK_NV_low_latency2 commands in VkDevice's dispatch table, faking success as a workaround but latency will not be reduced, please ensure that DXVK-NVAPI's Vulkan layer is present for real Reflex support");
 
-        if ((env::needsLowLatencyDevice() && fakeVkReflex != "0") || fakeVkReflex == "1") {
-            log::info("Initializing Vulkan Low-Latency failed: could not find VK_NV_low_latency2 commands in VkDevice's dispatch table, faking success as a workaround but latency will not be reduced, please ensure that DXVK-NVAPI's Vulkan layer is present for real Reflex support");
-            *semaphore = lowLatencyDevice->GetSemaphore();
-
-            return Ok(n);
-        }
-
-        log::info("Initializing Vulkan Low-Latency failed: could not find VK_NV_low_latency2 commands in VkDevice's dispatch table, please ensure that DXVK-NVAPI's Vulkan layer is present for Reflex support");
-        NvapiVulkanLowLatencyDevice::Destroy(device);
-
-        return NoImplementation(n);
-    }
-
-    log::info("Successfully initialized Vulkan Low-Latency, DXVK-NVAPI's Vulkan layer is present");
+    log::info(str::format("Successfully initialized Vulkan Low-Latency with ", implementation, " implementation"));
     *semaphore = lowLatencyDevice->GetSemaphore();
 
     return Ok(n);
@@ -185,18 +191,7 @@ NVAPI_FUNCTION NvAPI_Vulkan_GetLatency(HANDLE vkDevice, NV_VULKAN_LATENCY_RESULT
     static constexpr auto count = sizeof(pGetLatencyParams->frameReport) / sizeof(*pGetLatencyParams->frameReport);
     static_assert(count == 64);
 
-    std::array<VkLatencyTimingsFrameReportNV, count> timings;
-
-    if (lowLatencyDevice->GetLatencyTimings(timings)) {
-        for (size_t i = 0; i < count; ++i) {
-            std::memcpy(
-                &pGetLatencyParams->frameReport[i].frameID,
-                &timings[i].presentID,
-                offsetof(NV_VULKAN_LATENCY_RESULT_PARAMS::vkFrameReport, rsvd));
-        }
-    } else {
-        std::memset(pGetLatencyParams->frameReport, 0, sizeof(pGetLatencyParams->frameReport));
-    }
+    lowLatencyDevice->GetLatencyTimings(pGetLatencyParams->frameReport);
 
     return Ok(n, alreadyLoggedOk);
 }
@@ -226,11 +221,8 @@ NVAPI_FUNCTION NvAPI_Vulkan_SetLatencyMarker(HANDLE vkDevice, NV_VULKAN_LATENCY_
         return HandleInvalidated(n, alreadyLoggedHandleInvalidated);
 
     auto markerType = pSetLatencyMarkerParams->markerType;
-    auto marker = NvapiVulkanLowLatencyDevice::ToVkLatencyMarkerNV(markerType);
 
-    if (marker != VK_LATENCY_MARKER_MAX_ENUM_NV) {
-        lowLatencyDevice->SetLatencyMarker(pSetLatencyMarkerParams->frameID, marker);
-    } else {
+    if (!lowLatencyDevice->SetLatencyMarker(pSetLatencyMarkerParams->frameID, markerType)) {
         thread_local std::unordered_set<NV_VULKAN_LATENCY_MARKER_TYPE> unsupportedMarkerTypes{};
 
         if (auto [it, inserted] = unsupportedMarkerTypes.insert(markerType); inserted)
@@ -257,10 +249,7 @@ NVAPI_FUNCTION NvAPI_Vulkan_NotifyOutOfBandVkQueue(HANDLE vkDevice, HANDLE queue
     if (!lowLatencyDevice)
         return HandleInvalidated(n);
 
-    static_assert(static_cast<VkOutOfBandQueueTypeNV>(VULKAN_OUT_OF_BAND_QUEUE_TYPE_PRESENT) == VK_OUT_OF_BAND_QUEUE_TYPE_PRESENT_NV);
-    static_assert(static_cast<VkOutOfBandQueueTypeNV>(VULKAN_OUT_OF_BAND_QUEUE_TYPE_RENDER) == VK_OUT_OF_BAND_QUEUE_TYPE_RENDER_NV);
-
-    lowLatencyDevice->QueueNotifyOutOfBand(queue, static_cast<VkOutOfBandQueueTypeNV>(queueType));
+    lowLatencyDevice->QueueNotifyOutOfBand(queue, queueType);
 
     return Ok(n);
 }

--- a/src/nvapi_vulkan.cpp
+++ b/src/nvapi_vulkan.cpp
@@ -2,7 +2,6 @@
 #include "nvapi_globals.h"
 #include "nvapi/nvapi_vulkan_low_latency_device.h"
 #include "util/util_statuscode.h"
-#include "util/util_env.h"
 
 using namespace dxvk;
 
@@ -26,44 +25,20 @@ NVAPI_FUNCTION NvAPI_Vulkan_InitLowLatencyDevice(HANDLE vkDevice, HANDLE* signal
     if (!semaphore)
         return InvalidPointer(n);
 
-    auto fakeVkReflex = env::getEnvVariable("DXVK_NVAPI_FAKE_VKREFLEX");
-    bool fakeVkReflexAllowed;
-
-    if (fakeVkReflex == "0")
-        fakeVkReflexAllowed = false;
-    else if (fakeVkReflex == "1")
-        fakeVkReflexAllowed = true;
-    else
-        fakeVkReflexAllowed = env::needsLowLatencyDevice();
-
-    auto [lowLatencyDevice, vr] = NvapiVulkanLowLatencyDevice::GetOrCreate(device, fakeVkReflexAllowed);
+    auto [lowLatencyDevice, vr] = NvapiVulkanLowLatencyDevice::GetOrCreate(device);
 
     if (!lowLatencyDevice) {
         switch (vr) {
             case VK_ERROR_INCOMPATIBLE_DRIVER:
-                log::info("Initializing Vulkan Low-Latency failed: device does not appear to support semaphores?!");
-                return NotSupported(n);
             case VK_ERROR_EXTENSION_NOT_PRESENT:
-                if (fakeVkReflexAllowed) {
-                    log::info("Initializing Vulkan Low-Latency failed: could not find VK_NV_low_latency2 or vkSignalSemaphore commands in VkDevice's dispatch table, returning failure to the application due to no fallback possible");
-                    return NotSupported(n);
-                } else {
-                    log::info("Initializing Vulkan Low-Latency failed: could not find VK_NV_low_latency2 commands in VkDevice's dispatch table");
-                    return NoImplementation(n);
-                }
-            case VK_ERROR_INITIALIZATION_FAILED:
-                log::info("Initializing Vulkan Low-Latency failed: could not find usable Vulkan loader (or winevulkan) module in the current process");
-                [[fallthrough]];
+                return NotSupported(n);
+            case VK_ERROR_FEATURE_NOT_PRESENT:
+                return NoImplementation(n);
             default:
                 return Error(n, vr);
         }
     }
 
-    auto implementation = lowLatencyDevice->GetImplementation();
-    if (implementation == VulkanLowLatencyImplementation::Fake)
-        log::info("Initializing Vulkan Low-Latency failed: could not find VK_NV_low_latency2 commands in VkDevice's dispatch table, faking success as a workaround but latency will not be reduced, please ensure that DXVK-NVAPI's Vulkan layer is present for real Reflex support");
-
-    log::info(str::format("Successfully initialized Vulkan Low-Latency with ", implementation, " implementation"));
     *semaphore = lowLatencyDevice->GetSemaphore();
 
     return Ok(n);

--- a/tests/nvapi_vulkan.cpp
+++ b/tests/nvapi_vulkan.cpp
@@ -32,13 +32,10 @@ TEST_CASE("Vulkan methods succeed", "[.vulkan]") {
         REQUIRE_CALL(*t->Vk(), GetDeviceProcAddr(_, eq(std::string_view("vkQueueNotifyOutOfBandNV"))))
             .RETURN(nullptr);
 
-        auto vkSemaphore = reinterpret_cast<VkSemaphore>(0x12345678);
         auto vkDevice = std::make_unique<VkDeviceMock>();
 
-        REQUIRE_CALL(*vkDevice, vkCreateSemaphore(_, _, _, _))
-            .LR_SIDE_EFFECT(*_4 = vkSemaphore)
-            .RETURN(VK_SUCCESS);
-        REQUIRE_CALL(*vkDevice, vkDestroySemaphore(_, _, _));
+        FORBID_CALL(*vkDevice, vkCreateSemaphore(_, _, _, _));
+        FORBID_CALL(*vkDevice, vkDestroySemaphore(_, _, _));
 
         HANDLE signalSemaphoreHandle = VK_NULL_HANDLE;
         REQUIRE(NvAPI_Vulkan_InitLowLatencyDevice(vkDevice.get(), &signalSemaphoreHandle) == NVAPI_NO_IMPLEMENTATION);


### PR DESCRIPTION
Not sure if the extra level of indirection via `unique_ptr` is worth it, but I like having the backends separated.

(Let's not merge this just yet.)