### PR TITLE
Store D3D12 wrappers in private data

### DIFF
--- a/src/nvapi/nvapi_adapter_registry.cpp
+++ b/src/nvapi/nvapi_adapter_registry.cpp
@@ -1,6 +1,8 @@
 #include "nvapi_adapter_registry.h"
 #include "nvapi_d3d11_device.h"
 #include "nvapi_d3d12_device.h"
+#include "nvapi_d3d12_command_queue.h"
+#include "nvapi_d3d12_graphics_command_list.h"
 #include "nvapi_d3d_low_latency_device.h"
 #include "nvapi_vulkan_low_latency_device_factory.h"
 #include "../util/util_log.h"
@@ -13,6 +15,8 @@ namespace dxvk {
     NvapiAdapterRegistry::~NvapiAdapterRegistry() {
         NvapiD3d11Device::Reset();
         NvapiD3d12Device::Reset();
+        NvapiD3d12CommandQueue::Reset();
+        NvapiD3d12GraphicsCommandList::Reset();
         NvapiD3dLowLatencyDevice::Reset();
         NvapiVulkanLowLatencyDeviceFactory::Reset();
 

--- a/src/nvapi/nvapi_d3d12_command_queue.cpp
+++ b/src/nvapi/nvapi_d3d12_command_queue.cpp
@@ -2,34 +2,45 @@
 #include "../util/com_pointer.h"
 
 namespace dxvk {
-    std::unordered_map<ID3D12CommandQueue*, NvapiD3d12CommandQueue> NvapiD3d12CommandQueue::m_nvapiDeviceMap;
+    std::atomic<LONGLONG> NvapiD3d12CommandQueue::m_resetTimestamp;
     std::mutex NvapiD3d12CommandQueue::m_mutex;
 
     void NvapiD3d12CommandQueue::Reset() {
-        std::scoped_lock lock{m_mutex};
-        m_nvapiDeviceMap.clear();
+        LARGE_INTEGER count;
+        QueryPerformanceCounter(&count);
+        m_resetTimestamp.store(count.QuadPart, std::memory_order_release);
     }
 
-    NvapiD3d12CommandQueue* NvapiD3d12CommandQueue::GetOrCreate(ID3D12CommandQueue* commandQueue) {
+    std::optional<NvapiD3d12CommandQueue> NvapiD3d12CommandQueue::GetOrCreate(ID3D12CommandQueue* commandQueue) {
+        static constexpr GUID NvapiD3d12CommandQueueGuid = {0x3579ec19, 0x2741, 0x488a, {0xbb, 0x39, 0x5c, 0x03, 0xcd, 0x89, 0x5e, 0x2a}};
+
+        NvapiD3d12CommandQueue nvapiCommandQueue{nullptr};
+        UINT size = sizeof(nvapiCommandQueue);
+
+        auto result = commandQueue->GetPrivateData(NvapiD3d12CommandQueueGuid, &size, &nvapiCommandQueue);
+        if (SUCCEEDED(result) && size == sizeof(nvapiCommandQueue) && nvapiCommandQueue.m_creationTimestamp > m_resetTimestamp.load(std::memory_order_acquire))
+            return nvapiCommandQueue;
+
+        size = sizeof(nvapiCommandQueue);
         std::scoped_lock lock{m_mutex};
 
-        auto itF = m_nvapiDeviceMap.find(commandQueue);
-        if (itF != m_nvapiDeviceMap.end())
-            return &itF->second;
+        result = commandQueue->GetPrivateData(NvapiD3d12CommandQueueGuid, &size, &nvapiCommandQueue);
+        if (SUCCEEDED(result) && size == sizeof(nvapiCommandQueue) && nvapiCommandQueue.m_creationTimestamp > m_resetTimestamp.load(std::memory_order_acquire))
+            return nvapiCommandQueue;
 
         Com<ID3D12CommandQueueExt> commandQueueExt;
         if (FAILED(commandQueue->QueryInterface(IID_PPV_ARGS(&commandQueueExt))))
-            return nullptr;
+            return std::nullopt;
 
-        auto [itI, inserted] = m_nvapiDeviceMap.emplace(
-            std::piecewise_construct,
-            std::forward_as_tuple(commandQueue),
-            std::forward_as_tuple(commandQueueExt.ptr()));
+        LARGE_INTEGER count;
+        QueryPerformanceCounter(&count);
 
-        if (!inserted)
-            return nullptr;
+        nvapiCommandQueue = NvapiD3d12CommandQueue{commandQueueExt.ptr()};
+        nvapiCommandQueue.m_creationTimestamp = count.QuadPart;
 
-        return &itI->second;
+        commandQueue->SetPrivateData(NvapiD3d12CommandQueueGuid, sizeof(nvapiCommandQueue), &nvapiCommandQueue);
+
+        return nvapiCommandQueue;
     }
 
     NvapiD3d12CommandQueue::NvapiD3d12CommandQueue(ID3D12CommandQueueExt* vkd3dCommandQueue)

--- a/src/nvapi/nvapi_d3d12_command_queue.h
+++ b/src/nvapi/nvapi_d3d12_command_queue.h
@@ -8,7 +8,7 @@ namespace dxvk {
 
       public:
         static void Reset();
-        [[nodiscard]] static NvapiD3d12CommandQueue* GetOrCreate(ID3D12CommandQueue* device);
+        [[nodiscard]] static NvapiD3d12CommandQueue* GetOrCreate(ID3D12CommandQueue* commandQueue);
 
         explicit NvapiD3d12CommandQueue(ID3D12CommandQueueExt* vkd3dCommandQueue);
 

--- a/src/nvapi/nvapi_d3d12_command_queue.h
+++ b/src/nvapi/nvapi_d3d12_command_queue.h
@@ -4,20 +4,21 @@
 #include "../interfaces/vkd3d-proton_interfaces.h"
 
 namespace dxvk {
-    class NvapiD3d12CommandQueue {
+    class NvapiD3d12CommandQueue final {
 
       public:
         static void Reset();
-        [[nodiscard]] static NvapiD3d12CommandQueue* GetOrCreate(ID3D12CommandQueue* commandQueue);
+        [[nodiscard]] static std::optional<NvapiD3d12CommandQueue> GetOrCreate(ID3D12CommandQueue* commandQueue);
 
         explicit NvapiD3d12CommandQueue(ID3D12CommandQueueExt* vkd3dCommandQueue);
 
         [[nodiscard]] HRESULT NotifyOutOfBandCommandQueue(D3D12_OUT_OF_BAND_CQ_TYPE type) const;
 
       private:
-        static std::unordered_map<ID3D12CommandQueue*, NvapiD3d12CommandQueue> m_nvapiDeviceMap;
+        static std::atomic<LONGLONG> m_resetTimestamp;
         static std::mutex m_mutex;
 
+        LONGLONG m_creationTimestamp{};
         ID3D12CommandQueueExt* m_vkd3dCommandQueue{};
     };
 }

--- a/src/nvapi/nvapi_d3d12_device.cpp
+++ b/src/nvapi/nvapi_d3d12_device.cpp
@@ -102,7 +102,8 @@ namespace dxvk {
 
         m_supportsNvxBinaryImport = vkd3dDevice->GetExtensionSupport(D3D12_VK_NVX_BINARY_IMPORT);
         m_supportsNvxImageViewHandle = vkd3dDevice->GetExtensionSupport(D3D12_VK_NVX_IMAGE_VIEW_HANDLE);
-        m_supportsOpacityMicromap = deviceExtTier >= 5 && vkd3dDevice->GetExtensionSupport(D3D12_VK_OPACITY_MICROMAP);
+        m_supportsGlobalPipelineStateFlags = deviceExtTier >= 5;
+        m_supportsOpacityMicromap = m_supportsGlobalPipelineStateFlags && vkd3dDevice->GetExtensionSupport(D3D12_VK_OPACITY_MICROMAP);
 
         if (deviceExtTier >= 2 && m_supportsNvxBinaryImport && m_supportsNvxImageViewHandle)
             m_supportsCubin64bit = m_vkd3dDevice->SupportsCubin64bit();
@@ -207,7 +208,7 @@ namespace dxvk {
     }
 
     bool NvapiD3d12Device::SetCreatePipelineStateFlagsNVAPI(D3D12_VK_EXT_PIPELINE_CREATION_STATE_FLAG pipeline_state_flags) {
-        return m_vkd3dDevice->SetCreatePipelineStateFlagsNVAPI(pipeline_state_flags);
+        return m_supportsGlobalPipelineStateFlags && m_vkd3dDevice->SetCreatePipelineStateFlagsNVAPI(pipeline_state_flags);
     }
 
     bool NvapiD3d12Device::IsOpacityMicromapSupported() const {

--- a/src/nvapi/nvapi_d3d12_device.cpp
+++ b/src/nvapi/nvapi_d3d12_device.cpp
@@ -2,7 +2,7 @@
 #include "../util/util_log.h"
 
 namespace dxvk {
-    std::unordered_map<ID3D12Device*, NvapiD3d12Device> NvapiD3d12Device::m_nvapiDeviceMap;
+    std::atomic<LONGLONG> NvapiD3d12Device::m_resetTimestamp;
     std::mutex NvapiD3d12Device::m_mutex;
 
     std::unordered_map<NVDX_ObjectHandle, NvU32> NvapiD3d12Device::m_cubinSmemMap;
@@ -12,7 +12,9 @@ namespace dxvk {
 
     void NvapiD3d12Device::Reset() {
         std::scoped_lock lock{m_mutex, m_cubinSmemMutex};
-        m_nvapiDeviceMap.clear();
+        LARGE_INTEGER count;
+        QueryPerformanceCounter(&count);
+        m_resetTimestamp.store(count.QuadPart, std::memory_order_release);
         m_cubinSmemMap.clear();
         m_cubin64bitSupportAvailable.reset();
     }
@@ -43,26 +45,36 @@ namespace dxvk {
         return m_cubin64bitSupportAvailable.emplace(false);
     }
 
-    NvapiD3d12Device* NvapiD3d12Device::GetOrCreate(ID3D12Device* device) {
+    std::optional<NvapiD3d12Device> NvapiD3d12Device::GetOrCreate(ID3D12Device* device) {
+        static constexpr GUID NvapiD3d12DeviceGuid = {0x0266efbf, 0x6dc7, 0x4017, {0xb4, 0x21, 0x3d, 0x93, 0xce, 0xd0, 0x90, 0x64}};
+
+        NvapiD3d12Device nvapiDevice{nullptr};
+        UINT size = sizeof(nvapiDevice);
+
+        auto result = device->GetPrivateData(NvapiD3d12DeviceGuid, &size, &nvapiDevice);
+        if (SUCCEEDED(result) && size == sizeof(nvapiDevice) && nvapiDevice.m_creationTimestamp > m_resetTimestamp.load(std::memory_order_acquire))
+            return nvapiDevice;
+
+        size = sizeof(nvapiDevice);
         std::scoped_lock lock{m_mutex};
 
-        auto itF = m_nvapiDeviceMap.find(device);
-        if (itF != m_nvapiDeviceMap.end())
-            return &itF->second;
+        result = device->GetPrivateData(NvapiD3d12DeviceGuid, &size, &nvapiDevice);
+        if (SUCCEEDED(result) && size == sizeof(nvapiDevice) && nvapiDevice.m_creationTimestamp > m_resetTimestamp.load(std::memory_order_acquire))
+            return nvapiDevice;
 
         Com<ID3D12DeviceExt> deviceExt;
         if (FAILED(device->QueryInterface(IID_PPV_ARGS(&deviceExt))))
-            return nullptr;
+            return std::nullopt;
 
-        auto [itI, inserted] = m_nvapiDeviceMap.emplace(
-            std::piecewise_construct,
-            std::forward_as_tuple(device),
-            std::forward_as_tuple(deviceExt.ptr()));
+        LARGE_INTEGER count;
+        QueryPerformanceCounter(&count);
 
-        if (!inserted)
-            return nullptr;
+        nvapiDevice = NvapiD3d12Device{deviceExt.ptr()};
+        nvapiDevice.m_creationTimestamp = count.QuadPart;
 
-        return &itI->second;
+        device->SetPrivateData(NvapiD3d12DeviceGuid, sizeof(nvapiDevice), &nvapiDevice);
+
+        return nvapiDevice;
     }
 
     uint32_t NvapiD3d12Device::FindCubinSmem(NVDX_ObjectHandle pShader) {
@@ -77,6 +89,9 @@ namespace dxvk {
 
     NvapiD3d12Device::NvapiD3d12Device(ID3D12DeviceExt* vkd3dDevice)
         : m_vkd3dDevice(static_cast<ID3D12DeviceExt5*>(vkd3dDevice)) { // NOLINT(*-pro-type-static-cast-downcast)
+        if (!vkd3dDevice)
+            return;
+
         uint32_t deviceExtTier = probeInterfaceChain(vkd3dDevice, {
                                                                       __uuidof(ID3D12DeviceExt1),
                                                                       __uuidof(ID3D12DeviceExt2),

--- a/src/nvapi/nvapi_d3d12_device.h
+++ b/src/nvapi/nvapi_d3d12_device.h
@@ -53,6 +53,7 @@ namespace dxvk {
         bool m_supportsNvShaderExtn = false;
         bool m_supportsNvxBinaryImport = false;
         bool m_supportsNvxImageViewHandle = false;
+        bool m_supportsGlobalPipelineStateFlags = false;
         bool m_supportsOpacityMicromap = false;
     };
 }

--- a/src/nvapi/nvapi_d3d12_device.h
+++ b/src/nvapi/nvapi_d3d12_device.h
@@ -10,15 +10,13 @@ namespace dxvk {
       public:
         static void Reset();
         [[nodiscard]] static bool Cubin64bitSupportAvailable(NvapiResourceFactory* factory, NvapiAdapterRegistry* registry);
-        [[nodiscard]] static NvapiD3d12Device* GetOrCreate(ID3D12Device* device);
+        [[nodiscard]] static std::optional<NvapiD3d12Device> GetOrCreate(ID3D12Device* device);
         [[nodiscard]] static uint32_t FindCubinSmem(NVDX_ObjectHandle);
 
         explicit NvapiD3d12Device(ID3D12DeviceExt* vkd3dDevice);
 
-        // Prevent default construction and copy semantics.
+        // Prevent default construction semantics.
         NvapiD3d12Device() = delete;
-        NvapiD3d12Device(const NvapiD3d12Device&) = delete;
-        NvapiD3d12Device& operator=(const NvapiD3d12Device&) = delete;
 
         [[nodiscard]] HRESULT CreateCubinComputeShaderWithName(const void* cubinData, NvU32 cubinSize, NvU32 blockX, NvU32 blockY, NvU32 blockZ, const char* shaderName, NVDX_ObjectHandle* pShader);
         [[nodiscard]] HRESULT CreateCubinComputeShaderEx(const void* cubinData, NvU32 cubinSize, NvU32 blockX, NvU32 blockY, NvU32 blockZ, NvU32 smemSize, const char* shaderName, NVDX_ObjectHandle* pShader);
@@ -41,7 +39,7 @@ namespace dxvk {
         [[nodiscard]] bool SetCreatePipelineStateFlagsNVAPI(D3D12_VK_EXT_PIPELINE_CREATION_STATE_FLAG pipeline_state_flags);
 
       private:
-        static std::unordered_map<ID3D12Device*, NvapiD3d12Device> m_nvapiDeviceMap;
+        static std::atomic<LONGLONG> m_resetTimestamp;
         static std::mutex m_mutex;
 
         static std::unordered_map<NVDX_ObjectHandle, NvU32> m_cubinSmemMap;
@@ -49,6 +47,7 @@ namespace dxvk {
 
         static std::optional<bool> m_cubin64bitSupportAvailable;
 
+        LONGLONG m_creationTimestamp{};
         ID3D12DeviceExt5* m_vkd3dDevice{};
         bool m_supportsCubin64bit = false;
         bool m_supportsNvShaderExtn = false;

--- a/src/nvapi/nvapi_d3d12_graphics_command_list.cpp
+++ b/src/nvapi/nvapi_d3d12_graphics_command_list.cpp
@@ -4,38 +4,53 @@
 #include "../util/util_log.h"
 
 namespace dxvk {
-    std::unordered_map<ID3D12GraphicsCommandList*, NvapiD3d12GraphicsCommandList> NvapiD3d12GraphicsCommandList::m_nvapiDeviceMap;
+    thread_local NvapiAsConverter NvapiD3d12GraphicsCommandList::m_asConverter;
+    std::atomic<LONGLONG> NvapiD3d12GraphicsCommandList::m_resetTimestamp;
     std::mutex NvapiD3d12GraphicsCommandList::m_mutex;
 
     void NvapiD3d12GraphicsCommandList::Reset() {
-        std::scoped_lock lock{m_mutex};
-        m_nvapiDeviceMap.clear();
+        LARGE_INTEGER count;
+        QueryPerformanceCounter(&count);
+        m_resetTimestamp.store(count.QuadPart, std::memory_order_release);
     }
 
-    NvapiD3d12GraphicsCommandList* NvapiD3d12GraphicsCommandList::GetOrCreate(ID3D12GraphicsCommandList* commandList) {
+    std::optional<NvapiD3d12GraphicsCommandList> NvapiD3d12GraphicsCommandList::GetOrCreate(ID3D12GraphicsCommandList* commandList) {
+        static constexpr GUID NvapiD3d12GraphicsCommandListGuid = {0x1d409261, 0xd613, 0x4ef4, {0x86, 0x10, 0x25, 0x0e, 0x8b, 0x3b, 0x56, 0x56}};
+
+        NvapiD3d12GraphicsCommandList nvapiGraphicsCommandList{nullptr};
+        UINT size = sizeof(nvapiGraphicsCommandList);
+
+        auto result = commandList->GetPrivateData(NvapiD3d12GraphicsCommandListGuid, &size, &nvapiGraphicsCommandList);
+        if (SUCCEEDED(result) && size == sizeof(nvapiGraphicsCommandList) && nvapiGraphicsCommandList.m_creationTimestamp > m_resetTimestamp.load(std::memory_order_acquire))
+            return nvapiGraphicsCommandList;
+
+        size = sizeof(nvapiGraphicsCommandList);
         std::scoped_lock lock{m_mutex};
 
-        auto itF = m_nvapiDeviceMap.find(commandList);
-        if (itF != m_nvapiDeviceMap.end())
-            return &itF->second;
+        result = commandList->GetPrivateData(NvapiD3d12GraphicsCommandListGuid, &size, &nvapiGraphicsCommandList);
+        if (SUCCEEDED(result) && size == sizeof(nvapiGraphicsCommandList) && nvapiGraphicsCommandList.m_creationTimestamp > m_resetTimestamp.load(std::memory_order_acquire))
+            return nvapiGraphicsCommandList;
 
         Com<ID3D12GraphicsCommandListExt> commandListExt;
         if (FAILED(commandList->QueryInterface(IID_PPV_ARGS(&commandListExt))))
-            return nullptr;
+            return std::nullopt;
 
-        auto [itI, inserted] = m_nvapiDeviceMap.emplace(
-            std::piecewise_construct,
-            std::forward_as_tuple(commandList),
-            std::forward_as_tuple(commandListExt.ptr()));
+        LARGE_INTEGER count;
+        QueryPerformanceCounter(&count);
 
-        if (!inserted)
-            return nullptr;
+        nvapiGraphicsCommandList = NvapiD3d12GraphicsCommandList{commandListExt.ptr()};
+        nvapiGraphicsCommandList.m_creationTimestamp = count.QuadPart;
 
-        return &itI->second;
+        commandList->SetPrivateData(NvapiD3d12GraphicsCommandListGuid, sizeof(nvapiGraphicsCommandList), &nvapiGraphicsCommandList);
+
+        return nvapiGraphicsCommandList;
     }
 
     NvapiD3d12GraphicsCommandList::NvapiD3d12GraphicsCommandList(ID3D12GraphicsCommandListExt* vkd3dCommandList)
         : m_vkd3dGraphicsCommandList(static_cast<ID3D12GraphicsCommandListExt2*>(vkd3dCommandList)) { // NOLINT(*-pro-type-static-cast-downcast)
+        if (!vkd3dCommandList)
+            return;
+
         uint32_t commandListTier = probeInterfaceChain(vkd3dCommandList, {
                                                                              __uuidof(ID3D12GraphicsCommandListExt1),
                                                                              __uuidof(ID3D12GraphicsCommandListExt2),

--- a/src/nvapi/nvapi_d3d12_graphics_command_list.cpp
+++ b/src/nvapi/nvapi_d3d12_graphics_command_list.cpp
@@ -83,6 +83,6 @@ namespace dxvk {
     }
 
     bool NvapiD3d12GraphicsCommandList::VerifyOpacityMicromapArrayNVAPI(D3D12_GPU_VIRTUAL_ADDRESS opacity_micromap_array) const {
-        return m_vkd3dGraphicsCommandList->VerifyOpacityMicromapArrayNVAPI(opacity_micromap_array);
+        return m_supportsOpacityMicromap && m_vkd3dGraphicsCommandList->VerifyOpacityMicromapArrayNVAPI(opacity_micromap_array);
     }
 }

--- a/src/nvapi/nvapi_d3d12_graphics_command_list.h
+++ b/src/nvapi/nvapi_d3d12_graphics_command_list.h
@@ -9,7 +9,7 @@ namespace dxvk {
 
       public:
         static void Reset();
-        [[nodiscard]] static NvapiD3d12GraphicsCommandList* GetOrCreate(ID3D12GraphicsCommandList* commandList);
+        [[nodiscard]] static std::optional<NvapiD3d12GraphicsCommandList> GetOrCreate(ID3D12GraphicsCommandList* commandList);
 
         explicit NvapiD3d12GraphicsCommandList(ID3D12GraphicsCommandListExt* vkd3dCommandList);
 
@@ -21,15 +21,16 @@ namespace dxvk {
         [[nodiscard]] bool VerifyOpacityMicromapArrayNVAPI(D3D12_GPU_VIRTUAL_ADDRESS opacity_micromap_array) const;
 
       private:
-        static std::unordered_map<ID3D12GraphicsCommandList*, NvapiD3d12GraphicsCommandList> m_nvapiDeviceMap;
+        static std::atomic<LONGLONG> m_resetTimestamp;
         static std::mutex m_mutex;
 
+        LONGLONG m_creationTimestamp{};
         ID3D12GraphicsCommandListExt2* m_vkd3dGraphicsCommandList{};
         bool m_supportsCubinSMem = false;
         bool m_supportsOpacityMicromap = false;
 
         // Reused across calls so the per-build geometry-desc scratch settles at
-        // its max-N and stops hitting the heap. Per-instance state - not thread-safe.
-        NvapiAsConverter m_asConverter;
+        // its max-N and stops hitting the heap. Not thread-safe.
+        static thread_local NvapiAsConverter m_asConverter;
     };
 }

--- a/src/nvapi_d3d12.cpp
+++ b/src/nvapi_d3d12.cpp
@@ -1115,11 +1115,11 @@ NVAPI_FUNCTION NvAPI_D3D12_NotifyOutOfBandCommandQueue(ID3D12CommandQueue* pComm
     if (cqType == OUT_OF_BAND_RENDER_PRESENT && !std::exchange(alreadyLoggedTypeRenderPresent, true))
         log::info("NvAPI_D3D12_NotifyOutOfBandCommandQueue is called with OUT_OF_BAND_RENDER_PRESENT");
 
-    auto device = NvapiD3d12CommandQueue::GetOrCreate(pCommandQueue);
-    if (!device)
+    auto queue = NvapiD3d12CommandQueue::GetOrCreate(pCommandQueue);
+    if (!queue)
         return NoImplementation(n, alreadyLoggedNoImplementation);
 
-    switch (device->NotifyOutOfBandCommandQueue(static_cast<D3D12_OUT_OF_BAND_CQ_TYPE>(cqType))) {
+    switch (queue->NotifyOutOfBandCommandQueue(static_cast<D3D12_OUT_OF_BAND_CQ_TYPE>(cqType))) {
         case S_OK:
             return Ok(n, alreadyLoggedOk);
         case E_NOTIMPL:

--- a/src/nvapi_d3d12.cpp
+++ b/src/nvapi_d3d12.cpp
@@ -645,7 +645,7 @@ NVAPI_FUNCTION NvAPI_D3D12_SetDepthBoundsTestValues(ID3D12GraphicsCommandList* p
     return Ok(n, alreadyLoggedOk);
 }
 
-inline static bool IsThreadReorderingSupported(ID3D12Device* pDevice, NvapiD3d12Device* device) {
+inline static bool IsThreadReorderingSupported(ID3D12Device* pDevice, std::optional<NvapiD3d12Device>& device) {
     if (!env::isD3d12NvShaderExtnEnabled())
         return false;
 

--- a/src/nvapi_private.h
+++ b/src/nvapi_private.h
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <array>
+#include <atomic>
 #include <cassert>
 #include <cctype>
 #include <charconv>

--- a/tests/mocks/d3d12_mocks.h
+++ b/tests/mocks/d3d12_mocks.h
@@ -3,14 +3,79 @@
 #include "../../src/nvapi_private.h"
 #include "../../src/interfaces/vkd3d-proton_interfaces.h"
 
+class PrivateDataStore final {
+    struct GuidHash {
+        std::size_t operator()(const GUID& guid) const {
+            static constexpr auto hash = []<typename T>(T t) { return std::hash<T>{}(t); };
+
+            uint64_t data4;
+            std::memcpy(&data4, guid.Data4, sizeof(data4));
+
+            return hash(guid.Data1) ^ hash(guid.Data2) ^ hash(guid.Data3) ^ hash(data4);
+        }
+    };
+
+    struct GuidEquals {
+        bool operator()(const GUID& lhs, const GUID& rhs) const {
+            return !std::memcmp(&lhs, &rhs, sizeof(GUID));
+        }
+    };
+
+    std::unordered_map<GUID, std::vector<std::byte>, GuidHash, GuidEquals> m_privateData;
+    std::mutex m_privateDataMutex;
+
+  public:
+    HRESULT STDMETHODCALLTYPE GetPrivateData(const GUID& guid, UINT* pDataSize, void* pData) {
+        if (!pDataSize)
+            return E_INVALIDARG;
+
+        std::scoped_lock lock{m_privateDataMutex};
+
+        auto it = m_privateData.find(guid);
+        if (it == m_privateData.end())
+            return DXGI_ERROR_NOT_FOUND;
+
+        auto& data = it->second;
+        auto size = *pDataSize;
+        *pDataSize = data.size();
+
+        if (data.size() > size)
+            return DXGI_ERROR_MORE_DATA;
+
+        std::memcpy(pData, data.data(), data.size());
+
+        return S_OK;
+    }
+
+    HRESULT STDMETHODCALLTYPE SetPrivateData(const GUID& guid, UINT DataSize, const void* pData) {
+        auto ptr = static_cast<const std::byte*>(pData);
+        std::vector<std::byte> data{ptr, ptr + DataSize};
+
+        std::scoped_lock lock{m_privateDataMutex};
+
+        m_privateData.insert_or_assign(guid, std::move(data));
+
+        return S_OK;
+    }
+};
+
 class ID3D12Vkd3dDevice : public ID3D12Device5, public ID3D12DeviceExt5, public ID3D12DXVKInteropDevice1 {};
 
 class D3D12Vkd3dDeviceMock final : public trompeloeil::mock_interface<ID3D12Vkd3dDevice> {
+    PrivateDataStore m_store;
+
     MAKE_MOCK2(QueryInterface, HRESULT(REFIID, void**), override);
     MAKE_MOCK0(AddRef, ULONG(), override);
     MAKE_MOCK0(Release, ULONG(), override);
-    IMPLEMENT_MOCK3(GetPrivateData);
-    IMPLEMENT_MOCK3(SetPrivateData);
+
+    HRESULT STDMETHODCALLTYPE GetPrivateData(const GUID& guid, UINT* pDataSize, void* pData) override {
+        return m_store.GetPrivateData(guid, pDataSize, pData);
+    }
+
+    HRESULT STDMETHODCALLTYPE SetPrivateData(const GUID& guid, UINT DataSize, const void* pData) override {
+        return m_store.SetPrivateData(guid, DataSize, pData);
+    }
+
     IMPLEMENT_MOCK2(SetPrivateDataInterface);
     IMPLEMENT_MOCK1(SetName);
     IMPLEMENT_MOCK0(GetNodeCount);
@@ -122,11 +187,20 @@ class D3D12Vkd3dDeviceMock final : public trompeloeil::mock_interface<ID3D12Vkd3
 class ID3D12Vkd3dGraphicsCommandList : public ID3D12GraphicsCommandList4, public ID3D12GraphicsCommandListExt2 {};
 
 class D3D12Vkd3dGraphicsCommandListMock final : public trompeloeil::mock_interface<ID3D12Vkd3dGraphicsCommandList> {
+    PrivateDataStore m_store;
+
     MAKE_MOCK2(QueryInterface, HRESULT(REFIID, void**), override);
     MAKE_MOCK0(AddRef, ULONG(), override);
     MAKE_MOCK0(Release, ULONG(), override);
-    IMPLEMENT_MOCK3(GetPrivateData);
-    IMPLEMENT_MOCK3(SetPrivateData);
+
+    HRESULT STDMETHODCALLTYPE GetPrivateData(const GUID& guid, UINT* pDataSize, void* pData) override {
+        return m_store.GetPrivateData(guid, pDataSize, pData);
+    }
+
+    HRESULT STDMETHODCALLTYPE SetPrivateData(const GUID& guid, UINT DataSize, const void* pData) override {
+        return m_store.SetPrivateData(guid, DataSize, pData);
+    }
+
     IMPLEMENT_MOCK2(SetPrivateDataInterface);
     IMPLEMENT_MOCK1(SetName);
     IMPLEMENT_MOCK2(GetDevice);
@@ -209,11 +283,20 @@ class D3D12Vkd3dGraphicsCommandListMock final : public trompeloeil::mock_interfa
 class ID3D12Vkd3dCommandQueue : public ID3D12CommandQueue, public ID3D12CommandQueueExt {};
 
 class D3D12Vkd3dCommandQueueMock final : public trompeloeil::mock_interface<ID3D12Vkd3dCommandQueue> {
+    PrivateDataStore m_store;
+
     MAKE_MOCK2(QueryInterface, HRESULT(REFIID, void**), override);
     MAKE_MOCK0(AddRef, ULONG(), override);
     MAKE_MOCK0(Release, ULONG(), override);
-    IMPLEMENT_MOCK3(GetPrivateData);
-    IMPLEMENT_MOCK3(SetPrivateData);
+
+    HRESULT STDMETHODCALLTYPE GetPrivateData(const GUID& guid, UINT* pDataSize, void* pData) override {
+        return m_store.GetPrivateData(guid, pDataSize, pData);
+    }
+
+    HRESULT STDMETHODCALLTYPE SetPrivateData(const GUID& guid, UINT DataSize, const void* pData) override {
+        return m_store.SetPrivateData(guid, DataSize, pData);
+    }
+
     IMPLEMENT_MOCK2(SetPrivateDataInterface);
     IMPLEMENT_MOCK1(SetName);
     IMPLEMENT_MOCK2(GetDevice);


### PR DESCRIPTION
Should be more robust than caching stuff in maps. But, this prevents us from storing anything fancy like `NvapiAsConverter` there, so I've made it `thread_local` as a workaround. The fact that it doesn't store anything list-specific makes this… not much of a problem.

Plus fixes one naming derp I caught while working on this.

Supersedes https://github.com/jp7677/dxvk-nvapi/pull/390.