### PR TITLE
Add alternative VkReflex implementation using legacy VK_NV_low_latency ext

### DIFF
--- a/src/nvapi/nvapi_vulkan_low_latency_device.cpp
+++ b/src/nvapi/nvapi_vulkan_low_latency_device.cpp
@@ -6,6 +6,8 @@ namespace dxvk {
 
 #define INVOKE(call)                                                            \
     switch (m_implementation) {                                                 \
+        case LowLatencyDeviceImplementation::LowLatencyLegacy:                  \
+            return static_cast<NvapiVulkanLowLatencyLegacyDevice*>(this)->call; \
         case LowLatencyDeviceImplementation::LowLatency2:                       \
             return static_cast<NvapiVulkanLowLatency2LayerDevice*>(this)->call; \
         case LowLatencyDeviceImplementation::VkReflexFake:                      \
@@ -68,6 +70,113 @@ namespace dxvk {
     }
 
 #define VK_GET_DEVICE_PROC_ADDR(proc) auto proc = reinterpret_cast<PFN_##proc>(vk->GetDeviceProcAddr(device, #proc))
+
+    // NvapiVulkanLowLatencyLegacyDevice
+
+    std::pair<std::unique_ptr<NvapiVulkanLowLatencyLegacyDevice>, VkResult> NvapiVulkanLowLatencyLegacyDevice::TryCreate(Vk* vk, VkDevice device) {
+        VK_GET_DEVICE_PROC_ADDR(vkCreateSemaphore);
+        VK_GET_DEVICE_PROC_ADDR(vkDestroySemaphore);
+
+        if (!vkCreateSemaphore || !vkDestroySemaphore) {
+            log::info("Initializing Vulkan Low-Latency with VkNvLowLatencyLegacy implementation failed: device does not appear to support semaphores?!");
+            return {nullptr, VK_ERROR_INCOMPATIBLE_DRIVER};
+        }
+
+        VK_GET_DEVICE_PROC_ADDR(vkSetLatencySleepModeLegacyNV);
+        VK_GET_DEVICE_PROC_ADDR(vkLatencySleepLegacyNV);
+        VK_GET_DEVICE_PROC_ADDR(vkGetLatencyTimingsLegacyNV);
+        VK_GET_DEVICE_PROC_ADDR(vkSetLatencyMarkerLegacyNV);
+        VK_GET_DEVICE_PROC_ADDR(vkQueueNotifyOutOfBandLegacyNV);
+        VK_GET_DEVICE_PROC_ADDR(vkGetSleepStatusLegacyNV);
+        VK_GET_DEVICE_PROC_ADDR(vkShutdownLatencyDeviceLegacyNV);
+
+        if (!(vkSetLatencySleepModeLegacyNV && vkLatencySleepLegacyNV && vkGetLatencyTimingsLegacyNV && vkSetLatencyMarkerLegacyNV && vkQueueNotifyOutOfBandLegacyNV && vkGetSleepStatusLegacyNV && vkShutdownLatencyDeviceLegacyNV)) {
+            log::info("Initializing Vulkan Low-Latency with VkNvLowLatencyLegacy implementation failed, device (or winevulkan) does not support revision 2 of VK_NV_low_latency extension");
+            return {nullptr, VK_ERROR_EXTENSION_NOT_PRESENT};
+        }
+
+        auto [semaphore, vr] = CreateVkSemaphore(device, vkCreateSemaphore);
+
+        if (vr != VK_SUCCESS) {
+            log::info(str::format("Initializing Vulkan Low-Latency with VkNvLowLatencyLegacy implementation failed: create semaphore failed (", vr, ")?!"));
+            return {nullptr, vr};
+        }
+
+        auto lowLatencyDevice = std::make_unique<NvapiVulkanLowLatencyLegacyDevice>(
+            device,
+            semaphore,
+            vkDestroySemaphore,
+            vkSetLatencySleepModeLegacyNV,
+            vkLatencySleepLegacyNV,
+            vkGetLatencyTimingsLegacyNV,
+            vkSetLatencyMarkerLegacyNV,
+            vkQueueNotifyOutOfBandLegacyNV,
+            vkGetSleepStatusLegacyNV,
+            vkShutdownLatencyDeviceLegacyNV);
+
+        log::info("Successfully initialized Vulkan Low-Latency with VkNvLowLatencyLegacy implementation");
+        return {std::move(lowLatencyDevice), VK_SUCCESS};
+    }
+
+    NvapiVulkanLowLatencyLegacyDevice::NvapiVulkanLowLatencyLegacyDevice(
+        VkDevice device,
+        VkSemaphore semaphore,
+        PFN_PARAM(vkDestroySemaphore),
+        PFN_PARAM(vkSetLatencySleepModeLegacyNV),
+        PFN_PARAM(vkLatencySleepLegacyNV),
+        PFN_PARAM(vkGetLatencyTimingsLegacyNV),
+        PFN_PARAM(vkSetLatencyMarkerLegacyNV),
+        PFN_PARAM(vkQueueNotifyOutOfBandLegacyNV),
+        PFN_PARAM(vkGetSleepStatusLegacyNV),
+        PFN_PARAM(vkShutdownLatencyDeviceLegacyNV))
+        : NvapiVulkanLowLatencyDevice(LowLatencyDeviceImplementation::LowLatencyLegacy, device, semaphore, vkDestroySemaphore),
+          PFN_INIT(vkSetLatencySleepModeLegacyNV),
+          PFN_INIT(vkLatencySleepLegacyNV),
+          PFN_INIT(vkGetLatencyTimingsLegacyNV),
+          PFN_INIT(vkSetLatencyMarkerLegacyNV),
+          PFN_INIT(vkQueueNotifyOutOfBandLegacyNV),
+          PFN_INIT(vkGetSleepStatusLegacyNV),
+          PFN_INIT(vkShutdownLatencyDeviceLegacyNV) {}
+
+    NvBool NvapiVulkanLowLatencyLegacyDevice::GetLowLatencyModeImpl() {
+        VkBool32 lowLatencyMode;
+
+        m_vkGetSleepStatusLegacyNV(m_device, &lowLatencyMode);
+
+        return lowLatencyMode ? NV_TRUE : NV_FALSE;
+    }
+
+    VkResult NvapiVulkanLowLatencyLegacyDevice::SetLatencySleepModeImpl(std::nullptr_t) {
+        m_vkSetLatencySleepModeLegacyNV(m_device, VK_FALSE, VK_FALSE, 0);
+
+        return VK_SUCCESS;
+    }
+
+    VkResult NvapiVulkanLowLatencyLegacyDevice::SetLatencySleepModeImpl(bool lowLatencyMode, bool lowLatencyBoost, uint32_t minimumIntervalUs) {
+        m_vkSetLatencySleepModeLegacyNV(m_device, lowLatencyMode ? VK_TRUE : VK_FALSE, lowLatencyBoost ? VK_TRUE : VK_FALSE, minimumIntervalUs);
+
+        return VK_SUCCESS;
+    }
+
+    VkResult NvapiVulkanLowLatencyLegacyDevice::LatencySleepImpl(uint64_t value) {
+        m_vkLatencySleepLegacyNV(m_device, m_semaphore, value);
+
+        return VK_SUCCESS;
+    }
+
+    void NvapiVulkanLowLatencyLegacyDevice::GetLatencyTimingsImpl(std::span<NV_VULKAN_LATENCY_RESULT_PARAMS_V1::vkFrameReport, 64> frameReports) {
+        m_vkGetLatencyTimingsLegacyNV(m_device, frameReports.data());
+    }
+
+    bool NvapiVulkanLowLatencyLegacyDevice::SetLatencyMarkerImpl(uint64_t frameID, NV_VULKAN_LATENCY_MARKER_TYPE marker) {
+        m_vkSetLatencyMarkerLegacyNV(m_device, frameID, marker);
+
+        return true;
+    }
+
+    void NvapiVulkanLowLatencyLegacyDevice::QueueNotifyOutOfBandImpl(VkQueue queue, NV_VULKAN_OUT_OF_BAND_QUEUE_TYPE queueType) {
+        m_vkQueueNotifyOutOfBandLegacyNV(queue, queueType);
+    }
 
     // NvapiVulkanLowLatency2LayerDevice
 

--- a/src/nvapi/nvapi_vulkan_low_latency_device.h
+++ b/src/nvapi/nvapi_vulkan_low_latency_device.h
@@ -1,10 +1,11 @@
 #pragma once
 
 #include "../nvapi_private.h"
-#include "./nvapi_resource_factory.h"
+#include "../shared/vk.h"
 
 namespace dxvk {
     enum class LowLatencyDeviceImplementation : uint8_t {
+        LowLatencyLegacy,
         LowLatency2,
         VkReflexFake
     };
@@ -41,6 +42,48 @@ namespace dxvk {
       private:
         LowLatencyDeviceImplementation m_implementation;
         PFN_vkDestroySemaphore m_vkDestroySemaphore;
+    };
+
+    class NvapiVulkanLowLatencyLegacyDevice final : public NvapiVulkanLowLatencyDevice {
+
+      public:
+        [[nodiscard]] static std::pair<std::unique_ptr<NvapiVulkanLowLatencyLegacyDevice>, VkResult> TryCreate(Vk* vk, VkDevice device);
+
+#define PFN_PARAM(proc) PFN_##proc proc
+        [[nodiscard]] explicit NvapiVulkanLowLatencyLegacyDevice(
+            VkDevice device,
+            VkSemaphore semaphore,
+            PFN_PARAM(vkDestroySemaphore),
+            PFN_PARAM(vkSetLatencySleepModeLegacyNV),
+            PFN_PARAM(vkLatencySleepLegacyNV),
+            PFN_PARAM(vkGetLatencyTimingsLegacyNV),
+            PFN_PARAM(vkSetLatencyMarkerLegacyNV),
+            PFN_PARAM(vkQueueNotifyOutOfBandLegacyNV),
+            PFN_PARAM(vkGetSleepStatusLegacyNV),
+            PFN_PARAM(vkShutdownLatencyDeviceLegacyNV));
+#undef PFN_PARAM
+
+        [[nodiscard]] NvBool GetLowLatencyModeImpl();
+        [[nodiscard]] VkResult SetLatencySleepModeImpl(std::nullptr_t);
+        [[nodiscard]] VkResult SetLatencySleepModeImpl(bool lowLatencyMode, bool lowLatencyBoost, uint32_t minimumIntervalUs);
+        [[nodiscard]] VkResult LatencySleepImpl(uint64_t value);
+        void GetLatencyTimingsImpl(std::span<NV_VULKAN_LATENCY_RESULT_PARAMS_V1::vkFrameReport, 64> frameReports);
+        [[nodiscard]] bool SetLatencyMarkerImpl(uint64_t frameID, NV_VULKAN_LATENCY_MARKER_TYPE marker);
+        void QueueNotifyOutOfBandImpl(VkQueue queue, NV_VULKAN_OUT_OF_BAND_QUEUE_TYPE queueType);
+
+        ~NvapiVulkanLowLatencyLegacyDevice() override { m_vkShutdownLatencyDeviceLegacyNV(m_device); }
+
+      private:
+#define PFN_MEMBER(proc) \
+    PFN_##proc m_##proc {}
+        PFN_MEMBER(vkSetLatencySleepModeLegacyNV);
+        PFN_MEMBER(vkLatencySleepLegacyNV);
+        PFN_MEMBER(vkGetLatencyTimingsLegacyNV);
+        PFN_MEMBER(vkSetLatencyMarkerLegacyNV);
+        PFN_MEMBER(vkQueueNotifyOutOfBandLegacyNV);
+        PFN_MEMBER(vkGetSleepStatusLegacyNV);
+        PFN_MEMBER(vkShutdownLatencyDeviceLegacyNV);
+#undef PFN_MEMBER
     };
 
     class NvapiVulkanLowLatency2LayerDevice final : public NvapiVulkanLowLatencyDevice {

--- a/src/nvapi/nvapi_vulkan_low_latency_device_factory.cpp
+++ b/src/nvapi/nvapi_vulkan_low_latency_device_factory.cpp
@@ -44,7 +44,10 @@ namespace dxvk {
         std::unique_ptr<NvapiVulkanLowLatencyDevice> lowLatencyDevice;
         VkResult vr;
 
-        std::tie(lowLatencyDevice, vr) = NvapiVulkanLowLatency2LayerDevice::TryCreate(m_vk.get(), device);
+        std::tie(lowLatencyDevice, vr) = NvapiVulkanLowLatencyLegacyDevice::TryCreate(m_vk.get(), device);
+
+        if (!lowLatencyDevice || vr != VK_SUCCESS)
+            std::tie(lowLatencyDevice, vr) = NvapiVulkanLowLatency2LayerDevice::TryCreate(m_vk.get(), device);
 
         if (!lowLatencyDevice || vr != VK_SUCCESS)
             std::tie(lowLatencyDevice, vr) = NvapiVulkanLowLatencyFakeDevice::TryCreate(m_vk.get(), device);

--- a/tests/mocks/vulkan_mocks.h
+++ b/tests/mocks/vulkan_mocks.h
@@ -19,6 +19,12 @@ class VkDeviceMock {
     MAKE_MOCK4(vkCreateSemaphore, VkResult(VkDevice, const VkSemaphoreCreateInfo*, const VkAllocationCallbacks*, VkSemaphore*));
     MAKE_MOCK3(vkDestroySemaphore, void(VkDevice, VkSemaphore, const VkAllocationCallbacks*));
     MAKE_MOCK2(vkSignalSemaphore, VkResult(VkDevice, const VkSemaphoreSignalInfo*));
+    MAKE_MOCK4(vkSetLatencySleepModeLegacyNV, void(VkDevice, VkBool32, VkBool32, uint32_t));
+    MAKE_MOCK3(vkLatencySleepLegacyNV, void(VkDevice, VkSemaphore, uint64_t));
+    MAKE_MOCK2(vkGetLatencyTimingsLegacyNV, void(VkDevice, void*));
+    MAKE_MOCK3(vkSetLatencyMarkerLegacyNV, void(VkDevice, uint64_t, uint32_t));
+    MAKE_MOCK2(vkGetSleepStatusLegacyNV, void(VkDevice, VkBool32*));
+    MAKE_MOCK1(vkShutdownLatencyDeviceLegacyNV, void(VkDevice));
     MAKE_MOCK3(vkSetLatencySleepModeNV, VkResult(VkDevice, VkSwapchainKHR, const VkLatencySleepModeInfoNV*));
     MAKE_MOCK3(vkLatencySleepNV, VkResult(VkDevice, VkSwapchainKHR, const VkLatencySleepInfoNV*));
     MAKE_MOCK3(vkGetLatencyTimingsNV, void(VkDevice, VkSwapchainKHR, VkGetLatencyMarkerInfoNV*));
@@ -32,6 +38,24 @@ class VkDeviceMock {
     }
     static VkResult SignalSemaphore(VkDevice device, const VkSemaphoreSignalInfo* pSignalInfo) {
         return reinterpret_cast<VkDeviceMock*>(device)->vkSignalSemaphore(device, pSignalInfo);
+    }
+    static void SetLatencySleepModeLegacyNV(VkDevice device, VkBool32 lowLatencyMode, VkBool32 lowLatencyBoost, uint32_t minimumIntervalUs) {
+        reinterpret_cast<VkDeviceMock*>(device)->vkSetLatencySleepModeLegacyNV(device, lowLatencyMode, lowLatencyBoost, minimumIntervalUs);
+    }
+    static void LatencySleepLegacyNV(VkDevice device, VkSemaphore signalSemaphore, uint64_t value) {
+        reinterpret_cast<VkDeviceMock*>(device)->vkLatencySleepLegacyNV(device, signalSemaphore, value);
+    }
+    static void GetLatencyTimingsLegacyNV(VkDevice device, void* pTimings) {
+        reinterpret_cast<VkDeviceMock*>(device)->vkGetLatencyTimingsLegacyNV(device, pTimings);
+    }
+    static void SetLatencyMarkerLegacyNV(VkDevice device, uint64_t frameID, uint32_t marker) {
+        reinterpret_cast<VkDeviceMock*>(device)->vkSetLatencyMarkerLegacyNV(device, frameID, marker);
+    }
+    static void GetSleepStatusLegacyNV(VkDevice device, VkBool32* pLowLatencyMode) {
+        reinterpret_cast<VkDeviceMock*>(device)->vkGetSleepStatusLegacyNV(device, pLowLatencyMode);
+    }
+    static void ShutdownLatencyDeviceLegacyNV(VkDevice device) {
+        reinterpret_cast<VkDeviceMock*>(device)->vkShutdownLatencyDeviceLegacyNV(device);
     }
     static VkResult SetLatencySleepModeNV(VkDevice device, VkSwapchainKHR swapchain, const VkLatencySleepModeInfoNV* pSleepModeInfo) {
         return reinterpret_cast<VkDeviceMock*>(device)->vkSetLatencySleepModeNV(device, swapchain, pSleepModeInfo);
@@ -56,8 +80,12 @@ class VkPhysicalDeviceMock {
 };
 
 class VkQueueMock {
+    MAKE_MOCK2(vkQueueNotifyOutOfBandLegacyNV, void(VkQueue, uint32_t));
     MAKE_MOCK2(vkQueueNotifyOutOfBandNV, void(VkQueue, const VkOutOfBandQueueTypeInfoNV*));
 
+    static void QueueNotifyOutOfBandLegacyNV(VkQueue queue, uint32_t queueType) {
+        reinterpret_cast<VkQueueMock*>(queue)->vkQueueNotifyOutOfBandLegacyNV(queue, queueType);
+    }
     static void QueueNotifyOutOfBandNV(VkQueue queue, const VkOutOfBandQueueTypeInfoNV* pQueueTypeInfo) {
         reinterpret_cast<VkQueueMock*>(queue)->vkQueueNotifyOutOfBandNV(queue, pQueueTypeInfo);
     }
@@ -86,10 +114,44 @@ class VkMock final : public mock_interface<dxvk::Vk> {
                 .RETURN(reinterpret_cast<PFN_vkVoidFunction>(khr ? VkDeviceMock::SignalSemaphore : nullptr))};
     }
 
-    [[nodiscard]] static std::array<std::unique_ptr<expectation>, 6> ConfigureLL2PFN(VkMock& mock) {
+    [[nodiscard]] static std::array<std::unique_ptr<expectation>, 8> ConfigureLLLegacyPFN(VkMock& mock) {
         return {
             NAMED_ALLOW_CALL(mock, GetDeviceProcAddr(_, eq(std::string_view("vkSignalSemaphore"))))
                 .RETURN(reinterpret_cast<PFN_vkVoidFunction>(VkDeviceMock::SignalSemaphore)),
+            NAMED_ALLOW_CALL(mock, GetDeviceProcAddr(_, eq(std::string_view("vkSetLatencySleepModeLegacyNV"))))
+                .RETURN(reinterpret_cast<PFN_vkVoidFunction>(VkDeviceMock::SetLatencySleepModeLegacyNV)),
+            NAMED_ALLOW_CALL(mock, GetDeviceProcAddr(_, eq(std::string_view("vkLatencySleepLegacyNV"))))
+                .RETURN(reinterpret_cast<PFN_vkVoidFunction>(VkDeviceMock::LatencySleepLegacyNV)),
+            NAMED_ALLOW_CALL(mock, GetDeviceProcAddr(_, eq(std::string_view("vkGetLatencyTimingsLegacyNV"))))
+                .RETURN(reinterpret_cast<PFN_vkVoidFunction>(VkDeviceMock::GetLatencyTimingsLegacyNV)),
+            NAMED_ALLOW_CALL(mock, GetDeviceProcAddr(_, eq(std::string_view("vkSetLatencyMarkerLegacyNV"))))
+                .RETURN(reinterpret_cast<PFN_vkVoidFunction>(VkDeviceMock::SetLatencyMarkerLegacyNV)),
+            NAMED_ALLOW_CALL(mock, GetDeviceProcAddr(_, eq(std::string_view("vkQueueNotifyOutOfBandLegacyNV"))))
+                .RETURN(reinterpret_cast<PFN_vkVoidFunction>(VkQueueMock::QueueNotifyOutOfBandLegacyNV)),
+            NAMED_ALLOW_CALL(mock, GetDeviceProcAddr(_, eq(std::string_view("vkGetSleepStatusLegacyNV"))))
+                .RETURN(reinterpret_cast<PFN_vkVoidFunction>(VkDeviceMock::GetSleepStatusLegacyNV)),
+            NAMED_ALLOW_CALL(mock, GetDeviceProcAddr(_, eq(std::string_view("vkShutdownLatencyDeviceLegacyNV"))))
+                .RETURN(reinterpret_cast<PFN_vkVoidFunction>(VkDeviceMock::ShutdownLatencyDeviceLegacyNV))};
+    }
+
+    [[nodiscard]] static std::array<std::unique_ptr<expectation>, 13> ConfigureLL2PFN(VkMock& mock) {
+        return {
+            NAMED_ALLOW_CALL(mock, GetDeviceProcAddr(_, eq(std::string_view("vkSignalSemaphore"))))
+                .RETURN(reinterpret_cast<PFN_vkVoidFunction>(VkDeviceMock::SignalSemaphore)),
+            NAMED_ALLOW_CALL(mock, GetDeviceProcAddr(_, eq(std::string_view("vkSetLatencySleepModeLegacyNV"))))
+                .RETURN(nullptr),
+            NAMED_ALLOW_CALL(mock, GetDeviceProcAddr(_, eq(std::string_view("vkLatencySleepLegacyNV"))))
+                .RETURN(nullptr),
+            NAMED_ALLOW_CALL(mock, GetDeviceProcAddr(_, eq(std::string_view("vkGetLatencyTimingsLegacyNV"))))
+                .RETURN(nullptr),
+            NAMED_ALLOW_CALL(mock, GetDeviceProcAddr(_, eq(std::string_view("vkSetLatencyMarkerLegacyNV"))))
+                .RETURN(nullptr),
+            NAMED_ALLOW_CALL(mock, GetDeviceProcAddr(_, eq(std::string_view("vkQueueNotifyOutOfBandLegacyNV"))))
+                .RETURN(nullptr),
+            NAMED_ALLOW_CALL(mock, GetDeviceProcAddr(_, eq(std::string_view("vkGetSleepStatusLegacyNV"))))
+                .RETURN(nullptr),
+            NAMED_ALLOW_CALL(mock, GetDeviceProcAddr(_, eq(std::string_view("vkShutdownLatencyDeviceLegacyNV"))))
+                .RETURN(nullptr),
             NAMED_ALLOW_CALL(mock, GetDeviceProcAddr(_, eq(std::string_view("vkSetLatencySleepModeNV"))))
                 .RETURN(reinterpret_cast<PFN_vkVoidFunction>(VkDeviceMock::SetLatencySleepModeNV)),
             NAMED_ALLOW_CALL(mock, GetDeviceProcAddr(_, eq(std::string_view("vkLatencySleepNV"))))

--- a/tests/nvapi_vulkan.cpp
+++ b/tests/nvapi_vulkan.cpp
@@ -173,6 +173,199 @@ TEST_CASE("Vulkan methods succeed", "[.vulkan]") {
 
             REQUIRE(NvAPI_Vulkan_DestroyLowLatencyDevice(vkDevice.get()) == NVAPI_OK);
         }
+
+        SECTION("Uses LowLatencyLegacy over LowLatency2Layer if both are available") {
+            auto vkSemaphore = reinterpret_cast<VkSemaphore>(0x12345678);
+            auto vkDevice = std::make_unique<VkDeviceMock>();
+
+            ALLOW_CALL(*t->Vk(), GetDeviceProcAddr(_, eq(std::string_view("vkSetLatencySleepModeNV"))))
+                .RETURN(reinterpret_cast<PFN_vkVoidFunction>(VkDeviceMock::SetLatencySleepModeNV));
+            ALLOW_CALL(*t->Vk(), GetDeviceProcAddr(_, eq(std::string_view("vkLatencySleepNV"))))
+                .RETURN(reinterpret_cast<PFN_vkVoidFunction>(VkDeviceMock::LatencySleepNV));
+            ALLOW_CALL(*t->Vk(), GetDeviceProcAddr(_, eq(std::string_view("vkGetLatencyTimingsNV"))))
+                .RETURN(reinterpret_cast<PFN_vkVoidFunction>(VkDeviceMock::GetLatencyTimingsNV));
+            ALLOW_CALL(*t->Vk(), GetDeviceProcAddr(_, eq(std::string_view("vkSetLatencyMarkerNV"))))
+                .RETURN(reinterpret_cast<PFN_vkVoidFunction>(VkDeviceMock::SetLatencyMarkerNV));
+            ALLOW_CALL(*t->Vk(), GetDeviceProcAddr(_, eq(std::string_view("vkQueueNotifyOutOfBandNV"))))
+                .RETURN(reinterpret_cast<PFN_vkVoidFunction>(VkQueueMock::QueueNotifyOutOfBandNV));
+
+            REQUIRE_CALL(*vkDevice, vkCreateSemaphore(_, _, _, _))
+                .LR_SIDE_EFFECT(*_4 = vkSemaphore)
+                .RETURN(VK_SUCCESS);
+
+            HANDLE signalSemaphoreHandle = VK_NULL_HANDLE;
+            REQUIRE(NvAPI_Vulkan_InitLowLatencyDevice(vkDevice.get(), &signalSemaphoreHandle) == NVAPI_OK);
+            REQUIRE(signalSemaphoreHandle == vkSemaphore);
+
+            REQUIRE_CALL(*vkDevice, vkSetLatencySleepModeLegacyNV(_, _, _, _))
+                .WITH(_2 == VK_TRUE && _3 == VK_FALSE && _4 == 16666);
+            FORBID_CALL(*vkDevice, vkSetLatencySleepModeNV(_, _, _));
+
+            NV_VULKAN_SET_SLEEP_MODE_PARAMS setSleepModeParams;
+            setSleepModeParams.version = NV_VULKAN_SET_SLEEP_MODE_PARAMS_VER1;
+            setSleepModeParams.bLowLatencyMode = true;
+            setSleepModeParams.bLowLatencyBoost = false;
+            setSleepModeParams.minimumIntervalUs = 16666;
+            REQUIRE(NvAPI_Vulkan_SetSleepMode(vkDevice.get(), &setSleepModeParams) == NVAPI_OK);
+
+            REQUIRE_CALL(*vkDevice, vkShutdownLatencyDeviceLegacyNV(_));
+            REQUIRE_CALL(*vkDevice, vkDestroySemaphore(_, _, _));
+
+            REQUIRE(NvAPI_Vulkan_DestroyLowLatencyDevice(vkDevice.get()) == NVAPI_OK);
+        }
+
+        SECTION("Other entrypoints succeed") {
+            auto vkDevice = std::make_unique<VkDeviceMock>();
+            auto vkQueue = std::make_unique<VkQueueMock>();
+            HANDLE signalSemaphoreHandle = VK_NULL_HANDLE;
+
+            ALLOW_CALL(*vkDevice, vkCreateSemaphore(_, _, _, _))
+                .RETURN(VK_SUCCESS);
+            ALLOW_CALL(*vkDevice, vkDestroySemaphore(_, _, _));
+            ALLOW_CALL(*vkDevice, vkShutdownLatencyDeviceLegacyNV(_));
+
+            SECTION("SetSleepMode / GetSleepStatus returns OK") {
+                REQUIRE(NvAPI_Vulkan_InitLowLatencyDevice(vkDevice.get(), &signalSemaphoreHandle) == NVAPI_OK);
+
+                REQUIRE_CALL(*vkDevice, vkSetLatencySleepModeLegacyNV(_, _, _, _))
+                    .WITH(_2 == VK_TRUE && _3 == VK_FALSE && _4 == 16666);
+
+                NV_VULKAN_SET_SLEEP_MODE_PARAMS setSleepModeParams;
+                setSleepModeParams.version = NV_VULKAN_SET_SLEEP_MODE_PARAMS_VER1;
+                setSleepModeParams.bLowLatencyMode = true;
+                setSleepModeParams.bLowLatencyBoost = false;
+                setSleepModeParams.minimumIntervalUs = 16666;
+                REQUIRE(NvAPI_Vulkan_SetSleepMode(vkDevice.get(), &setSleepModeParams) == NVAPI_OK);
+
+                REQUIRE_CALL(*vkDevice, vkGetSleepStatusLegacyNV(_, _))
+                    .SIDE_EFFECT(*_2 = VK_TRUE);
+
+                NV_VULKAN_GET_SLEEP_STATUS_PARAMS getSleepStatusParams{};
+                getSleepStatusParams.version = NV_VULKAN_GET_SLEEP_STATUS_PARAMS_VER1;
+                REQUIRE(NvAPI_Vulkan_GetSleepStatus(vkDevice.get(), &getSleepStatusParams) == NVAPI_OK);
+                REQUIRE(getSleepStatusParams.bLowLatencyMode == NV_TRUE);
+
+                REQUIRE(NvAPI_Vulkan_DestroyLowLatencyDevice(vkDevice.get()) == NVAPI_OK);
+            }
+
+            SECTION("GetSleepStatus with unknown struct version returns incompatible-struct-version") {
+                NV_VULKAN_GET_SLEEP_STATUS_PARAMS params;
+                params.version = NV_VULKAN_GET_SLEEP_STATUS_PARAMS_VER1 + 1;
+                REQUIRE(NvAPI_Vulkan_GetSleepStatus(vkDevice.get(), &params) == NVAPI_INCOMPATIBLE_STRUCT_VERSION);
+            }
+
+            SECTION("GetSleepStatus with current struct version returns not incompatible-struct-version") {
+                // This test should fail when a header update provides a newer not yet implemented struct version
+                NV_VULKAN_GET_SLEEP_STATUS_PARAMS params;
+                params.version = NV_VULKAN_GET_SLEEP_STATUS_PARAMS_VER;
+                REQUIRE(NvAPI_Vulkan_GetSleepStatus(vkDevice.get(), &params) != NVAPI_INCOMPATIBLE_STRUCT_VERSION);
+            }
+
+            SECTION("SetSleepMode with unknown struct version returns incompatible-struct-version") {
+                NV_VULKAN_SET_SLEEP_MODE_PARAMS params;
+                params.version = NV_VULKAN_SET_SLEEP_MODE_PARAMS_VER1 + 1;
+                REQUIRE(NvAPI_Vulkan_SetSleepMode(vkDevice.get(), &params) == NVAPI_INCOMPATIBLE_STRUCT_VERSION);
+            }
+
+            SECTION("SetSleepMode with current struct version returns not incompatible-struct-version") {
+                // This test should fail when a header update provides a newer not yet implemented struct version
+                NV_VULKAN_SET_SLEEP_MODE_PARAMS params;
+                params.version = NV_VULKAN_SET_SLEEP_MODE_PARAMS_VER;
+                REQUIRE(NvAPI_Vulkan_SetSleepMode(vkDevice.get(), &params) != NVAPI_INCOMPATIBLE_STRUCT_VERSION);
+            }
+
+            SECTION("Sleep returns OK") {
+                auto signal = 1365ULL;
+
+                REQUIRE_CALL(*vkDevice, vkLatencySleepLegacyNV(_, _, _))
+                    .WITH(_3 == signal);
+
+                REQUIRE(NvAPI_Vulkan_InitLowLatencyDevice(vkDevice.get(), &signalSemaphoreHandle) == NVAPI_OK);
+                REQUIRE(NvAPI_Vulkan_Sleep(vkDevice.get(), signal) == NVAPI_OK);
+                REQUIRE(NvAPI_Vulkan_DestroyLowLatencyDevice(vkDevice.get()) == NVAPI_OK);
+            }
+
+            SECTION("GetLatency returns OK") {
+                REQUIRE_CALL(*vkDevice, vkGetLatencyTimingsLegacyNV(_, _))
+                    .SIDE_EFFECT({
+                        auto* fr = static_cast<NV_VULKAN_LATENCY_RESULT_PARAMS::vkFrameReport*>(_2);
+                        fr[0].frameID = 5;
+                        fr[0].inputSampleTime = 8;
+                        fr[1].frameID = 6;
+                        fr[1].inputSampleTime = 7;
+                    });
+
+                REQUIRE(NvAPI_Vulkan_InitLowLatencyDevice(vkDevice.get(), &signalSemaphoreHandle) == NVAPI_OK);
+
+                NV_VULKAN_LATENCY_RESULT_PARAMS params{};
+                params.version = NV_VULKAN_LATENCY_RESULT_PARAMS_VER1;
+                REQUIRE(NvAPI_Vulkan_GetLatency(vkDevice.get(), &params) == NVAPI_OK);
+                REQUIRE(params.frameReport[0].frameID == 5);
+                REQUIRE(params.frameReport[0].inputSampleTime == 8);
+                REQUIRE(params.frameReport[1].frameID == 6);
+                REQUIRE(params.frameReport[1].inputSampleTime == 7);
+
+                REQUIRE(NvAPI_Vulkan_DestroyLowLatencyDevice(vkDevice.get()) == NVAPI_OK);
+            }
+
+            SECTION("GetLatency with unknown struct version returns incompatible-struct-version") {
+                NV_VULKAN_LATENCY_RESULT_PARAMS params;
+                params.version = NV_VULKAN_LATENCY_RESULT_PARAMS_VER1 + 1;
+                REQUIRE(NvAPI_Vulkan_GetLatency(vkDevice.get(), &params) == NVAPI_INCOMPATIBLE_STRUCT_VERSION);
+            }
+
+            SECTION("GetLatency with current struct version returns not incompatible-struct-version") {
+                // This test should fail when a header update provides a newer not yet implemented struct version
+                NV_VULKAN_LATENCY_RESULT_PARAMS params;
+                params.version = NV_VULKAN_LATENCY_RESULT_PARAMS_VER;
+                REQUIRE(NvAPI_Vulkan_GetLatency(vkDevice.get(), &params) != NVAPI_INCOMPATIBLE_STRUCT_VERSION);
+            }
+
+            SECTION("SetLatencyMarker returns OK") {
+                sequence seq1, seq2;
+                REQUIRE_CALL(*vkDevice, vkSetLatencyMarkerLegacyNV(_, _, _))
+                    .IN_SEQUENCE(seq1)
+                    .WITH(_2 == 4 && _3 == VULKAN_PRESENT_START);
+                REQUIRE_CALL(*vkDevice, vkSetLatencyMarkerLegacyNV(_, _, _))
+                    .IN_SEQUENCE(seq2)
+                    .WITH(_2 == 4 && _3 == static_cast<NV_VULKAN_LATENCY_MARKER_TYPE>(15));
+
+                REQUIRE(NvAPI_Vulkan_InitLowLatencyDevice(vkDevice.get(), &signalSemaphoreHandle) == NVAPI_OK);
+
+                NV_VULKAN_LATENCY_MARKER_PARAMS params;
+                params.version = NV_VULKAN_LATENCY_MARKER_PARAMS_VER1;
+                params.frameID = 4;
+                params.markerType = VULKAN_PRESENT_START;
+                REQUIRE(NvAPI_Vulkan_SetLatencyMarker(vkDevice.get(), &params) == NVAPI_OK);
+
+                params.markerType = static_cast<NV_VULKAN_LATENCY_MARKER_TYPE>(15);
+                REQUIRE(NvAPI_Vulkan_SetLatencyMarker(vkDevice.get(), &params) == NVAPI_OK);
+
+                REQUIRE(NvAPI_Vulkan_DestroyLowLatencyDevice(vkDevice.get()) == NVAPI_OK);
+            }
+
+            SECTION("SetLatencyMarker with unknown struct version returns incompatible-struct-version") {
+                NV_VULKAN_LATENCY_MARKER_PARAMS params;
+                params.version = NV_VULKAN_LATENCY_MARKER_PARAMS_VER1 + 1;
+                REQUIRE(NvAPI_Vulkan_SetLatencyMarker(vkDevice.get(), &params) == NVAPI_INCOMPATIBLE_STRUCT_VERSION);
+            }
+
+            SECTION("SetLatencyMarker with current struct version returns not incompatible-struct-version") {
+                // This test should fail when a header update provides a newer not yet implemented struct version
+                NV_VULKAN_LATENCY_MARKER_PARAMS params;
+                params.version = NV_VULKAN_LATENCY_MARKER_PARAMS_VER;
+                REQUIRE(NvAPI_Vulkan_SetLatencyMarker(vkDevice.get(), &params) != NVAPI_INCOMPATIBLE_STRUCT_VERSION);
+            }
+
+            SECTION("NotifyOutOfBandVkQueue returns OK") {
+                REQUIRE_CALL(*vkQueue, vkQueueNotifyOutOfBandLegacyNV(_, _))
+                    .WITH(_2 == VULKAN_OUT_OF_BAND_QUEUE_TYPE_PRESENT);
+
+                REQUIRE(NvAPI_Vulkan_InitLowLatencyDevice(vkDevice.get(), &signalSemaphoreHandle) == NVAPI_OK);
+                REQUIRE(NvAPI_Vulkan_NotifyOutOfBandVkQueue(vkDevice.get(), vkQueue.get(), VULKAN_OUT_OF_BAND_QUEUE_TYPE_PRESENT) == NVAPI_OK);
+                REQUIRE(NvAPI_Vulkan_DestroyLowLatencyDevice(vkDevice.get()) == NVAPI_OK);
+            }
+        }
     }
 
     SECTION("VkReflex with LowLatency2Layer") {

--- a/tests/nvapi_vulkan.cpp
+++ b/tests/nvapi_vulkan.cpp
@@ -151,6 +151,62 @@ TEST_CASE("Vulkan methods succeed", "[.vulkan]") {
         REQUIRE(NvAPI_Vulkan_InitLowLatencyDevice(vkDevice.get(), reinterpret_cast<HANDLE*>(&result)) == NVAPI_NOT_SUPPORTED);
     }
 
+    SECTION("VkReflex shared") {
+        auto vkDevice = std::make_unique<VkDeviceMock>();
+
+        SECTION("GetSleepStatus with unknown struct version returns incompatible-struct-version") {
+            NV_VULKAN_GET_SLEEP_STATUS_PARAMS params;
+            params.version = NV_VULKAN_GET_SLEEP_STATUS_PARAMS_VER1 + 1;
+            REQUIRE(NvAPI_Vulkan_GetSleepStatus(vkDevice.get(), &params) == NVAPI_INCOMPATIBLE_STRUCT_VERSION);
+        }
+
+        SECTION("GetSleepStatus with current struct version returns not incompatible-struct-version") {
+            // This test should fail when a header update provides a newer not yet implemented struct version
+            NV_VULKAN_GET_SLEEP_STATUS_PARAMS params;
+            params.version = NV_VULKAN_GET_SLEEP_STATUS_PARAMS_VER;
+            REQUIRE(NvAPI_Vulkan_GetSleepStatus(vkDevice.get(), &params) != NVAPI_INCOMPATIBLE_STRUCT_VERSION);
+        }
+
+        SECTION("SetSleepMode with unknown struct version returns incompatible-struct-version") {
+            NV_VULKAN_SET_SLEEP_MODE_PARAMS params;
+            params.version = NV_VULKAN_SET_SLEEP_MODE_PARAMS_VER1 + 1;
+            REQUIRE(NvAPI_Vulkan_SetSleepMode(vkDevice.get(), &params) == NVAPI_INCOMPATIBLE_STRUCT_VERSION);
+        }
+
+        SECTION("SetSleepMode with current struct version returns not incompatible-struct-version") {
+            // This test should fail when a header update provides a newer not yet implemented struct version
+            NV_VULKAN_SET_SLEEP_MODE_PARAMS params;
+            params.version = NV_VULKAN_SET_SLEEP_MODE_PARAMS_VER;
+            REQUIRE(NvAPI_Vulkan_SetSleepMode(vkDevice.get(), &params) != NVAPI_INCOMPATIBLE_STRUCT_VERSION);
+        }
+
+        SECTION("GetLatency with unknown struct version returns incompatible-struct-version") {
+            NV_VULKAN_LATENCY_RESULT_PARAMS params;
+            params.version = NV_VULKAN_LATENCY_RESULT_PARAMS_VER1 + 1;
+            REQUIRE(NvAPI_Vulkan_GetLatency(vkDevice.get(), &params) == NVAPI_INCOMPATIBLE_STRUCT_VERSION);
+        }
+
+        SECTION("GetLatency with current struct version returns not incompatible-struct-version") {
+            // This test should fail when a header update provides a newer not yet implemented struct version
+            NV_VULKAN_LATENCY_RESULT_PARAMS params;
+            params.version = NV_VULKAN_LATENCY_RESULT_PARAMS_VER;
+            REQUIRE(NvAPI_Vulkan_GetLatency(vkDevice.get(), &params) != NVAPI_INCOMPATIBLE_STRUCT_VERSION);
+        }
+
+        SECTION("SetLatencyMarker with unknown struct version returns incompatible-struct-version") {
+            NV_VULKAN_LATENCY_MARKER_PARAMS params;
+            params.version = NV_VULKAN_LATENCY_MARKER_PARAMS_VER1 + 1;
+            REQUIRE(NvAPI_Vulkan_SetLatencyMarker(vkDevice.get(), &params) == NVAPI_INCOMPATIBLE_STRUCT_VERSION);
+        }
+
+        SECTION("SetLatencyMarker with current struct version returns not incompatible-struct-version") {
+            // This test should fail when a header update provides a newer not yet implemented struct version
+            NV_VULKAN_LATENCY_MARKER_PARAMS params;
+            params.version = NV_VULKAN_LATENCY_MARKER_PARAMS_VER;
+            REQUIRE(NvAPI_Vulkan_SetLatencyMarker(vkDevice.get(), &params) != NVAPI_INCOMPATIBLE_STRUCT_VERSION);
+        }
+    }
+
     SECTION("VkReflex with LowLatencyLegacy") {
         ALLOW_CALL(*t->Vk(), IsAvailable()).RETURN(true);
         auto e1 = VkMock::ConfigureDefaultPFN(*t->Vk());
@@ -248,32 +304,6 @@ TEST_CASE("Vulkan methods succeed", "[.vulkan]") {
                 REQUIRE(NvAPI_Vulkan_DestroyLowLatencyDevice(vkDevice.get()) == NVAPI_OK);
             }
 
-            SECTION("GetSleepStatus with unknown struct version returns incompatible-struct-version") {
-                NV_VULKAN_GET_SLEEP_STATUS_PARAMS params;
-                params.version = NV_VULKAN_GET_SLEEP_STATUS_PARAMS_VER1 + 1;
-                REQUIRE(NvAPI_Vulkan_GetSleepStatus(vkDevice.get(), &params) == NVAPI_INCOMPATIBLE_STRUCT_VERSION);
-            }
-
-            SECTION("GetSleepStatus with current struct version returns not incompatible-struct-version") {
-                // This test should fail when a header update provides a newer not yet implemented struct version
-                NV_VULKAN_GET_SLEEP_STATUS_PARAMS params;
-                params.version = NV_VULKAN_GET_SLEEP_STATUS_PARAMS_VER;
-                REQUIRE(NvAPI_Vulkan_GetSleepStatus(vkDevice.get(), &params) != NVAPI_INCOMPATIBLE_STRUCT_VERSION);
-            }
-
-            SECTION("SetSleepMode with unknown struct version returns incompatible-struct-version") {
-                NV_VULKAN_SET_SLEEP_MODE_PARAMS params;
-                params.version = NV_VULKAN_SET_SLEEP_MODE_PARAMS_VER1 + 1;
-                REQUIRE(NvAPI_Vulkan_SetSleepMode(vkDevice.get(), &params) == NVAPI_INCOMPATIBLE_STRUCT_VERSION);
-            }
-
-            SECTION("SetSleepMode with current struct version returns not incompatible-struct-version") {
-                // This test should fail when a header update provides a newer not yet implemented struct version
-                NV_VULKAN_SET_SLEEP_MODE_PARAMS params;
-                params.version = NV_VULKAN_SET_SLEEP_MODE_PARAMS_VER;
-                REQUIRE(NvAPI_Vulkan_SetSleepMode(vkDevice.get(), &params) != NVAPI_INCOMPATIBLE_STRUCT_VERSION);
-            }
-
             SECTION("Sleep returns OK") {
                 auto signal = 1365ULL;
 
@@ -308,19 +338,6 @@ TEST_CASE("Vulkan methods succeed", "[.vulkan]") {
                 REQUIRE(NvAPI_Vulkan_DestroyLowLatencyDevice(vkDevice.get()) == NVAPI_OK);
             }
 
-            SECTION("GetLatency with unknown struct version returns incompatible-struct-version") {
-                NV_VULKAN_LATENCY_RESULT_PARAMS params;
-                params.version = NV_VULKAN_LATENCY_RESULT_PARAMS_VER1 + 1;
-                REQUIRE(NvAPI_Vulkan_GetLatency(vkDevice.get(), &params) == NVAPI_INCOMPATIBLE_STRUCT_VERSION);
-            }
-
-            SECTION("GetLatency with current struct version returns not incompatible-struct-version") {
-                // This test should fail when a header update provides a newer not yet implemented struct version
-                NV_VULKAN_LATENCY_RESULT_PARAMS params;
-                params.version = NV_VULKAN_LATENCY_RESULT_PARAMS_VER;
-                REQUIRE(NvAPI_Vulkan_GetLatency(vkDevice.get(), &params) != NVAPI_INCOMPATIBLE_STRUCT_VERSION);
-            }
-
             SECTION("SetLatencyMarker returns OK") {
                 sequence seq1, seq2;
                 REQUIRE_CALL(*vkDevice, vkSetLatencyMarkerLegacyNV(_, _, _))
@@ -342,19 +359,6 @@ TEST_CASE("Vulkan methods succeed", "[.vulkan]") {
                 REQUIRE(NvAPI_Vulkan_SetLatencyMarker(vkDevice.get(), &params) == NVAPI_OK);
 
                 REQUIRE(NvAPI_Vulkan_DestroyLowLatencyDevice(vkDevice.get()) == NVAPI_OK);
-            }
-
-            SECTION("SetLatencyMarker with unknown struct version returns incompatible-struct-version") {
-                NV_VULKAN_LATENCY_MARKER_PARAMS params;
-                params.version = NV_VULKAN_LATENCY_MARKER_PARAMS_VER1 + 1;
-                REQUIRE(NvAPI_Vulkan_SetLatencyMarker(vkDevice.get(), &params) == NVAPI_INCOMPATIBLE_STRUCT_VERSION);
-            }
-
-            SECTION("SetLatencyMarker with current struct version returns not incompatible-struct-version") {
-                // This test should fail when a header update provides a newer not yet implemented struct version
-                NV_VULKAN_LATENCY_MARKER_PARAMS params;
-                params.version = NV_VULKAN_LATENCY_MARKER_PARAMS_VER;
-                REQUIRE(NvAPI_Vulkan_SetLatencyMarker(vkDevice.get(), &params) != NVAPI_INCOMPATIBLE_STRUCT_VERSION);
             }
 
             SECTION("NotifyOutOfBandVkQueue returns OK") {
@@ -471,32 +475,6 @@ TEST_CASE("Vulkan methods succeed", "[.vulkan]") {
                 REQUIRE(NvAPI_Vulkan_DestroyLowLatencyDevice(vkDevice.get()) == NVAPI_OK);
             }
 
-            SECTION("GetSleepStatus with unknown struct version returns incompatible-struct-version") {
-                NV_VULKAN_GET_SLEEP_STATUS_PARAMS params;
-                params.version = NV_VULKAN_GET_SLEEP_STATUS_PARAMS_VER1 + 1;
-                REQUIRE(NvAPI_Vulkan_GetSleepStatus(vkDevice.get(), &params) == NVAPI_INCOMPATIBLE_STRUCT_VERSION);
-            }
-
-            SECTION("GetSleepStatus with current struct version returns not incompatible-struct-version") {
-                // This test should fail when a header update provides a newer not yet implemented struct version
-                NV_VULKAN_GET_SLEEP_STATUS_PARAMS params;
-                params.version = NV_VULKAN_GET_SLEEP_STATUS_PARAMS_VER;
-                REQUIRE(NvAPI_Vulkan_GetSleepStatus(vkDevice.get(), &params) != NVAPI_INCOMPATIBLE_STRUCT_VERSION);
-            }
-
-            SECTION("SetSleepMode with unknown struct version returns incompatible-struct-version") {
-                NV_VULKAN_SET_SLEEP_MODE_PARAMS params;
-                params.version = NV_VULKAN_SET_SLEEP_MODE_PARAMS_VER1 + 1;
-                REQUIRE(NvAPI_Vulkan_SetSleepMode(vkDevice.get(), &params) == NVAPI_INCOMPATIBLE_STRUCT_VERSION);
-            }
-
-            SECTION("SetSleepMode with current struct version returns not incompatible-struct-version") {
-                // This test should fail when a header update provides a newer not yet implemented struct version
-                NV_VULKAN_SET_SLEEP_MODE_PARAMS params;
-                params.version = NV_VULKAN_SET_SLEEP_MODE_PARAMS_VER;
-                REQUIRE(NvAPI_Vulkan_SetSleepMode(vkDevice.get(), &params) != NVAPI_INCOMPATIBLE_STRUCT_VERSION);
-            }
-
             SECTION("Sleep returns OK") {
                 auto signal = 1365ULL;
 
@@ -552,19 +530,6 @@ TEST_CASE("Vulkan methods succeed", "[.vulkan]") {
                 REQUIRE(NvAPI_Vulkan_DestroyLowLatencyDevice(vkDevice.get()) == NVAPI_OK);
             }
 
-            SECTION("GetLatency with unknown struct version returns incompatible-struct-version") {
-                NV_VULKAN_LATENCY_RESULT_PARAMS params;
-                params.version = NV_VULKAN_LATENCY_RESULT_PARAMS_VER1 + 1;
-                REQUIRE(NvAPI_Vulkan_GetLatency(vkDevice.get(), &params) == NVAPI_INCOMPATIBLE_STRUCT_VERSION);
-            }
-
-            SECTION("GetLatency with current struct version returns not incompatible-struct-version") {
-                // This test should fail when a header update provides a newer not yet implemented struct version
-                NV_VULKAN_LATENCY_RESULT_PARAMS params;
-                params.version = NV_VULKAN_LATENCY_RESULT_PARAMS_VER;
-                REQUIRE(NvAPI_Vulkan_GetLatency(vkDevice.get(), &params) != NVAPI_INCOMPATIBLE_STRUCT_VERSION);
-            }
-
             SECTION("SetLatencyMarker returns OK") {
                 REQUIRE_CALL(*vkDevice, vkSetLatencyMarkerNV(_, _, _))
                     .WITH(_3->marker == VK_LATENCY_MARKER_PRESENT_START_NV);
@@ -590,19 +555,6 @@ TEST_CASE("Vulkan methods succeed", "[.vulkan]") {
                 REQUIRE(NvAPI_Vulkan_SetLatencyMarker(vkDevice.get(), &params) == NVAPI_OK);
 
                 REQUIRE(NvAPI_Vulkan_DestroyLowLatencyDevice(vkDevice.get()) == NVAPI_OK);
-            }
-
-            SECTION("SetLatencyMarker with unknown struct version returns incompatible-struct-version") {
-                NV_VULKAN_LATENCY_MARKER_PARAMS params;
-                params.version = NV_VULKAN_LATENCY_MARKER_PARAMS_VER1 + 1;
-                REQUIRE(NvAPI_Vulkan_SetLatencyMarker(vkDevice.get(), &params) == NVAPI_INCOMPATIBLE_STRUCT_VERSION);
-            }
-
-            SECTION("SetLatencyMarker with current struct version returns not incompatible-struct-version") {
-                // This test should fail when a header update provides a newer not yet implemented struct version
-                NV_VULKAN_LATENCY_MARKER_PARAMS params;
-                params.version = NV_VULKAN_LATENCY_MARKER_PARAMS_VER;
-                REQUIRE(NvAPI_Vulkan_SetLatencyMarker(vkDevice.get(), &params) != NVAPI_INCOMPATIBLE_STRUCT_VERSION);
             }
 
             SECTION("NotifyOutOfBandVkQueue returns OK") {

--- a/tests/nvapi_vulkan.cpp
+++ b/tests/nvapi_vulkan.cpp
@@ -7,6 +7,21 @@ TEST_CASE("Vulkan methods succeed", "[.vulkan]") {
     auto t = std::make_unique<DefaultTestEnvironment>();
     auto e = t->ConfigureExpectations();
 
+    ALLOW_CALL(*t->Vk(), GetDeviceProcAddr(_, eq(std::string_view("vkSetLatencySleepModeLegacyNV"))))
+        .RETURN(nullptr);
+    ALLOW_CALL(*t->Vk(), GetDeviceProcAddr(_, eq(std::string_view("vkLatencySleepLegacyNV"))))
+        .RETURN(nullptr);
+    ALLOW_CALL(*t->Vk(), GetDeviceProcAddr(_, eq(std::string_view("vkGetLatencyTimingsLegacyNV"))))
+        .RETURN(nullptr);
+    ALLOW_CALL(*t->Vk(), GetDeviceProcAddr(_, eq(std::string_view("vkSetLatencyMarkerLegacyNV"))))
+        .RETURN(nullptr);
+    ALLOW_CALL(*t->Vk(), GetDeviceProcAddr(_, eq(std::string_view("vkQueueNotifyOutOfBandLegacyNV"))))
+        .RETURN(nullptr);
+    ALLOW_CALL(*t->Vk(), GetDeviceProcAddr(_, eq(std::string_view("vkGetSleepStatusLegacyNV"))))
+        .RETURN(nullptr);
+    ALLOW_CALL(*t->Vk(), GetDeviceProcAddr(_, eq(std::string_view("vkShutdownLatencyDeviceLegacyNV"))))
+        .RETURN(nullptr);
+
     SECTION("InitLowLatencyDevice fails to initialize when Vulkan is not available") {
         ALLOW_CALL(*t->Vk(), IsAvailable()).RETURN(false);
         FORBID_CALL(*t->Vk(), GetDeviceProcAddr(_, _));

--- a/tests/nvapi_vulkan.cpp
+++ b/tests/nvapi_vulkan.cpp
@@ -7,21 +7,6 @@ TEST_CASE("Vulkan methods succeed", "[.vulkan]") {
     auto t = std::make_unique<DefaultTestEnvironment>();
     auto e = t->ConfigureExpectations();
 
-    ALLOW_CALL(*t->Vk(), GetDeviceProcAddr(_, eq(std::string_view("vkSetLatencySleepModeLegacyNV"))))
-        .RETURN(nullptr);
-    ALLOW_CALL(*t->Vk(), GetDeviceProcAddr(_, eq(std::string_view("vkLatencySleepLegacyNV"))))
-        .RETURN(nullptr);
-    ALLOW_CALL(*t->Vk(), GetDeviceProcAddr(_, eq(std::string_view("vkGetLatencyTimingsLegacyNV"))))
-        .RETURN(nullptr);
-    ALLOW_CALL(*t->Vk(), GetDeviceProcAddr(_, eq(std::string_view("vkSetLatencyMarkerLegacyNV"))))
-        .RETURN(nullptr);
-    ALLOW_CALL(*t->Vk(), GetDeviceProcAddr(_, eq(std::string_view("vkQueueNotifyOutOfBandLegacyNV"))))
-        .RETURN(nullptr);
-    ALLOW_CALL(*t->Vk(), GetDeviceProcAddr(_, eq(std::string_view("vkGetSleepStatusLegacyNV"))))
-        .RETURN(nullptr);
-    ALLOW_CALL(*t->Vk(), GetDeviceProcAddr(_, eq(std::string_view("vkShutdownLatencyDeviceLegacyNV"))))
-        .RETURN(nullptr);
-
     SECTION("InitLowLatencyDevice fails to initialize when Vulkan is not available") {
         ALLOW_CALL(*t->Vk(), IsAvailable()).RETURN(false);
         FORBID_CALL(*t->Vk(), GetDeviceProcAddr(_, _));
@@ -31,11 +16,25 @@ TEST_CASE("Vulkan methods succeed", "[.vulkan]") {
         REQUIRE(NvAPI_Vulkan_InitLowLatencyDevice(vkDevice.get(), reinterpret_cast<HANDLE*>(&result)) == NVAPI_ERROR);
     }
 
-    SECTION("InitLowLatencyDevice fails to initialize when Vulkan Reflex layer is not available") {
+    SECTION("InitLowLatencyDevice fails to initialize when no Vulkan Reflex implementation is available") {
         ALLOW_CALL(*t->Vk(), IsAvailable()).RETURN(true);
         auto e1 = VkMock::ConfigureDefaultPFN(*t->Vk());
         auto e2 = VkMock::ConfigureSignalSemaphorePFN(*t->Vk(), GENERATE(false, true));
 
+        REQUIRE_CALL(*t->Vk(), GetDeviceProcAddr(_, eq(std::string_view("vkSetLatencySleepModeLegacyNV"))))
+            .RETURN(nullptr);
+        REQUIRE_CALL(*t->Vk(), GetDeviceProcAddr(_, eq(std::string_view("vkLatencySleepLegacyNV"))))
+            .RETURN(nullptr);
+        REQUIRE_CALL(*t->Vk(), GetDeviceProcAddr(_, eq(std::string_view("vkGetLatencyTimingsLegacyNV"))))
+            .RETURN(nullptr);
+        REQUIRE_CALL(*t->Vk(), GetDeviceProcAddr(_, eq(std::string_view("vkSetLatencyMarkerLegacyNV"))))
+            .RETURN(nullptr);
+        REQUIRE_CALL(*t->Vk(), GetDeviceProcAddr(_, eq(std::string_view("vkQueueNotifyOutOfBandLegacyNV"))))
+            .RETURN(nullptr);
+        REQUIRE_CALL(*t->Vk(), GetDeviceProcAddr(_, eq(std::string_view("vkGetSleepStatusLegacyNV"))))
+            .RETURN(nullptr);
+        REQUIRE_CALL(*t->Vk(), GetDeviceProcAddr(_, eq(std::string_view("vkShutdownLatencyDeviceLegacyNV"))))
+            .RETURN(nullptr);
         REQUIRE_CALL(*t->Vk(), GetDeviceProcAddr(_, eq(std::string_view("vkSetLatencySleepModeNV"))))
             .RETURN(nullptr);
         REQUIRE_CALL(*t->Vk(), GetDeviceProcAddr(_, eq(std::string_view("vkLatencySleepNV"))))
@@ -66,6 +65,20 @@ TEST_CASE("Vulkan methods succeed", "[.vulkan]") {
         auto e1 = VkMock::ConfigureDefaultPFN(*t->Vk());
         auto e2 = VkMock::ConfigureSignalSemaphorePFN(*t->Vk(), GENERATE(false, true));
 
+        REQUIRE_CALL(*t->Vk(), GetDeviceProcAddr(_, eq(std::string_view("vkSetLatencySleepModeLegacyNV"))))
+            .RETURN(nullptr);
+        REQUIRE_CALL(*t->Vk(), GetDeviceProcAddr(_, eq(std::string_view("vkLatencySleepLegacyNV"))))
+            .RETURN(nullptr);
+        REQUIRE_CALL(*t->Vk(), GetDeviceProcAddr(_, eq(std::string_view("vkGetLatencyTimingsLegacyNV"))))
+            .RETURN(nullptr);
+        REQUIRE_CALL(*t->Vk(), GetDeviceProcAddr(_, eq(std::string_view("vkSetLatencyMarkerLegacyNV"))))
+            .RETURN(nullptr);
+        REQUIRE_CALL(*t->Vk(), GetDeviceProcAddr(_, eq(std::string_view("vkQueueNotifyOutOfBandLegacyNV"))))
+            .RETURN(nullptr);
+        REQUIRE_CALL(*t->Vk(), GetDeviceProcAddr(_, eq(std::string_view("vkGetSleepStatusLegacyNV"))))
+            .RETURN(nullptr);
+        REQUIRE_CALL(*t->Vk(), GetDeviceProcAddr(_, eq(std::string_view("vkShutdownLatencyDeviceLegacyNV"))))
+            .RETURN(nullptr);
         REQUIRE_CALL(*t->Vk(), GetDeviceProcAddr(_, eq(std::string_view("vkSetLatencySleepModeNV"))))
             .RETURN(nullptr);
         REQUIRE_CALL(*t->Vk(), GetDeviceProcAddr(_, eq(std::string_view("vkLatencySleepNV"))))
@@ -99,11 +112,25 @@ TEST_CASE("Vulkan methods succeed", "[.vulkan]") {
         REQUIRE(NvAPI_Vulkan_DestroyLowLatencyDevice(vkDevice.get()) == NVAPI_OK);
     }
 
-    SECTION("InitLowLatencyDevice fails to initialize when Vulkan Reflex layer is not available and Reflex is needed but vkSignalSemaphore cannot be found") {
+    SECTION("InitLowLatencyDevice fails to initialize when no Vulkan Reflex implementation is available and Reflex is needed but vkSignalSemaphore cannot be found") {
         ::SetEnvironmentVariableA("DXVK_NVAPI_FAKE_VKREFLEX", "1");
         ALLOW_CALL(*t->Vk(), IsAvailable()).RETURN(true);
         auto e1 = VkMock::ConfigureDefaultPFN(*t->Vk());
 
+        REQUIRE_CALL(*t->Vk(), GetDeviceProcAddr(_, eq(std::string_view("vkSetLatencySleepModeLegacyNV"))))
+            .RETURN(nullptr);
+        REQUIRE_CALL(*t->Vk(), GetDeviceProcAddr(_, eq(std::string_view("vkLatencySleepLegacyNV"))))
+            .RETURN(nullptr);
+        REQUIRE_CALL(*t->Vk(), GetDeviceProcAddr(_, eq(std::string_view("vkGetLatencyTimingsLegacyNV"))))
+            .RETURN(nullptr);
+        REQUIRE_CALL(*t->Vk(), GetDeviceProcAddr(_, eq(std::string_view("vkSetLatencyMarkerLegacyNV"))))
+            .RETURN(nullptr);
+        REQUIRE_CALL(*t->Vk(), GetDeviceProcAddr(_, eq(std::string_view("vkQueueNotifyOutOfBandLegacyNV"))))
+            .RETURN(nullptr);
+        REQUIRE_CALL(*t->Vk(), GetDeviceProcAddr(_, eq(std::string_view("vkGetSleepStatusLegacyNV"))))
+            .RETURN(nullptr);
+        REQUIRE_CALL(*t->Vk(), GetDeviceProcAddr(_, eq(std::string_view("vkShutdownLatencyDeviceLegacyNV"))))
+            .RETURN(nullptr);
         REQUIRE_CALL(*t->Vk(), GetDeviceProcAddr(_, eq(std::string_view("vkSetLatencySleepModeNV"))))
             .RETURN(nullptr);
         REQUIRE_CALL(*t->Vk(), GetDeviceProcAddr(_, eq(std::string_view("vkLatencySleepNV"))))
@@ -124,252 +151,275 @@ TEST_CASE("Vulkan methods succeed", "[.vulkan]") {
         REQUIRE(NvAPI_Vulkan_InitLowLatencyDevice(vkDevice.get(), reinterpret_cast<HANDLE*>(&result)) == NVAPI_NOT_SUPPORTED);
     }
 
-    SECTION("InitLowLatencyDevice and DestroyLowLatencyDevice returns OK") {
+    SECTION("VkReflex with LowLatencyLegacy") {
         ALLOW_CALL(*t->Vk(), IsAvailable()).RETURN(true);
         auto e1 = VkMock::ConfigureDefaultPFN(*t->Vk());
-        auto e2 = VkMock::ConfigureLL2PFN(*t->Vk());
+        auto e2 = VkMock::ConfigureLLLegacyPFN(*t->Vk());
 
-        auto vkSemaphore = reinterpret_cast<VkSemaphore>(0x12345678);
-        auto vkDevice = std::make_unique<VkDeviceMock>();
+        SECTION("InitLowLatencyDevice and DestroyLowLatencyDevice returns OK") {
+            auto vkSemaphore = reinterpret_cast<VkSemaphore>(0x12345678);
+            auto vkDevice = std::make_unique<VkDeviceMock>();
 
-        REQUIRE_CALL(*vkDevice, vkCreateSemaphore(_, _, _, _))
-            .LR_SIDE_EFFECT(*_4 = vkSemaphore)
-            .RETURN(VK_SUCCESS);
-        REQUIRE_CALL(*vkDevice, vkDestroySemaphore(_, _, _));
+            REQUIRE_CALL(*vkDevice, vkCreateSemaphore(_, _, _, _))
+                .LR_SIDE_EFFECT(*_4 = vkSemaphore)
+                .RETURN(VK_SUCCESS);
 
-        HANDLE signalSemaphoreHandle = VK_NULL_HANDLE;
-        REQUIRE(NvAPI_Vulkan_InitLowLatencyDevice(vkDevice.get(), &signalSemaphoreHandle) == NVAPI_OK);
-        REQUIRE(signalSemaphoreHandle == vkSemaphore);
+            HANDLE signalSemaphoreHandle = VK_NULL_HANDLE;
+            REQUIRE(NvAPI_Vulkan_InitLowLatencyDevice(vkDevice.get(), &signalSemaphoreHandle) == NVAPI_OK);
+            REQUIRE(signalSemaphoreHandle == vkSemaphore);
 
-        REQUIRE(NvAPI_Vulkan_DestroyLowLatencyDevice(vkDevice.get()) == NVAPI_OK);
+            REQUIRE_CALL(*vkDevice, vkShutdownLatencyDeviceLegacyNV(_));
+            REQUIRE_CALL(*vkDevice, vkDestroySemaphore(_, _, _));
+
+            REQUIRE(NvAPI_Vulkan_DestroyLowLatencyDevice(vkDevice.get()) == NVAPI_OK);
+        }
     }
 
-    SECTION("Other entrypoints succeed") {
+    SECTION("VkReflex with LowLatency2Layer") {
         ALLOW_CALL(*t->Vk(), IsAvailable()).RETURN(true);
         auto e1 = VkMock::ConfigureDefaultPFN(*t->Vk());
         auto e2 = VkMock::ConfigureLL2PFN(*t->Vk());
 
-        auto vkDevice = std::make_unique<VkDeviceMock>();
-        auto vkQueue = std::make_unique<VkQueueMock>();
-        HANDLE signalSemaphoreHandle = VK_NULL_HANDLE;
+        SECTION("InitLowLatencyDevice and DestroyLowLatencyDevice returns OK") {
+            auto vkSemaphore = reinterpret_cast<VkSemaphore>(0x12345678);
+            auto vkDevice = std::make_unique<VkDeviceMock>();
 
-        ALLOW_CALL(*vkDevice, vkCreateSemaphore(_, _, _, _))
-            .RETURN(VK_SUCCESS);
-        ALLOW_CALL(*vkDevice, vkDestroySemaphore(_, _, _));
-
-        SECTION("SetSleepMode / GetSleepStatus returns OK") {
-            sequence seq1, seq2;
-
-            REQUIRE_CALL(*vkDevice, vkSetLatencySleepModeNV(_, _, _))
-                .IN_SEQUENCE(seq1)
-                .WITH(_3->lowLatencyMode == true && _3->lowLatencyBoost == true && _3->minimumIntervalUs == 4)
-                .RETURN(VK_SUCCESS);
-            REQUIRE_CALL(*vkDevice, vkSetLatencySleepModeNV(_, _, _))
-                .IN_SEQUENCE(seq2)
-                .WITH(_3->lowLatencyMode == false && _3->lowLatencyBoost == false)
+            REQUIRE_CALL(*vkDevice, vkCreateSemaphore(_, _, _, _))
+                .LR_SIDE_EFFECT(*_4 = vkSemaphore)
                 .RETURN(VK_SUCCESS);
 
+            HANDLE signalSemaphoreHandle = VK_NULL_HANDLE;
             REQUIRE(NvAPI_Vulkan_InitLowLatencyDevice(vkDevice.get(), &signalSemaphoreHandle) == NVAPI_OK);
+            REQUIRE(signalSemaphoreHandle == vkSemaphore);
 
-            NV_VULKAN_SET_SLEEP_MODE_PARAMS setSleepModeParams;
-            setSleepModeParams.version = NV_VULKAN_SET_SLEEP_MODE_PARAMS_VER1;
-            setSleepModeParams.bLowLatencyMode = true;
-            setSleepModeParams.bLowLatencyBoost = true;
-            setSleepModeParams.minimumIntervalUs = 4;
-            REQUIRE(NvAPI_Vulkan_SetSleepMode(vkDevice.get(), &setSleepModeParams) == NVAPI_OK);
-
-            NV_VULKAN_GET_SLEEP_STATUS_PARAMS getSleepStatusParams{};
-            getSleepStatusParams.version = NV_VULKAN_GET_SLEEP_STATUS_PARAMS_VER1;
-            REQUIRE(NvAPI_Vulkan_GetSleepStatus(vkDevice.get(), &getSleepStatusParams) == NVAPI_OK);
-            REQUIRE(getSleepStatusParams.bLowLatencyMode == true);
-
-            setSleepModeParams.bLowLatencyMode = false;
-            setSleepModeParams.bLowLatencyBoost = false;
-            REQUIRE(NvAPI_Vulkan_SetSleepMode(vkDevice.get(), &setSleepModeParams) == NVAPI_OK);
-
-            REQUIRE(NvAPI_Vulkan_GetSleepStatus(vkDevice.get(), &getSleepStatusParams) == NVAPI_OK);
-            REQUIRE_FALSE(getSleepStatusParams.bLowLatencyMode);
+            REQUIRE_CALL(*vkDevice, vkDestroySemaphore(_, _, _));
 
             REQUIRE(NvAPI_Vulkan_DestroyLowLatencyDevice(vkDevice.get()) == NVAPI_OK);
         }
 
-        SECTION("GetSleepStatus returns previous value if `vkSetLatencySleepModeNV` fails") {
-            sequence seq1, seq2;
+        SECTION("Other entrypoints succeed") {
+            auto vkDevice = std::make_unique<VkDeviceMock>();
+            auto vkQueue = std::make_unique<VkQueueMock>();
+            HANDLE signalSemaphoreHandle = VK_NULL_HANDLE;
 
-            REQUIRE_CALL(*vkDevice, vkSetLatencySleepModeNV(_, _, _))
-                .IN_SEQUENCE(seq1)
-                .WITH(_3->lowLatencyMode == true && _3->lowLatencyBoost == true && _3->minimumIntervalUs == 4)
+            ALLOW_CALL(*vkDevice, vkCreateSemaphore(_, _, _, _))
                 .RETURN(VK_SUCCESS);
-            REQUIRE_CALL(*vkDevice, vkSetLatencySleepModeNV(_, _, _))
-                .IN_SEQUENCE(seq2)
-                .WITH(_3->lowLatencyMode == false && _3->lowLatencyBoost == false)
-                .RETURN(VK_ERROR_UNKNOWN);
+            ALLOW_CALL(*vkDevice, vkDestroySemaphore(_, _, _));
 
-            REQUIRE(NvAPI_Vulkan_InitLowLatencyDevice(vkDevice.get(), &signalSemaphoreHandle) == NVAPI_OK);
+            SECTION("SetSleepMode / GetSleepStatus returns OK") {
+                sequence seq1, seq2;
 
-            NV_VULKAN_SET_SLEEP_MODE_PARAMS setSleepModeParams;
-            setSleepModeParams.version = NV_VULKAN_SET_SLEEP_MODE_PARAMS_VER1;
-            setSleepModeParams.bLowLatencyMode = true;
-            setSleepModeParams.bLowLatencyBoost = true;
-            setSleepModeParams.minimumIntervalUs = 4;
-            REQUIRE(NvAPI_Vulkan_SetSleepMode(vkDevice.get(), &setSleepModeParams) == NVAPI_OK);
+                REQUIRE_CALL(*vkDevice, vkSetLatencySleepModeNV(_, _, _))
+                    .IN_SEQUENCE(seq1)
+                    .WITH(_3->lowLatencyMode == true && _3->lowLatencyBoost == true && _3->minimumIntervalUs == 4)
+                    .RETURN(VK_SUCCESS);
+                REQUIRE_CALL(*vkDevice, vkSetLatencySleepModeNV(_, _, _))
+                    .IN_SEQUENCE(seq2)
+                    .WITH(_3->lowLatencyMode == false && _3->lowLatencyBoost == false)
+                    .RETURN(VK_SUCCESS);
 
-            NV_VULKAN_GET_SLEEP_STATUS_PARAMS getSleepStatusParams{};
-            getSleepStatusParams.version = NV_VULKAN_GET_SLEEP_STATUS_PARAMS_VER1;
-            REQUIRE(NvAPI_Vulkan_GetSleepStatus(vkDevice.get(), &getSleepStatusParams) == NVAPI_OK);
-            REQUIRE(getSleepStatusParams.bLowLatencyMode == true);
+                REQUIRE(NvAPI_Vulkan_InitLowLatencyDevice(vkDevice.get(), &signalSemaphoreHandle) == NVAPI_OK);
 
-            setSleepModeParams.bLowLatencyMode = false;
-            setSleepModeParams.bLowLatencyBoost = false;
-            REQUIRE(NvAPI_Vulkan_SetSleepMode(vkDevice.get(), &setSleepModeParams) == NVAPI_ERROR);
+                NV_VULKAN_SET_SLEEP_MODE_PARAMS setSleepModeParams;
+                setSleepModeParams.version = NV_VULKAN_SET_SLEEP_MODE_PARAMS_VER1;
+                setSleepModeParams.bLowLatencyMode = true;
+                setSleepModeParams.bLowLatencyBoost = true;
+                setSleepModeParams.minimumIntervalUs = 4;
+                REQUIRE(NvAPI_Vulkan_SetSleepMode(vkDevice.get(), &setSleepModeParams) == NVAPI_OK);
 
-            REQUIRE(NvAPI_Vulkan_GetSleepStatus(vkDevice.get(), &getSleepStatusParams) == NVAPI_OK);
-            REQUIRE(getSleepStatusParams.bLowLatencyMode == true);
+                NV_VULKAN_GET_SLEEP_STATUS_PARAMS getSleepStatusParams{};
+                getSleepStatusParams.version = NV_VULKAN_GET_SLEEP_STATUS_PARAMS_VER1;
+                REQUIRE(NvAPI_Vulkan_GetSleepStatus(vkDevice.get(), &getSleepStatusParams) == NVAPI_OK);
+                REQUIRE(getSleepStatusParams.bLowLatencyMode == true);
 
-            REQUIRE(NvAPI_Vulkan_DestroyLowLatencyDevice(vkDevice.get()) == NVAPI_OK);
-        }
+                setSleepModeParams.bLowLatencyMode = false;
+                setSleepModeParams.bLowLatencyBoost = false;
+                REQUIRE(NvAPI_Vulkan_SetSleepMode(vkDevice.get(), &setSleepModeParams) == NVAPI_OK);
 
-        SECTION("GetSleepStatus with unknown struct version returns incompatible-struct-version") {
-            NV_VULKAN_GET_SLEEP_STATUS_PARAMS params;
-            params.version = NV_VULKAN_GET_SLEEP_STATUS_PARAMS_VER1 + 1;
-            REQUIRE(NvAPI_Vulkan_GetSleepStatus(vkDevice.get(), &params) == NVAPI_INCOMPATIBLE_STRUCT_VERSION);
-        }
+                REQUIRE(NvAPI_Vulkan_GetSleepStatus(vkDevice.get(), &getSleepStatusParams) == NVAPI_OK);
+                REQUIRE_FALSE(getSleepStatusParams.bLowLatencyMode);
 
-        SECTION("GetSleepStatus with current struct version returns not incompatible-struct-version") {
-            // This test should fail when a header update provides a newer not yet implemented struct version
-            NV_VULKAN_GET_SLEEP_STATUS_PARAMS params;
-            params.version = NV_VULKAN_GET_SLEEP_STATUS_PARAMS_VER;
-            REQUIRE(NvAPI_Vulkan_GetSleepStatus(vkDevice.get(), &params) != NVAPI_INCOMPATIBLE_STRUCT_VERSION);
-        }
+                REQUIRE(NvAPI_Vulkan_DestroyLowLatencyDevice(vkDevice.get()) == NVAPI_OK);
+            }
 
-        SECTION("SetSleepMode with unknown struct version returns incompatible-struct-version") {
-            NV_VULKAN_SET_SLEEP_MODE_PARAMS params;
-            params.version = NV_VULKAN_SET_SLEEP_MODE_PARAMS_VER1 + 1;
-            REQUIRE(NvAPI_Vulkan_SetSleepMode(vkDevice.get(), &params) == NVAPI_INCOMPATIBLE_STRUCT_VERSION);
-        }
+            SECTION("GetSleepStatus returns previous value if `vkSetLatencySleepModeNV` fails") {
+                sequence seq1, seq2;
 
-        SECTION("SetSleepMode with current struct version returns not incompatible-struct-version") {
-            // This test should fail when a header update provides a newer not yet implemented struct version
-            NV_VULKAN_SET_SLEEP_MODE_PARAMS params;
-            params.version = NV_VULKAN_SET_SLEEP_MODE_PARAMS_VER;
-            REQUIRE(NvAPI_Vulkan_SetSleepMode(vkDevice.get(), &params) != NVAPI_INCOMPATIBLE_STRUCT_VERSION);
-        }
+                REQUIRE_CALL(*vkDevice, vkSetLatencySleepModeNV(_, _, _))
+                    .IN_SEQUENCE(seq1)
+                    .WITH(_3->lowLatencyMode == true && _3->lowLatencyBoost == true && _3->minimumIntervalUs == 4)
+                    .RETURN(VK_SUCCESS);
+                REQUIRE_CALL(*vkDevice, vkSetLatencySleepModeNV(_, _, _))
+                    .IN_SEQUENCE(seq2)
+                    .WITH(_3->lowLatencyMode == false && _3->lowLatencyBoost == false)
+                    .RETURN(VK_ERROR_UNKNOWN);
 
-        SECTION("Sleep returns OK") {
-            auto signal = 1365ULL;
+                REQUIRE(NvAPI_Vulkan_InitLowLatencyDevice(vkDevice.get(), &signalSemaphoreHandle) == NVAPI_OK);
 
-            REQUIRE_CALL(*vkDevice, vkLatencySleepNV(_, _, _))
-                .WITH(_3->value == signal)
-                .RETURN(VK_SUCCESS);
+                NV_VULKAN_SET_SLEEP_MODE_PARAMS setSleepModeParams;
+                setSleepModeParams.version = NV_VULKAN_SET_SLEEP_MODE_PARAMS_VER1;
+                setSleepModeParams.bLowLatencyMode = true;
+                setSleepModeParams.bLowLatencyBoost = true;
+                setSleepModeParams.minimumIntervalUs = 4;
+                REQUIRE(NvAPI_Vulkan_SetSleepMode(vkDevice.get(), &setSleepModeParams) == NVAPI_OK);
 
-            REQUIRE(NvAPI_Vulkan_InitLowLatencyDevice(vkDevice.get(), &signalSemaphoreHandle) == NVAPI_OK);
-            REQUIRE(NvAPI_Vulkan_Sleep(vkDevice.get(), signal) == NVAPI_OK);
-            REQUIRE(NvAPI_Vulkan_DestroyLowLatencyDevice(vkDevice.get()) == NVAPI_OK);
-        }
+                NV_VULKAN_GET_SLEEP_STATUS_PARAMS getSleepStatusParams{};
+                getSleepStatusParams.version = NV_VULKAN_GET_SLEEP_STATUS_PARAMS_VER1;
+                REQUIRE(NvAPI_Vulkan_GetSleepStatus(vkDevice.get(), &getSleepStatusParams) == NVAPI_OK);
+                REQUIRE(getSleepStatusParams.bLowLatencyMode == true);
 
-        SECTION("GetLatency returns OK") {
-            REQUIRE_CALL(*vkDevice, vkGetLatencyTimingsNV(_, _, _))
-                .SIDE_EFFECT({
-                    _3->timingCount = 64;
-                    _3->pTimings[0].presentID = 5;
-                    _3->pTimings[0].inputSampleTimeUs = 8;
-                    _3->pTimings[1].presentID = 6;
-                    _3->pTimings[1].inputSampleTimeUs = 7;
-                });
+                setSleepModeParams.bLowLatencyMode = false;
+                setSleepModeParams.bLowLatencyBoost = false;
+                REQUIRE(NvAPI_Vulkan_SetSleepMode(vkDevice.get(), &setSleepModeParams) == NVAPI_ERROR);
 
-            REQUIRE(NvAPI_Vulkan_InitLowLatencyDevice(vkDevice.get(), &signalSemaphoreHandle) == NVAPI_OK);
+                REQUIRE(NvAPI_Vulkan_GetSleepStatus(vkDevice.get(), &getSleepStatusParams) == NVAPI_OK);
+                REQUIRE(getSleepStatusParams.bLowLatencyMode == true);
 
-            NV_VULKAN_LATENCY_RESULT_PARAMS params{};
-            params.version = NV_VULKAN_LATENCY_RESULT_PARAMS_VER1;
-            REQUIRE(NvAPI_Vulkan_GetLatency(vkDevice.get(), &params) == NVAPI_OK);
-            REQUIRE(params.frameReport[0].frameID == 5);
-            REQUIRE(params.frameReport[0].inputSampleTime == 8);
-            REQUIRE(params.frameReport[1].frameID == 6);
-            REQUIRE(params.frameReport[1].inputSampleTime == 7);
+                REQUIRE(NvAPI_Vulkan_DestroyLowLatencyDevice(vkDevice.get()) == NVAPI_OK);
+            }
 
-            REQUIRE(NvAPI_Vulkan_DestroyLowLatencyDevice(vkDevice.get()) == NVAPI_OK);
-        }
+            SECTION("GetSleepStatus with unknown struct version returns incompatible-struct-version") {
+                NV_VULKAN_GET_SLEEP_STATUS_PARAMS params;
+                params.version = NV_VULKAN_GET_SLEEP_STATUS_PARAMS_VER1 + 1;
+                REQUIRE(NvAPI_Vulkan_GetSleepStatus(vkDevice.get(), &params) == NVAPI_INCOMPATIBLE_STRUCT_VERSION);
+            }
 
-        SECTION("GetLatency with other than 64 reports clears timings returns OK") {
-            REQUIRE_CALL(*vkDevice, vkGetLatencyTimingsNV(_, _, _))
-                .SIDE_EFFECT({
-                    _3->timingCount = 1;
-                    _3->pTimings[0].presentID = 5;
-                });
+            SECTION("GetSleepStatus with current struct version returns not incompatible-struct-version") {
+                // This test should fail when a header update provides a newer not yet implemented struct version
+                NV_VULKAN_GET_SLEEP_STATUS_PARAMS params;
+                params.version = NV_VULKAN_GET_SLEEP_STATUS_PARAMS_VER;
+                REQUIRE(NvAPI_Vulkan_GetSleepStatus(vkDevice.get(), &params) != NVAPI_INCOMPATIBLE_STRUCT_VERSION);
+            }
 
-            REQUIRE(NvAPI_Vulkan_InitLowLatencyDevice(vkDevice.get(), &signalSemaphoreHandle) == NVAPI_OK);
+            SECTION("SetSleepMode with unknown struct version returns incompatible-struct-version") {
+                NV_VULKAN_SET_SLEEP_MODE_PARAMS params;
+                params.version = NV_VULKAN_SET_SLEEP_MODE_PARAMS_VER1 + 1;
+                REQUIRE(NvAPI_Vulkan_SetSleepMode(vkDevice.get(), &params) == NVAPI_INCOMPATIBLE_STRUCT_VERSION);
+            }
 
-            NV_VULKAN_LATENCY_RESULT_PARAMS params{};
-            params.version = NV_VULKAN_LATENCY_RESULT_PARAMS_VER1;
-            for (auto i = 0U; i < 64; i++)
-                params.frameReport[i].frameID = std::numeric_limits<uint32_t>::max();
-            REQUIRE(NvAPI_Vulkan_GetLatency(vkDevice.get(), &params) == NVAPI_OK);
-            for (auto i = 0U; i < 64; i++)
-                REQUIRE(params.frameReport[i].frameID == 0);
+            SECTION("SetSleepMode with current struct version returns not incompatible-struct-version") {
+                // This test should fail when a header update provides a newer not yet implemented struct version
+                NV_VULKAN_SET_SLEEP_MODE_PARAMS params;
+                params.version = NV_VULKAN_SET_SLEEP_MODE_PARAMS_VER;
+                REQUIRE(NvAPI_Vulkan_SetSleepMode(vkDevice.get(), &params) != NVAPI_INCOMPATIBLE_STRUCT_VERSION);
+            }
 
-            REQUIRE(NvAPI_Vulkan_DestroyLowLatencyDevice(vkDevice.get()) == NVAPI_OK);
-        }
+            SECTION("Sleep returns OK") {
+                auto signal = 1365ULL;
 
-        SECTION("GetLatency with unknown struct version returns incompatible-struct-version") {
-            NV_VULKAN_LATENCY_RESULT_PARAMS params;
-            params.version = NV_VULKAN_LATENCY_RESULT_PARAMS_VER1 + 1;
-            REQUIRE(NvAPI_Vulkan_GetLatency(vkDevice.get(), &params) == NVAPI_INCOMPATIBLE_STRUCT_VERSION);
-        }
+                REQUIRE_CALL(*vkDevice, vkLatencySleepNV(_, _, _))
+                    .WITH(_3->value == signal)
+                    .RETURN(VK_SUCCESS);
 
-        SECTION("GetLatency with current struct version returns not incompatible-struct-version") {
-            // This test should fail when a header update provides a newer not yet implemented struct version
-            NV_VULKAN_LATENCY_RESULT_PARAMS params;
-            params.version = NV_VULKAN_LATENCY_RESULT_PARAMS_VER;
-            REQUIRE(NvAPI_Vulkan_GetLatency(vkDevice.get(), &params) != NVAPI_INCOMPATIBLE_STRUCT_VERSION);
-        }
+                REQUIRE(NvAPI_Vulkan_InitLowLatencyDevice(vkDevice.get(), &signalSemaphoreHandle) == NVAPI_OK);
+                REQUIRE(NvAPI_Vulkan_Sleep(vkDevice.get(), signal) == NVAPI_OK);
+                REQUIRE(NvAPI_Vulkan_DestroyLowLatencyDevice(vkDevice.get()) == NVAPI_OK);
+            }
 
-        SECTION("SetLatencyMarker returns OK") {
-            REQUIRE_CALL(*vkDevice, vkSetLatencyMarkerNV(_, _, _))
-                .WITH(_3->marker == VK_LATENCY_MARKER_PRESENT_START_NV);
+            SECTION("GetLatency returns OK") {
+                REQUIRE_CALL(*vkDevice, vkGetLatencyTimingsNV(_, _, _))
+                    .SIDE_EFFECT({
+                        _3->timingCount = 64;
+                        _3->pTimings[0].presentID = 5;
+                        _3->pTimings[0].inputSampleTimeUs = 8;
+                        _3->pTimings[1].presentID = 6;
+                        _3->pTimings[1].inputSampleTimeUs = 7;
+                    });
 
-            REQUIRE(NvAPI_Vulkan_InitLowLatencyDevice(vkDevice.get(), &signalSemaphoreHandle) == NVAPI_OK);
+                REQUIRE(NvAPI_Vulkan_InitLowLatencyDevice(vkDevice.get(), &signalSemaphoreHandle) == NVAPI_OK);
 
-            NV_VULKAN_LATENCY_MARKER_PARAMS params;
-            params.version = NV_VULKAN_LATENCY_MARKER_PARAMS_VER1;
-            params.markerType = VULKAN_PRESENT_START;
-            REQUIRE(NvAPI_Vulkan_SetLatencyMarker(vkDevice.get(), &params) == NVAPI_OK);
+                NV_VULKAN_LATENCY_RESULT_PARAMS params{};
+                params.version = NV_VULKAN_LATENCY_RESULT_PARAMS_VER1;
+                REQUIRE(NvAPI_Vulkan_GetLatency(vkDevice.get(), &params) == NVAPI_OK);
+                REQUIRE(params.frameReport[0].frameID == 5);
+                REQUIRE(params.frameReport[0].inputSampleTime == 8);
+                REQUIRE(params.frameReport[1].frameID == 6);
+                REQUIRE(params.frameReport[1].inputSampleTime == 7);
 
-            REQUIRE(NvAPI_Vulkan_DestroyLowLatencyDevice(vkDevice.get()) == NVAPI_OK);
-        }
+                REQUIRE(NvAPI_Vulkan_DestroyLowLatencyDevice(vkDevice.get()) == NVAPI_OK);
+            }
 
-        SECTION("SetLatencyMarker drops unknown marker types and returns OK") {
-            FORBID_CALL(*vkDevice, vkSetLatencyMarkerNV(_, _, _));
+            SECTION("GetLatency with other than 64 reports clears timings returns OK") {
+                REQUIRE_CALL(*vkDevice, vkGetLatencyTimingsNV(_, _, _))
+                    .SIDE_EFFECT({
+                        _3->timingCount = 1;
+                        _3->pTimings[0].presentID = 5;
+                    });
 
-            REQUIRE(NvAPI_Vulkan_InitLowLatencyDevice(vkDevice.get(), &signalSemaphoreHandle) == NVAPI_OK);
+                REQUIRE(NvAPI_Vulkan_InitLowLatencyDevice(vkDevice.get(), &signalSemaphoreHandle) == NVAPI_OK);
 
-            NV_VULKAN_LATENCY_MARKER_PARAMS params;
-            params.version = NV_VULKAN_LATENCY_MARKER_PARAMS_VER1;
-            params.markerType = static_cast<NV_VULKAN_LATENCY_MARKER_TYPE>(15);
-            REQUIRE(NvAPI_Vulkan_SetLatencyMarker(vkDevice.get(), &params) == NVAPI_OK);
+                NV_VULKAN_LATENCY_RESULT_PARAMS params{};
+                params.version = NV_VULKAN_LATENCY_RESULT_PARAMS_VER1;
+                for (auto i = 0U; i < 64; i++)
+                    params.frameReport[i].frameID = std::numeric_limits<uint32_t>::max();
+                REQUIRE(NvAPI_Vulkan_GetLatency(vkDevice.get(), &params) == NVAPI_OK);
+                for (auto i = 0U; i < 64; i++)
+                    REQUIRE(params.frameReport[i].frameID == 0);
 
-            REQUIRE(NvAPI_Vulkan_DestroyLowLatencyDevice(vkDevice.get()) == NVAPI_OK);
-        }
+                REQUIRE(NvAPI_Vulkan_DestroyLowLatencyDevice(vkDevice.get()) == NVAPI_OK);
+            }
 
-        SECTION("SetLatencyMarker with unknown struct version returns incompatible-struct-version") {
-            NV_VULKAN_LATENCY_MARKER_PARAMS params;
-            params.version = NV_VULKAN_LATENCY_MARKER_PARAMS_VER1 + 1;
-            REQUIRE(NvAPI_Vulkan_SetLatencyMarker(vkDevice.get(), &params) == NVAPI_INCOMPATIBLE_STRUCT_VERSION);
-        }
+            SECTION("GetLatency with unknown struct version returns incompatible-struct-version") {
+                NV_VULKAN_LATENCY_RESULT_PARAMS params;
+                params.version = NV_VULKAN_LATENCY_RESULT_PARAMS_VER1 + 1;
+                REQUIRE(NvAPI_Vulkan_GetLatency(vkDevice.get(), &params) == NVAPI_INCOMPATIBLE_STRUCT_VERSION);
+            }
 
-        SECTION("SetLatencyMarker with current struct version returns not incompatible-struct-version") {
-            // This test should fail when a header update provides a newer not yet implemented struct version
-            NV_VULKAN_LATENCY_MARKER_PARAMS params;
-            params.version = NV_VULKAN_LATENCY_MARKER_PARAMS_VER;
-            REQUIRE(NvAPI_Vulkan_SetLatencyMarker(vkDevice.get(), &params) != NVAPI_INCOMPATIBLE_STRUCT_VERSION);
-        }
+            SECTION("GetLatency with current struct version returns not incompatible-struct-version") {
+                // This test should fail when a header update provides a newer not yet implemented struct version
+                NV_VULKAN_LATENCY_RESULT_PARAMS params;
+                params.version = NV_VULKAN_LATENCY_RESULT_PARAMS_VER;
+                REQUIRE(NvAPI_Vulkan_GetLatency(vkDevice.get(), &params) != NVAPI_INCOMPATIBLE_STRUCT_VERSION);
+            }
 
-        SECTION("NotifyOutOfBandVkQueue returns OK") {
-            REQUIRE_CALL(*vkQueue, vkQueueNotifyOutOfBandNV(_, _))
-                .WITH(_2->queueType == VK_OUT_OF_BAND_QUEUE_TYPE_PRESENT_NV);
+            SECTION("SetLatencyMarker returns OK") {
+                REQUIRE_CALL(*vkDevice, vkSetLatencyMarkerNV(_, _, _))
+                    .WITH(_3->marker == VK_LATENCY_MARKER_PRESENT_START_NV);
 
-            REQUIRE(NvAPI_Vulkan_InitLowLatencyDevice(vkDevice.get(), &signalSemaphoreHandle) == NVAPI_OK);
-            REQUIRE(NvAPI_Vulkan_NotifyOutOfBandVkQueue(vkDevice.get(), vkQueue.get(), VULKAN_OUT_OF_BAND_QUEUE_TYPE_PRESENT) == NVAPI_OK);
-            REQUIRE(NvAPI_Vulkan_DestroyLowLatencyDevice(vkDevice.get()) == NVAPI_OK);
+                REQUIRE(NvAPI_Vulkan_InitLowLatencyDevice(vkDevice.get(), &signalSemaphoreHandle) == NVAPI_OK);
+
+                NV_VULKAN_LATENCY_MARKER_PARAMS params;
+                params.version = NV_VULKAN_LATENCY_MARKER_PARAMS_VER1;
+                params.markerType = VULKAN_PRESENT_START;
+                REQUIRE(NvAPI_Vulkan_SetLatencyMarker(vkDevice.get(), &params) == NVAPI_OK);
+
+                REQUIRE(NvAPI_Vulkan_DestroyLowLatencyDevice(vkDevice.get()) == NVAPI_OK);
+            }
+
+            SECTION("SetLatencyMarker drops unknown marker types and returns OK") {
+                FORBID_CALL(*vkDevice, vkSetLatencyMarkerNV(_, _, _));
+
+                REQUIRE(NvAPI_Vulkan_InitLowLatencyDevice(vkDevice.get(), &signalSemaphoreHandle) == NVAPI_OK);
+
+                NV_VULKAN_LATENCY_MARKER_PARAMS params;
+                params.version = NV_VULKAN_LATENCY_MARKER_PARAMS_VER1;
+                params.markerType = static_cast<NV_VULKAN_LATENCY_MARKER_TYPE>(15);
+                REQUIRE(NvAPI_Vulkan_SetLatencyMarker(vkDevice.get(), &params) == NVAPI_OK);
+
+                REQUIRE(NvAPI_Vulkan_DestroyLowLatencyDevice(vkDevice.get()) == NVAPI_OK);
+            }
+
+            SECTION("SetLatencyMarker with unknown struct version returns incompatible-struct-version") {
+                NV_VULKAN_LATENCY_MARKER_PARAMS params;
+                params.version = NV_VULKAN_LATENCY_MARKER_PARAMS_VER1 + 1;
+                REQUIRE(NvAPI_Vulkan_SetLatencyMarker(vkDevice.get(), &params) == NVAPI_INCOMPATIBLE_STRUCT_VERSION);
+            }
+
+            SECTION("SetLatencyMarker with current struct version returns not incompatible-struct-version") {
+                // This test should fail when a header update provides a newer not yet implemented struct version
+                NV_VULKAN_LATENCY_MARKER_PARAMS params;
+                params.version = NV_VULKAN_LATENCY_MARKER_PARAMS_VER;
+                REQUIRE(NvAPI_Vulkan_SetLatencyMarker(vkDevice.get(), &params) != NVAPI_INCOMPATIBLE_STRUCT_VERSION);
+            }
+
+            SECTION("NotifyOutOfBandVkQueue returns OK") {
+                REQUIRE_CALL(*vkQueue, vkQueueNotifyOutOfBandNV(_, _))
+                    .WITH(_2->queueType == VK_OUT_OF_BAND_QUEUE_TYPE_PRESENT_NV);
+
+                REQUIRE(NvAPI_Vulkan_InitLowLatencyDevice(vkDevice.get(), &signalSemaphoreHandle) == NVAPI_OK);
+                REQUIRE(NvAPI_Vulkan_NotifyOutOfBandVkQueue(vkDevice.get(), vkQueue.get(), VULKAN_OUT_OF_BAND_QUEUE_TYPE_PRESENT) == NVAPI_OK);
+                REQUIRE(NvAPI_Vulkan_DestroyLowLatencyDevice(vkDevice.get()) == NVAPI_OK);
+            }
         }
     }
 }


### PR DESCRIPTION
Should make the layer obsolete on sufficiently new drivers and winevulkan…

TODO: add more tests