### PR TITLE
nvapi-d3d12: Allows NVK in GetGraphicsCapabilities

### DIFF
--- a/src/nvapi_d3d12.cpp
+++ b/src/nvapi_d3d12.cpp
@@ -445,7 +445,7 @@ NVAPI_FUNCTION NvAPI_D3D12_GetGraphicsCapabilities(IUnknown* pDevice, NvU32 stru
 
     // From https://arnon.dk/matching-sm-architectures-arch-and-gencode-for-various-nvidia-cards/ and https://en.wikipedia.org/wiki/CUDA#GPUs_supported
     // Note: One might think that SM here is D3D12 Shader Model, in fact it is the "Streaming Multiprocessor" architecture version
-    if (adapter->HasNvProprietaryDriver()) {
+    if (adapter->HasNvProprietaryDriver() || adapter->HasNvkDriver()) {
         // Based on https://gitlab.freedesktop.org/mesa/mesa/-/blob/main/src/nouveau/winsys/nouveau_device.c
         auto architectureId = adapter->GetArchitectureId();
         if (architectureId >= NV_GPU_ARCHITECTURE_GB200) {

--- a/tests/nvapi_d3d12.cpp
+++ b/tests/nvapi_d3d12.cpp
@@ -386,8 +386,8 @@ TEST_CASE("D3D12 methods succeed", "[.d3d12]") {
             auto args = GENERATE(
                 Data{VK_DRIVER_ID_NVIDIA_PROPRIETARY, 0x2000, {VK_KHR_FRAGMENT_SHADING_RATE_EXTENSION_NAME}, 8, 6, true},
                 Data{VK_DRIVER_ID_NVIDIA_PROPRIETARY, 0x2000, {}, 0, 0, false},
-                Data{VK_DRIVER_ID_MESA_NVK, 0x2600, {VK_KHR_FRAGMENT_SHADING_RATE_EXTENSION_NAME}, 0, 0, true},
-                Data{VK_DRIVER_ID_MESA_NVK, 0x2600, {}, 0, 0, false},
+                Data{VK_DRIVER_ID_MESA_NVK, 0x2600, {VK_KHR_FRAGMENT_SHADING_RATE_EXTENSION_NAME}, 8, 9, true},
+                Data{VK_DRIVER_ID_MESA_NVK, 0x2600, {}, 8, 9, false},
                 Data{VK_DRIVER_ID_AMD_OPEN_SOURCE, 0x2000, {}, 0, 0, false},
                 Data{VK_DRIVER_ID_NVIDIA_PROPRIETARY, 0x2000, {}, 0, 0, false});
 


### PR DESCRIPTION
Saw this while doing some tracing with DLSS on NVK, might not matter much but lets be consistent here.