### PR TITLE
nvapi: Fix an adapter registry initialization race.

### DIFF
--- a/src/nvapi.cpp
+++ b/src/nvapi.cpp
@@ -375,12 +375,12 @@ NVAPI_FUNCTION NvAPI_Initialize() {
     if (!resourceFactory)
         resourceFactory = std::make_unique<NvapiResourceFactory>();
 
-    nvapiAdapterRegistry = std::make_unique<NvapiAdapterRegistry>(*resourceFactory);
-    if (!nvapiAdapterRegistry->Initialize()) {
-        nvapiAdapterRegistry.reset();
+    auto registry = std::make_unique<NvapiAdapterRegistry>(*resourceFactory);
+    if (!registry->Initialize()) {
         --initializationCount;
         return NvidiaDeviceNotFound(n);
     }
+    nvapiAdapterRegistry = std::move(registry);
 
 #if _WIN64
     SetNgxDebugOptions(); // NGX is 64-bit only


### PR DESCRIPTION
`NvAPI_Initialize()` currently allocates and assigns `nvapiAdapterRegistry` before the registry had finished initializing, allowing other NVAPI entrypoints to observe an uninitialized non-null adapter registry.

This fixes a crash in Elite Dangerous when using the EDHM mod, where `NvAPI_SYS_GetDriverAndBranchVersion()` races with `NvAPI_Initialize()` and calls `nvapiAdapterRegistry->GetFirstAdapter()` before the registry is initialized.