### PR TITLE
nvapi-d3d12: Correct m_nvapiDeviceMap invalidation

### DIFF
--- a/src/nvapi/nvapi_d3d12_command_queue.cpp
+++ b/src/nvapi/nvapi_d3d12_command_queue.cpp
@@ -11,15 +11,20 @@ namespace dxvk {
     }
 
     NvapiD3d12CommandQueue* NvapiD3d12CommandQueue::GetOrCreate(ID3D12CommandQueue* commandQueue) {
-        std::scoped_lock lock{m_mutex};
-
-        auto itF = m_nvapiDeviceMap.find(commandQueue);
-        if (itF != m_nvapiDeviceMap.end())
-            return &itF->second;
-
+        // Same non-owning-key hazard as NvapiD3d12GraphicsCommandList::GetOrCreate; see there.
         Com<ID3D12CommandQueueExt> commandQueueExt;
         if (FAILED(commandQueue->QueryInterface(IID_PPV_ARGS(&commandQueueExt))))
             return nullptr;
+
+        std::scoped_lock lock{m_mutex};
+
+        auto itF = m_nvapiDeviceMap.find(commandQueue);
+        if (itF != m_nvapiDeviceMap.end()) {
+            if (itF->second.m_vkd3dCommandQueue == commandQueueExt.ptr())
+                return &itF->second;
+
+            m_nvapiDeviceMap.erase(itF);
+        }
 
         auto [itI, inserted] = m_nvapiDeviceMap.emplace(
             std::piecewise_construct,

--- a/src/nvapi/nvapi_d3d12_graphics_command_list.cpp
+++ b/src/nvapi/nvapi_d3d12_graphics_command_list.cpp
@@ -13,15 +13,19 @@ namespace dxvk {
     }
 
     NvapiD3d12GraphicsCommandList* NvapiD3d12GraphicsCommandList::GetOrCreate(ID3D12GraphicsCommandList* commandList) {
-        std::scoped_lock lock{m_mutex};
-
-        auto itF = m_nvapiDeviceMap.find(commandList);
-        if (itF != m_nvapiDeviceMap.end())
-            return &itF->second;
-
         Com<ID3D12GraphicsCommandListExt> commandListExt;
         if (FAILED(commandList->QueryInterface(IID_PPV_ARGS(&commandListExt))))
             return nullptr;
+
+        std::scoped_lock lock{m_mutex};
+
+        auto itF = m_nvapiDeviceMap.find(commandList);
+        if (itF != m_nvapiDeviceMap.end()) {
+            if (itF->second.m_vkd3dGraphicsCommandList == commandListExt.ptr())
+                return &itF->second;
+
+            m_nvapiDeviceMap.erase(itF);
+        }
 
         auto [itI, inserted] = m_nvapiDeviceMap.emplace(
             std::piecewise_construct,


### PR DESCRIPTION
This PR fixes a crash related to ReShade. 

My understanding of what happened before is:
1. The application calls and ReShade intercepts `CreateCommandList`, grabs the real `NvapiD3d12GraphicsCommandList*` and returns a proxy to the application.
2. `m_nvapiDeviceMap` ends up mapping the proxy object's address to the real object pointer. 
3. The game drops the proxy object, which also drops the real object. But the entry remains in `m_nvapiDeviceMap`.
4. Eventually ReShade creates a new proxy object that happens to be on the same address as the earlier dropped one, but which wraps a different command list.
5. The next time `m_nvapiDeviceMap` is accessed, it yields the old `NvapiD3d12GraphicsCommandList*` that was actually freed. Dereferencing it for a vtable finally results in a crash.

The fix is to tighten the cache logic a bit. It moves the QueryInterface up as well, but I believe this should be fine since the expensive part is `probeInterfaceChain`, `GetDevice`, etc. 

This has indeed fixed my crashes in Cyberpunk 2077 and Kingdom Come: Deliverance II when using ReShade + RenoDX DLSS5 addon.

Thanks.